### PR TITLE
ML-5 / Add mocked LLM parser tests

### DIFF
--- a/app/agent/llm.py
+++ b/app/agent/llm.py
@@ -22,7 +22,12 @@ class ToolCall:
     type: str = "function"
 
     def arguments_as_json(self) -> JsonDict:
-        return json.loads(self.arguments or "{}")
+        try:
+            return json.loads(self.arguments or "{}")
+        except json.JSONDecodeError as exc:
+            raise LLMProtocolError(
+                f"Tool call {self.id or self.name or '<unknown>'} returned malformed JSON arguments."
+            ) from exc
 
 
 @dataclass(frozen=True)
@@ -225,6 +230,9 @@ def parse_chat_completion(payload: JsonDict) -> LLMResponse:
     ]
     usage_data = payload.get("usage")
     usage = parse_usage(usage_data) if usage_data else None
+
+    for tool_call in tool_calls:
+        tool_call.arguments_as_json()
 
     return LLMResponse(
         model=payload.get("model", ""),

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -76,6 +76,38 @@ def test_parse_chat_completion_requires_choices() -> None:
         raise AssertionError("Expected LLMProtocolError when choices are missing.")
 
 
+def test_parse_chat_completion_rejects_malformed_tool_call_json() -> None:
+    try:
+        parse_chat_completion(
+            {
+                "id": "resp_bad_json",
+                "model": "gpt-5.4",
+                "choices": [
+                    {
+                        "finish_reason": "tool_calls",
+                        "message": {
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "call_bad",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "read_file",
+                                        "arguments": '{"path":',
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+    except LLMProtocolError as exc:
+        assert "malformed JSON arguments" in str(exc)
+    else:
+        raise AssertionError("Expected malformed tool call JSON to raise LLMProtocolError.")
+
+
 def test_apply_stream_chunk_accumulates_content_tool_calls_and_usage() -> None:
     from app.agent.llm import _StreamState
 
@@ -144,6 +176,45 @@ def test_apply_stream_chunk_accumulates_content_tool_calls_and_usage() -> None:
     assert response.usage.total_tokens == 28
     assert response.tool_calls[0].name == "list_files"
     assert response.tool_calls[0].arguments == '{"path":"."}'
+
+
+def test_streamed_tool_call_arguments_raise_on_malformed_json() -> None:
+    from app.agent.llm import _StreamState
+
+    state = _StreamState()
+    apply_stream_chunk(
+        state,
+        {
+            "id": "resp_stream_bad",
+            "model": "gpt-5.4",
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_bad",
+                                "type": "function",
+                                "function": {
+                                    "name": "search_text",
+                                    "arguments": '{"query":',
+                                },
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+        },
+    )
+
+    response = state.to_response()
+    try:
+        response.tool_calls[0].arguments_as_json()
+    except LLMProtocolError as exc:
+        assert "malformed JSON arguments" in str(exc)
+    else:
+        raise AssertionError("Expected malformed streamed tool call JSON to raise LLMProtocolError.")
 
 
 def test_client_non_streaming_chat_uses_openai_shape() -> None:


### PR DESCRIPTION
## Summary
- add malformed JSON handling for tool-call argument parsing
- add mocked tests for malformed tool-call JSON in full responses and streamed deltas
- keep the existing LLM parser coverage passing with the updated behavior

## Testing
- `pytest -q`
- parser sanity check for `ToolCall.arguments_as_json()`

## Notes
This is a narrow parser-hardening task on top of the existing LLM client work. The main goal is to make bad model output fail in a controlled way and keep that behavior covered by tests.

## Reference
Issue: #9