### PR TITLE
ML-3 / Add configuration and environment loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,55 @@
+# ML Copilot example environment
+#
+# Copy this file to `.env` and adjust the values for your provider.
+
+# -----------------------------------------------------------------------------
+# Core model configuration
+# -----------------------------------------------------------------------------
+
+# Any OpenAI-compatible endpoint can be used here.
+# Examples:
+# - OpenAI: https://api.openai.com/v1
+# - OpenRouter: https://openrouter.ai/api/v1
+# - Groq: https://api.groq.com/openai/v1
+# - DeepInfra: https://api.deepinfra.com/v1/openai
+# - Local vLLM / gateway: http://localhost:8000/v1
+LLM_BASE_URL=https://api.openai.com/v1
+
+# Provider API key for the configured endpoint.
+LLM_API_KEY=replace-me
+
+# Model name for the configured endpoint.
+# Examples:
+# - gpt-5.4
+# - openai/gpt-4.1-mini
+# - llama-3.3-70b-versatile
+# - meta-llama/Meta-Llama-3.1-70B-Instruct
+LLM_MODEL=gpt-5.4
+
+# Optional request timeout for model calls.
+LLM_TIMEOUT_SECONDS=600
+
+# -----------------------------------------------------------------------------
+# Workspace and persistence
+# -----------------------------------------------------------------------------
+
+# Optional override. By default ML Copilot uses the repository root.
+# ML_COPILOT_WORKSPACE_ROOT=D:\path\to\ml-copilot
+
+# Optional override. By default this resolves to .ml-copilot/ml-copilot.db
+# under the workspace root.
+# ML_COPILOT_DB_PATH=.ml-copilot/ml-copilot.db
+
+# -----------------------------------------------------------------------------
+# Safety controls
+# -----------------------------------------------------------------------------
+
+ML_COPILOT_REQUIRE_TOOL_APPROVAL=true
+ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS=false
+ML_COPILOT_REDACT_SECRETS=true
+
+# -----------------------------------------------------------------------------
+# Optional custom env file location
+# -----------------------------------------------------------------------------
+
+# ML_COPILOT_ENV_FILE=D:\path\to\custom.env

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 Thumbs.db
 .env
 .env.*
+!.env.example

--- a/app/config.py
+++ b/app/config.py
@@ -1,13 +1,11 @@
-"""Bootstrap configuration primitives.
-
-This module intentionally stays light for ML-2. Environment loading and richer
-runtime settings belong to the dedicated configuration task later in Phase 1.
-"""
+"""Application configuration and environment loading."""
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping
 
 
 @dataclass(frozen=True)
@@ -21,6 +19,11 @@ class AppPaths:
     @classmethod
     def default(cls) -> "AppPaths":
         workspace_root = Path(__file__).resolve().parent.parent
+        return cls.from_workspace_root(workspace_root)
+
+    @classmethod
+    def from_workspace_root(cls, workspace_root: Path) -> "AppPaths":
+        workspace_root = workspace_root.resolve()
         return cls(
             workspace_root=workspace_root,
             app_dir=workspace_root / "app",
@@ -31,10 +34,28 @@ class AppPaths:
 
 
 @dataclass(frozen=True)
+class LLMSettings:
+    base_url: str
+    api_key: str | None
+    model: str
+    timeout_seconds: int
+
+
+@dataclass(frozen=True)
+class SafetySettings:
+    require_tool_approval: bool
+    allow_destructive_commands: bool
+    redact_secrets: bool
+
+
+@dataclass(frozen=True)
 class AppSettings:
     app_name: str
     version: str
     paths: AppPaths
+    llm: LLMSettings
+    db_path: Path
+    safety: SafetySettings
 
     @classmethod
     def from_paths(cls, paths: AppPaths) -> "AppSettings":
@@ -42,4 +63,145 @@ class AppSettings:
             app_name="ML Copilot",
             version="0.1.0",
             paths=paths,
+            llm=LLMSettings(
+                base_url="https://api.openai.com/v1",
+                api_key=None,
+                model="gpt-5.4",
+                timeout_seconds=600,
+            ),
+            db_path=paths.workspace_root / ".ml-copilot" / "ml-copilot.db",
+            safety=SafetySettings(
+                require_tool_approval=True,
+                allow_destructive_commands=False,
+                redact_secrets=True,
+            ),
         )
