### PR TITLE
ML-6 / Design SQLite schema and repository layer

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,14 @@
+"""SQLite database helpers for ML Copilot persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def connect_sqlite(database_path: Path) -> sqlite3.Connection:
+    database_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(database_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection

--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -1,0 +1,46 @@
+"""Persistence models for the SQLite repository layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    id: str
+    title: str | None
+    status: str
+    model: str
+    metadata_json: str
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class MessageRecord:
+    id: str
+    session_id: str
+    turn_id: str
+    role: str
+    content: str
+    tool_call_id: str | None
+    name: str | None
+    raw_json: str
+    sequence: int
+    created_at: str
+
+
+@dataclass(frozen=True)
+class EventRecord:
+    id: str
+    session_id: str
+    turn_id: str
+    event_type: str
+    data_json: str
+    sequence: int
+    created_at: str

--- a/app/storage/repository.py
+++ b/app/storage/repository.py
@@ -1,0 +1,334 @@
+"""SQLite repository layer for sessions, messages, and events."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+from app.db import connect_sqlite
+from app.storage.models import EventRecord, MessageRecord, SessionRecord, utc_now
+
+
+SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY,
+        title TEXT,
+        status TEXT NOT NULL,
+        model TEXT NOT NULL,
+        metadata_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS messages (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
+        tool_call_id TEXT,
+        name TEXT,
+        raw_json TEXT NOT NULL,
+        sequence INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS events (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        data_json TEXT NOT NULL,
+        sequence INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tool_calls (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        tool_name TEXT NOT NULL,
+        arguments_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        requires_approval INTEGER NOT NULL,
+        approval_id TEXT,
+        started_at TEXT,
+        finished_at TEXT,
+        output TEXT,
+        success INTEGER,
+        error TEXT,
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS approvals (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        tool_call_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        requested_at TEXT NOT NULL,
+        responded_at TEXT,
+        user_feedback TEXT,
+        edited_payload_json TEXT,
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS eval_runs (
+        id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        score REAL,
+        started_at TEXT NOT NULL,
+        finished_at TEXT,
+        report_json TEXT NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    )
+    """,
+)
+
+
+class SQLiteRepository:
+    def __init__(self, database_path: Path) -> None:
+        self.database_path = database_path
+
+    def initialize(self) -> None:
+        with connect_sqlite(self.database_path) as connection:
+            for statement in SCHEMA_STATEMENTS:
+                connection.execute(statement)
+            connection.commit()
+
+    def create_session(
+        self,
+        *,
+        model: str,
+        title: str | None = None,
+        status: str = "active",
+        metadata: dict | None = None,
+        session_id: str | None = None,
+    ) -> SessionRecord:
+        now = utc_now()
+        record = SessionRecord(
+            id=session_id or str(uuid.uuid4()),
+            title=title,
+            status=status,
+            model=model,
+            metadata_json=json.dumps(metadata or {}, sort_keys=True),
+            created_at=now,
+            updated_at=now,
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO sessions (id, title, status, model, metadata_json, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.id,
+                    record.title,
+                    record.status,
+                    record.model,
+                    record.metadata_json,
+                    record.created_at,
+                    record.updated_at,
+                ),
+            )
+            connection.commit()
+        return record
+
+    def get_session(self, session_id: str) -> SessionRecord | None:
+        with connect_sqlite(self.database_path) as connection:
+            row = connection.execute(
+                """
+                SELECT id, title, status, model, metadata_json, created_at, updated_at
+                FROM sessions
+                WHERE id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        return _session_from_row(row) if row else None
+
+    def list_sessions(self) -> list[SessionRecord]:
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, title, status, model, metadata_json, created_at, updated_at
+                FROM sessions
+                ORDER BY created_at ASC
+                """
+            ).fetchall()
+        return [_session_from_row(row) for row in rows]
+
+    def add_message(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        role: str,
+        content: str,
+        sequence: int,
+        tool_call_id: str | None = None,
+        name: str | None = None,
+        raw: dict | None = None,
+        message_id: str | None = None,
+    ) -> MessageRecord:
+        record = MessageRecord(
+            id=message_id or str(uuid.uuid4()),
+            session_id=session_id,
+            turn_id=turn_id,
+            role=role,
+            content=content,
+            tool_call_id=tool_call_id,
+            name=name,
+            raw_json=json.dumps(raw or {}, sort_keys=True),
+            sequence=sequence,
+            created_at=utc_now(),
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO messages (
+                    id, session_id, turn_id, role, content, tool_call_id, name, raw_json, sequence, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.id,
+                    record.session_id,
+                    record.turn_id,
+                    record.role,
+                    record.content,
+                    record.tool_call_id,
+                    record.name,
+                    record.raw_json,
+                    record.sequence,
+                    record.created_at,
+                ),
+            )
+            self._touch_session(connection, session_id)
+            connection.commit()
+        return record
+
+    def list_messages(self, session_id: str) -> list[MessageRecord]:
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, session_id, turn_id, role, content, tool_call_id, name, raw_json, sequence, created_at
+                FROM messages
+                WHERE session_id = ?
+                ORDER BY sequence ASC, created_at ASC
+                """,
+                (session_id,),
+            ).fetchall()
+        return [_message_from_row(row) for row in rows]
+
+    def add_event(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        event_type: str,
+        data: dict | None,
+        sequence: int,
+        event_id: str | None = None,
+    ) -> EventRecord:
+        record = EventRecord(
+            id=event_id or str(uuid.uuid4()),
+            session_id=session_id,
+            turn_id=turn_id,
+            event_type=event_type,
+            data_json=json.dumps(data or {}, sort_keys=True),
+            sequence=sequence,
+            created_at=utc_now(),
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO events (id, session_id, turn_id, event_type, data_json, sequence, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.id,
+                    record.session_id,
+                    record.turn_id,
+                    record.event_type,
+                    record.data_json,
+                    record.sequence,
+                    record.created_at,
+                ),
+            )
+            self._touch_session(connection, session_id)
+            connection.commit()
+        return record
+
+    def list_events(self, session_id: str) -> list[EventRecord]:
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, session_id, turn_id, event_type, data_json, sequence, created_at
+                FROM events
+                WHERE session_id = ?
+                ORDER BY sequence ASC, created_at ASC
+                """,
+                (session_id,),
+            ).fetchall()
+        return [_event_from_row(row) for row in rows]
+
+    def _touch_session(self, connection: sqlite3.Connection, session_id: str) -> None:
+        connection.execute(
+            """
+            UPDATE sessions
+            SET updated_at = ?
+            WHERE id = ?
+            """,
+            (utc_now(), session_id),
+        )
+
+
+def _session_from_row(row: sqlite3.Row) -> SessionRecord:
+    return SessionRecord(
+        id=row["id"],
+        title=row["title"],
+        status=row["status"],
+        model=row["model"],
+        metadata_json=row["metadata_json"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _message_from_row(row: sqlite3.Row) -> MessageRecord:
+    return MessageRecord(
+        id=row["id"],
+        session_id=row["session_id"],
+        turn_id=row["turn_id"],
+        role=row["role"],
+        content=row["content"],
+        tool_call_id=row["tool_call_id"],
+        name=row["name"],
+        raw_json=row["raw_json"],
+        sequence=row["sequence"],
+        created_at=row["created_at"],
+    )
+
+
+def _event_from_row(row: sqlite3.Row) -> EventRecord:
+    return EventRecord(
+        id=row["id"],
+        session_id=row["session_id"],
+        turn_id=row["turn_id"],
+        event_type=row["event_type"],
+        data_json=row["data_json"],
+        sequence=row["sequence"],
+        created_at=row["created_at"],
+    )

--- a/docs/phase-1-persistence.md
+++ b/docs/phase-1-persistence.md
@@ -1,0 +1,37 @@
+# Phase 1 Persistence
+
+This document captures the persistence slice for `ML Copilot`.
+
+## Task
+
+`ML-6 / Design SQLite schema and repository layer`
+
+## Scope
+
+This slice adds a stdlib SQLite persistence layer with:
+
+- schema creation for sessions, messages, events, tool calls, approvals, and eval runs
+- dataclass records for the main persisted entities
+- a repository API for sessions, messages, and events
+- timestamp updates on session activity
+
+## Why This Shape
+
+The repository layer stays intentionally small for now:
+
+- enough to persist session history
+- enough to support replay and debugging later
+- enough to stabilize the schema before route and agent-loop work lands
+
+That gives later tasks a clean place to build:
+
+- event replay
+- approval storage
+- agent turn persistence
+- eval reporting
+
+## Notes
+
+This uses `sqlite3` from the standard library to keep the persistence layer easy
+to inspect and easy to test. We can move to migrations or a heavier ORM later if
+the project grows enough to justify that complexity.

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+from app.storage.repository import SQLiteRepository
+
+
+def test_initialize_creates_expected_tables(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+
+    repository.initialize()
+
+    table_names = {
+        row[0]
+        for row in repository_path_tables(repository.database_path)
+    }
+
+    assert {
+        "sessions",
+        "messages",
+        "events",
+        "tool_calls",
+        "approvals",
+        "eval_runs",
+    }.issubset(table_names)
+
+
+def test_create_and_list_sessions(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+
+    created = repository.create_session(
+        session_id="session-1",
+        title="Repo analysis",
+        model="gpt-5.4",
+        metadata={"source": "test"},
+    )
+    fetched = repository.get_session("session-1")
+    listed = repository.list_sessions()
+
+    assert fetched == created
+    assert listed == [created]
+
+
+def test_add_message_and_event_updates_session_history(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    session = repository.create_session(
+        session_id="session-1",
+        title="Chat",
+        model="gpt-5.4",
+    )
+
+    message = repository.add_message(
+        session_id=session.id,
+        turn_id="turn-1",
+        role="user",
+        content="Analyze this repo",
+        sequence=1,
+        raw={"role": "user"},
+    )
+    event = repository.add_event(
+        session_id=session.id,
+        turn_id="turn-1",
+        event_type="processing",
+        data={"status": "started"},
+        sequence=1,
+    )
+
+    messages = repository.list_messages(session.id)
+    events = repository.list_events(session.id)
+    refreshed = repository.get_session(session.id)
+
+    assert messages == [message]
+    assert events == [event]
+    assert refreshed is not None
+    assert refreshed.updated_at >= session.updated_at
+
+
+def repository_path_tables(database_path: Path) -> list[tuple[str]]:
+    import sqlite3
+
+    connection = sqlite3.connect(database_path)
+    try:
+        return connection.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table'
+            """
+        ).fetchall()
+    finally:
+        connection.close()


### PR DESCRIPTION
## Summary
- add a stdlib SQLite schema for sessions, messages, events, tool calls, approvals, and eval runs
- add a repository layer for sessions, messages, and events
- add persistence docs and focused repository tests

## Testing
- `pytest -q`
- import check for `SQLiteRepository`

## Notes
This keeps the persistence layer small and explicit for now. It is enough to unblock later work on session replay, backend routes, and agent history without bringing in extra abstraction too early.

## Reference
Issue: #11