### PR TITLE
ML-4 / Implement OpenAI-compatible LLM client

### DIFF
--- a/app/agent/llm.py
+++ b/app/agent/llm.py
@@ -1,0 +1,331 @@
+"""OpenAI-compatible LLM client and wire-format parsers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from app.config import AppSettings
+
+
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    id: str
+    name: str
+    arguments: str
+    type: str = "function"
+
+    def arguments_as_json(self) -> JsonDict:
+        return json.loads(self.arguments or "{}")
+
+
+@dataclass(frozen=True)
+class Usage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+@dataclass(frozen=True)
+class StreamEvent:
+    type: str
+    data: JsonDict
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    model: str
+    content: str
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    finish_reason: str | None = None
+    usage: Usage | None = None
+    response_id: str | None = None
+    events: list[StreamEvent] = field(default_factory=list)
+    raw: JsonDict | None = None
+
+
+class LLMError(RuntimeError):
+    """Base error for LLM client failures."""
+
+
+class LLMProtocolError(LLMError):
+    """Raised when the remote response does not match the expected schema."""
+
+
+class LLMClient:
+    """Small provider-neutral client for OpenAI-compatible chat completions."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str | None,
+        default_model: str,
+        timeout_seconds: int = 600,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.default_model = default_model
+        self.timeout_seconds = timeout_seconds
+        self._http_client = http_client
+
+    @classmethod
+    def from_settings(
+        cls,
+        settings: AppSettings,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> "LLMClient":
+        return cls(
+            base_url=settings.llm.base_url,
+            api_key=settings.llm.api_key,
+            default_model=settings.llm.model,
+            timeout_seconds=settings.llm.timeout_seconds,
+            http_client=http_client,
+        )
+
+    async def chat(
+        self,
+        messages: list[JsonDict],
+        tools: list[JsonDict] | None = None,
+        tool_choice: str | JsonDict | None = "auto",
+        stream: bool = True,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> LLMResponse:
+        payload = self._build_payload(
+            messages=messages,
+            tools=tools,
+            tool_choice=tool_choice,
+            stream=stream,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+        if stream:
+            return await self._chat_stream(payload)
+        return await self._chat_once(payload)
+
+    def _build_payload(
+        self,
+        *,
+        messages: list[JsonDict],
+        tools: list[JsonDict] | None,
+        tool_choice: str | JsonDict | None,
+        stream: bool,
+        model: str | None,
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> JsonDict:
+        payload: JsonDict = {
+            "model": model or self.default_model,
+            "messages": messages,
+            "stream": stream,
+        }
+        if tools:
+            payload["tools"] = tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        return payload
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    async def _chat_once(self, payload: JsonDict) -> LLMResponse:
+        async with self._client() as client:
+            response = await client.post(
+                "/chat/completions",
+                json=payload,
+                headers=self._headers(),
+            )
+            response.raise_for_status()
+            data = response.json()
+        return parse_chat_completion(data)
+
+    async def _chat_stream(self, payload: JsonDict) -> LLMResponse:
+        state = _StreamState()
+        async with self._client() as client:
+            async with client.stream(
+                "POST",
+                "/chat/completions",
+                json=payload,
+                headers=self._headers(),
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+                    if not line.startswith("data:"):
+                        continue
+                    body = line[5:].strip()
+                    if body == "[DONE]":
+                        break
+                    chunk = json.loads(body)
+                    apply_stream_chunk(state, chunk)
+        return state.to_response()
+
+    def _client(self) -> "_ClientContextManager":
+        if self._http_client is not None:
+            return _ClientContextManager(self._http_client, close_on_exit=False)
+        client = httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=self.timeout_seconds,
+        )
+        return _ClientContextManager(client, close_on_exit=True)
+
+
+class _ClientContextManager:
+    def __init__(self, client: httpx.AsyncClient, *, close_on_exit: bool) -> None:
+        self._client = client
+        self._close_on_exit = close_on_exit
+
+    async def __aenter__(self) -> httpx.AsyncClient:
+        return self._client
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._close_on_exit:
+            await self._client.aclose()
+
+
+def parse_chat_completion(payload: JsonDict) -> LLMResponse:
+    choices = payload.get("choices")
+    if not choices:
+        raise LLMProtocolError("Chat completion response did not include choices.")
+
+    choice = choices[0]
+    message = choice.get("message") or {}
+    content = message.get("content") or ""
+    tool_calls = [
+        ToolCall(
+            id=item.get("id", ""),
+            type=item.get("type", "function"),
+            name=((item.get("function") or {}).get("name") or ""),
+            arguments=((item.get("function") or {}).get("arguments") or ""),
+        )
+        for item in message.get("tool_calls") or []
+    ]
+    usage_data = payload.get("usage")
+    usage = parse_usage(usage_data) if usage_data else None
+
+    return LLMResponse(
+        model=payload.get("model", ""),
+        content=content,
+        tool_calls=tool_calls,
+        finish_reason=choice.get("finish_reason"),
+        usage=usage,
+        response_id=payload.get("id"),
+        raw=payload,
+    )
+
+
+def parse_usage(payload: JsonDict) -> Usage:
+    return Usage(
+        prompt_tokens=int(payload.get("prompt_tokens", 0) or 0),
+        completion_tokens=int(payload.get("completion_tokens", 0) or 0),
+        total_tokens=int(payload.get("total_tokens", 0) or 0),
+    )
+
+
+@dataclass
+class _ToolCallBuilder:
+    id: str = ""
+    type: str = "function"
+    name: str = ""
+    arguments: str = ""
+
+    def to_tool_call(self) -> ToolCall:
+        return ToolCall(
+            id=self.id,
+            type=self.type,
+            name=self.name,
+            arguments=self.arguments,
+        )
+
+
+@dataclass
+class _StreamState:
+    model: str = ""
+    content_parts: list[str] = field(default_factory=list)
+    finish_reason: str | None = None
+    usage: Usage | None = None
+    response_id: str | None = None
+    events: list[StreamEvent] = field(default_factory=list)
+    tool_calls: dict[int, _ToolCallBuilder] = field(default_factory=dict)
+
+    def to_response(self) -> LLMResponse:
+        ordered_tool_calls = [
+            builder.to_tool_call()
+            for _, builder in sorted(self.tool_calls.items(), key=lambda item: item[0])
+        ]
+        return LLMResponse(
+            model=self.model,
+            content="".join(self.content_parts),
+            tool_calls=ordered_tool_calls,
+            finish_reason=self.finish_reason,
+            usage=self.usage,
+            response_id=self.response_id,
+            events=self.events,
+        )
+
+
+def apply_stream_chunk(state: _StreamState, payload: JsonDict) -> None:
+    if not state.model:
+        state.model = payload.get("model", "")
+    if state.response_id is None:
+        state.response_id = payload.get("id")
+    if payload.get("usage"):
+        state.usage = parse_usage(payload["usage"])
+
+    choices = payload.get("choices") or []
+    if not choices:
+        return
+
+    choice = choices[0]
+    delta = choice.get("delta") or {}
+    finish_reason = choice.get("finish_reason")
+    if finish_reason:
+        state.finish_reason = finish_reason
+
+    content_piece = delta.get("content")
+    if content_piece:
+        state.content_parts.append(content_piece)
+        state.events.append(StreamEvent(type="content_delta", data={"content": content_piece}))
+
+    for item in delta.get("tool_calls") or []:
+        index = int(item.get("index", 0))
+        builder = state.tool_calls.setdefault(index, _ToolCallBuilder())
+        builder.id = item.get("id", builder.id)
+        builder.type = item.get("type", builder.type)
+        function = item.get("function") or {}
+        builder.name = function.get("name", builder.name)
+        builder.arguments += function.get("arguments", "")
+        state.events.append(
+            StreamEvent(
+                type="tool_call_delta",
+                data={
+                    "index": index,
+                    "id": builder.id,
+                    "name": builder.name,
+                    "arguments": function.get("arguments", ""),
+                },
+            )
+        )

--- a/docs/phase-1-llm-client.md
+++ b/docs/phase-1-llm-client.md
@@ -1,0 +1,46 @@
+# Phase 1 LLM Client
+
+This document captures the LLM client slice for `ML Copilot`.
+
+## Task
+
+`ML-4 / Implement OpenAI-compatible LLM client`
+
+## Scope
+
+The current client is intentionally narrow and provider-neutral:
+
+- OpenAI-style `/chat/completions`
+- non-streaming response parsing
+- streaming SSE parsing
+- tool-call parsing for full responses and streamed deltas
+- timeout handling through the configured HTTP client
+- usage parsing when the provider returns token counts
+
+## Why This Shape
+
+The goal here is to stabilize one internal contract before the agent loop lands.
+That gives later work a single client surface for:
+
+- the agent runtime
+- tests with mocked transports
+- OpenAI-compatible providers and gateways
+- future native provider adapters
+
+## Deferred To Later Tasks
+
+This task does not yet include:
+
+- provider-specific SDK adapters
+- retries and backoff policy
+- cost accounting
+- event emission into the session model
+- context management integration
+
+## Provider Strategy
+
+The default path stays OpenAI-compatible-first. That keeps the initial client
+small while covering several practical backends through configuration.
+
+Later native adapters should sit behind the same internal interface rather than
+leaking provider-specific conditionals across the codebase.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 description = "Focused ML engineering agent with safe tools, durable sessions, and eval-driven development."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "httpx>=0.28.0,<0.29.0",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,0 +1,244 @@
+import asyncio
+import json
+
+import httpx
+
+from app.agent.llm import LLMClient, LLMProtocolError, ToolCall, apply_stream_chunk, parse_chat_completion
+from app.config import AppSettings
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class MockAsyncStream(httpx.AsyncByteStream):
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    async def __aiter__(self):
+        for line in self._lines:
+            yield f"{line}\n\n".encode("utf-8")
+
+
+def test_parse_chat_completion_reads_content_tool_calls_and_usage() -> None:
+    response = parse_chat_completion(
+        {
+            "id": "resp_123",
+            "model": "gpt-5.4",
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "content": "I can help with that.",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": "{\"path\":\"README.md\"}",
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 7,
+                "total_tokens": 17,
+            },
+        }
+    )
+
+    assert response.response_id == "resp_123"
+    assert response.model == "gpt-5.4"
+    assert response.content == "I can help with that."
+    assert response.finish_reason == "tool_calls"
+    assert response.usage is not None
+    assert response.usage.total_tokens == 17
+    assert response.tool_calls == [
+        ToolCall(
+            id="call_1",
+            type="function",
+            name="read_file",
+            arguments='{"path":"README.md"}',
+        )
+    ]
+
+
+def test_parse_chat_completion_requires_choices() -> None:
+    try:
+        parse_chat_completion({"id": "missing_choices"})
+    except LLMProtocolError:
+        pass
+    else:
+        raise AssertionError("Expected LLMProtocolError when choices are missing.")
+
+
+def test_apply_stream_chunk_accumulates_content_tool_calls_and_usage() -> None:
+    from app.agent.llm import _StreamState
+
+    state = _StreamState()
+
+    apply_stream_chunk(
+        state,
+        {
+            "id": "resp_stream",
+            "model": "gpt-5.4",
+            "choices": [
+                {
+                    "delta": {
+                        "content": "Hello ",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "list_files",
+                                    "arguments": "{\"path\":",
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+    )
+    apply_stream_chunk(
+        state,
+        {
+            "id": "resp_stream",
+            "model": "gpt-5.4",
+            "choices": [
+                {
+                    "delta": {
+                        "content": "world",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "arguments": "\".\"}",
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 20,
+                "completion_tokens": 8,
+                "total_tokens": 28,
+            },
+        },
+    )
+
+    response = state.to_response()
+    assert response.response_id == "resp_stream"
+    assert response.content == "Hello world"
+    assert response.finish_reason == "tool_calls"
+    assert response.usage is not None
+    assert response.usage.total_tokens == 28
+    assert response.tool_calls[0].name == "list_files"
+    assert response.tool_calls[0].arguments == '{"path":"."}'
+
+
+def test_client_non_streaming_chat_uses_openai_shape() -> None:
+    recorded = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded["path"] = request.url.path
+        recorded["authorization"] = request.headers.get("Authorization")
+        recorded["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_non_stream",
+                "model": "demo-model",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {
+                            "content": "done",
+                            "tool_calls": [],
+                        },
+                    }
+                ],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+            },
+        )
+
+    client = LLMClient(
+        base_url="https://example.invalid/v1",
+        api_key="secret",
+        default_model="demo-model",
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://example.invalid/v1",
+        ),
+    )
+
+    response = run(
+        client.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "list_files"}}],
+            stream=False,
+            temperature=0.2,
+        )
+    )
+
+    assert recorded["path"] == "/v1/chat/completions"
+    assert recorded["authorization"] == "Bearer secret"
+    assert recorded["payload"]["model"] == "demo-model"
+    assert recorded["payload"]["stream"] is False
+    assert recorded["payload"]["messages"][0]["content"] == "hello"
+    assert "tools" in recorded["payload"]
+    assert response.content == "done"
+
+
+def test_client_streaming_chat_aggregates_sse_chunks() -> None:
+    lines = [
+        'data: {"id":"resp_stream","model":"demo-model","choices":[{"delta":{"content":"Hello "},"finish_reason":null}]}',
+        'data: {"id":"resp_stream","model":"demo-model","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search_text","arguments":"{\\"query\\":"}}]},"finish_reason":null}]}',
+        'data: {"id":"resp_stream","model":"demo-model","choices":[{"delta":{"content":"there","tool_calls":[{"index":0,"function":{"arguments":"\\"ml\\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":11,"completion_tokens":4,"total_tokens":15}}',
+        "data: [DONE]",
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=MockAsyncStream(lines),
+        )
+
+    client = LLMClient.from_settings(
+        AppSettings.load(environ={"LLM_BASE_URL": "https://example.invalid/v1", "LLM_MODEL": "demo-model"}),
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://example.invalid/v1",
+        ),
+    )
+
+    response = run(
+        client.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+    )
+
+    assert response.model == "demo-model"
+    assert response.content == "Hello there"
+    assert response.finish_reason == "tool_calls"
+    assert response.usage is not None
+    assert response.usage.total_tokens == 15
+    assert response.tool_calls[0].name == "search_text"
+    assert response.tool_calls[0].arguments == '{"query":"ml"}'
+    assert [event.type for event in response.events] == [
+        "content_delta",
+        "tool_call_delta",
+        "content_delta",
+        "tool_call_delta",
+    ]


### PR DESCRIPTION
## Summary
- add a provider-neutral OpenAI-compatible chat client with streaming and non-streaming support
- parse usage and tool calls from full responses and streamed deltas
- add docs and mocked unit tests for the client surface

## Testing
- `pytest -q`
- import check for `app.agent.llm.LLMClient`

## Notes
This keeps the first client layer small and provider-neutral. Native provider adapters can be added later behind the same interface instead of being mixed into the initial runtime.

## Reference
Issue: #7 