+
+    @classmethod
+    def load(
+        cls,
+        environ: Mapping[str, str] | None = None,
+        env_file: Path | None = None,
+    ) -> "AppSettings":
+        merged_env = load_environment(environ=environ, env_file=env_file)
+        workspace_root = Path(
+            merged_env.get("ML_COPILOT_WORKSPACE_ROOT", str(AppPaths.default().workspace_root))
+        )
+        paths = AppPaths.from_workspace_root(workspace_root)
+
+        db_path = Path(
+            merged_env.get(
+                "ML_COPILOT_DB_PATH",
+                str(paths.workspace_root / ".ml-copilot" / "ml-copilot.db"),
+            )
+        )
+        if not db_path.is_absolute():
+            db_path = paths.workspace_root / db_path
+
+        return cls(
+            app_name="ML Copilot",
+            version="0.1.0",
+            paths=paths,
+            llm=LLMSettings(
+                base_url=merged_env.get("LLM_BASE_URL", "https://api.openai.com/v1"),
+                api_key=blank_to_none(merged_env.get("LLM_API_KEY")),
+                model=merged_env.get("LLM_MODEL", "gpt-5.4"),
+                timeout_seconds=parse_int(
+                    "LLM_TIMEOUT_SECONDS",
+                    merged_env.get("LLM_TIMEOUT_SECONDS"),
+                    default=600,
+                    minimum=1,
+                ),
+            ),
+            db_path=db_path.resolve(),
+            safety=SafetySettings(
+                require_tool_approval=parse_bool(
+                    "ML_COPILOT_REQUIRE_TOOL_APPROVAL",
+                    merged_env.get("ML_COPILOT_REQUIRE_TOOL_APPROVAL"),
+                    default=True,
+                ),
+                allow_destructive_commands=parse_bool(
+                    "ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS",
+                    merged_env.get("ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS"),
+                    default=False,
+                ),
+                redact_secrets=parse_bool(
+                    "ML_COPILOT_REDACT_SECRETS",
+                    merged_env.get("ML_COPILOT_REDACT_SECRETS"),
+                    default=True,
+                ),
+            ),
+        )
+
+
+def blank_to_none(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def parse_bool(name: str, value: str | None, *, default: bool) -> bool:
+    if value is None:
+        return default
+
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean value, got {value!r}.")
+
+
+def parse_int(name: str, value: str | None, *, default: int, minimum: int | None = None) -> int:
+    if value is None:
+        return default
+
+    parsed = int(value)
+    if minimum is not None and parsed < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {parsed}.")
+    return parsed
+
+
+def load_environment(
+    environ: Mapping[str, str] | None = None,
+    env_file: Path | None = None,
+) -> dict[str, str]:
+    environment = dict(os.environ if environ is None else environ)
+    resolved_env_file = _resolve_env_file(environment, env_file=env_file)
+    file_values = read_env_file(resolved_env_file)
+    return {**file_values, **environment}
+
+
+def _resolve_env_file(environment: Mapping[str, str], env_file: Path | None) -> Path:
+    if env_file is not None:
+        return env_file
+
+    configured = environment.get("ML_COPILOT_ENV_FILE")
+    if configured:
+        return Path(configured)
+
+    return AppPaths.default().workspace_root / ".env"
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"Invalid env line in {path}: {raw_line!r}")
+
+        key, raw_value = line.split("=", 1)
+        values[key.strip()] = strip_optional_quotes(raw_value.strip())
+    return values
+
+
+def strip_optional_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from app.config import AppPaths, AppSettings
+from app.config import AppSettings
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -16,6 +16,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--print-layout",
         action="store_true",
         help="Print the expected repository layout for the current bootstrap slice.",
+    )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print the effective runtime configuration with sensitive values redacted.",
     )
     return parser
 
@@ -34,13 +39,35 @@ def format_layout(settings: AppSettings) -> str:
     )
 
 
+def format_config(settings: AppSettings) -> str:
+    redacted_api_key = "<unset>" if settings.llm.api_key is None else "<redacted>"
+    return "\n".join(
+        [
+            "ML Copilot configuration",
+            f"workspace_root={settings.paths.workspace_root}",
+            f"db_path={settings.db_path}",
+            f"llm.base_url={settings.llm.base_url}",
+            f"llm.model={settings.llm.model}",
+            f"llm.api_key={redacted_api_key}",
+            f"llm.timeout_seconds={settings.llm.timeout_seconds}",
+            f"safety.require_tool_approval={settings.safety.require_tool_approval}",
+            f"safety.allow_destructive_commands={settings.safety.allow_destructive_commands}",
+            f"safety.redact_secrets={settings.safety.redact_secrets}",
+        ]
+    )
+
+
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    settings = AppSettings.from_paths(AppPaths.default())
+    settings = AppSettings.load()
 
     if args.print_layout:
         print(format_layout(settings))
+        return 0
+
+    if args.print_config:
+        print(format_config(settings))
         return 0
 
     parser.print_help()

--- a/docs/phase-1-configuration.md
+++ b/docs/phase-1-configuration.md
@@ -1,0 +1,95 @@
+# Phase 1 Configuration
+
+This document captures the configuration slice for `ML Copilot`.
+
+## Task
+
+`ML-3 / Add configuration and environment loading`
+
+## Supported Settings
+
+The current configuration layer supports:
+
+- `LLM_BASE_URL`
+- `LLM_API_KEY`
+- `LLM_MODEL`
+- `LLM_TIMEOUT_SECONDS`
+- `ML_COPILOT_WORKSPACE_ROOT`
+- `ML_COPILOT_DB_PATH`
+- `ML_COPILOT_REQUIRE_TOOL_APPROVAL`
+- `ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS`
+- `ML_COPILOT_REDACT_SECRETS`
+- `ML_COPILOT_ENV_FILE`
+
+An example configuration file is included at `.env.example`.
+
+## Precedence
+
+Configuration is resolved in this order:
+
+1. process environment variables
+2. values loaded from a `.env` file
+3. built-in defaults
+
+Process environment wins over `.env` so local overrides remain predictable in
+development, tests, and CI.
+
+## Defaults
+
+- `LLM_BASE_URL=https://api.openai.com/v1`
+- `LLM_MODEL=gpt-5.4`
+- `LLM_TIMEOUT_SECONDS=600`
+- `ML_COPILOT_REQUIRE_TOOL_APPROVAL=true`
+- `ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS=false`
+- `ML_COPILOT_REDACT_SECRETS=true`
+- default database path is `.ml-copilot/ml-copilot.db` under the workspace root
+
+## Provider Strategy
+
+For the MVP, `ML Copilot` should stay provider-agnostic through an
+OpenAI-compatible interface:
+
+- one internal request shape
+- one `base_url`
+- one `api_key`
+- one `model`
+
+That already covers a lot of real providers and gateways when they expose an
+OpenAI-style API, including:
+
+- OpenAI
+- OpenRouter
+- Groq
+- DeepInfra
+- local vLLM and similar gateways
+
+Some providers may also offer OpenAI-compatible adapters depending on the
+gateway or routing layer in front of them.
+
+For providers with native APIs that are not cleanly OpenAI-compatible, the next
+step should be an adapter layer rather than hardwiring provider logic all over
+the app. A later design can introduce a dedicated provider field such as:
+
+```text
+LLM_PROVIDER=openai_compatible | anthropic | gemini
+```
+
+Then the runtime can route through small provider clients behind one internal
+`LLMClient` interface.
+
+That gives us a good path to support:
+
+- Anthropic
+- Google Gemini
+- xAI Grok
+- Minimax
+- Kimi
+- Z.ai
+
+without breaking the simpler MVP contract.
+
+## Notes
+
+This slice keeps the configuration layer stdlib-only on purpose. We can add a
+heavier settings framework later if the runtime grows enough to justify it, but
+the current approach is easy to test and has no extra bootstrap dependency.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,8 @@
-from app.config import AppPaths, AppSettings
+from pathlib import Path
+
+import pytest
+
+from app.config import AppPaths, AppSettings, load_environment, parse_bool, read_env_file
 
 
 def test_default_paths_are_repo_relative() -> None:
@@ -16,3 +20,60 @@ def test_settings_wrap_default_paths() -> None:
     assert settings.app_name == "ML Copilot"
     assert settings.version == "0.1.0"
     assert settings.paths.workspace_root.name == "ml-copilot"
+    assert settings.llm.base_url == "https://api.openai.com/v1"
+    assert settings.safety.require_tool_approval is True
+
+
+def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
+    settings = AppSettings.load(
+        environ={
+            "LLM_API_KEY": "secret-key",
+            "LLM_MODEL": "gpt-test",
+            "ML_COPILOT_WORKSPACE_ROOT": str(tmp_path),
+            "ML_COPILOT_REQUIRE_TOOL_APPROVAL": "false",
+            "ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS": "true",
+            "ML_COPILOT_REDACT_SECRETS": "false",
+        }
+    )
+
+    assert settings.llm.base_url == "https://api.openai.com/v1"
+    assert settings.llm.api_key == "secret-key"
+    assert settings.llm.model == "gpt-test"
+    assert settings.paths.workspace_root == tmp_path.resolve()
+    assert settings.db_path == (tmp_path / ".ml-copilot" / "ml-copilot.db").resolve()
+    assert settings.safety.require_tool_approval is False
+    assert settings.safety.allow_destructive_commands is True
+    assert settings.safety.redact_secrets is False
+
+
+def test_environment_prefers_process_env_over_env_file(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("LLM_MODEL=file-model\nLLM_BASE_URL=https://example.invalid/v1\n", encoding="utf-8")
+
+    loaded = load_environment(
+        environ={"LLM_MODEL": "process-model"},
+        env_file=env_file,
+    )
+
+    assert loaded["LLM_MODEL"] == "process-model"
+    assert loaded["LLM_BASE_URL"] == "https://example.invalid/v1"
+
+
+def test_read_env_file_strips_quotes_and_comments(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        '# comment\nLLM_MODEL="quoted-model"\nLLM_API_KEY=\'token\'\n',
+        encoding="utf-8",
+    )
+
+    loaded = read_env_file(env_file)
+
+    assert loaded == {
+        "LLM_MODEL": "quoted-model",
+        "LLM_API_KEY": "token",
+    }
+
+
+def test_parse_bool_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError):
+        parse_bool("FLAG", "sometimes", default=True)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,4 +1,5 @@
-from app.main import build_parser, format_layout, main
+from app.config import AppPaths, AppSettings
+from app.main import build_parser, format_config, format_layout, main
 
 
 def test_build_parser_uses_project_name() -> None:
@@ -8,13 +9,25 @@ def test_build_parser_uses_project_name() -> None:
 
 
 def test_format_layout_includes_expected_directories() -> None:
-    output = format_layout(__import__("app.config", fromlist=["AppSettings"]).AppSettings.from_paths(
-        __import__("app.config", fromlist=["AppPaths"]).AppPaths.default()
-    ))
+    output = format_layout(AppSettings.from_paths(AppPaths.default()))
 
     assert "workspace_root=" in output
     assert "app_dir=" in output
     assert "tests_dir=" in output
+
+
+def test_format_config_redacts_api_key() -> None:
+    settings = AppSettings.load(
+        environ={
+            "LLM_API_KEY": "top-secret",
+            "ML_COPILOT_WORKSPACE_ROOT": str(AppPaths.default().workspace_root),
+        }
+    )
+
+    output = format_config(settings)
+
+    assert "llm.api_key=<redacted>" in output
+    assert "top-secret" not in output
 
 
 def test_main_returns_success_for_default_help(monkeypatch, capsys) -> None:
@@ -25,3 +38,16 @@ def test_main_returns_success_for_default_help(monkeypatch, capsys) -> None:
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Focused ML engineering agent" in captured.out
+
+
+def test_main_prints_config(monkeypatch, capsys, tmp_path) -> None:
+    monkeypatch.setattr("sys.argv", ["ml-copilot", "--print-config"])
+    monkeypatch.setenv("ML_COPILOT_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LLM_MODEL", "gpt-config")
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "ML Copilot configuration" in captured.out
+    assert "llm.model=gpt-config" in captured.out


### PR DESCRIPTION
## Summary
- add a real configuration loader for env and `.env` values
- support model endpoint settings, workspace and database paths, and safety flags
- add `.env.example`, config docs, and tests for precedence, parsing, and secret redaction

## Testing
- `pytest -q`
- `python -m app.main --print-config`

## Notes
This keeps the runtime OpenAI-compatible-first for now. Native provider adapters should be added later behind the same internal client interface instead of being mixed into the first implementation.

## Reference
Issue: `#5`