### PR TITLE
ML-7 / Implement persistent sessions messages and events

### DIFF
--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -44,3 +44,10 @@ class EventRecord:
     data_json: str
     sequence: int
     created_at: str
+
+
+@dataclass(frozen=True)
+class SessionHistory:
+    session: SessionRecord
+    messages: list[MessageRecord]
+    events: list[EventRecord]

--- a/app/storage/repository.py
+++ b/app/storage/repository.py
@@ -8,7 +8,7 @@ import uuid
 from pathlib import Path
 
 from app.db import connect_sqlite
-from app.storage.models import EventRecord, MessageRecord, SessionRecord, utc_now
+from app.storage.models import EventRecord, MessageRecord, SessionHistory, SessionRecord, utc_now
 
 
 SCHEMA_STATEMENTS = (
@@ -158,6 +158,50 @@ class SQLiteRepository:
             ).fetchone()
         return _session_from_row(row) if row else None
 
+    def update_session(
+        self,
+        session_id: str,
+        *,
+        title: str | None = None,
+        status: str | None = None,
+        model: str | None = None,
+        metadata: dict | None = None,
+    ) -> SessionRecord:
+        current = self.get_session(session_id)
+        if current is None:
+            raise KeyError(f"Unknown session: {session_id}")
+
+        record = SessionRecord(
+            id=current.id,
+            title=title if title is not None else current.title,
+            status=status if status is not None else current.status,
+            model=model if model is not None else current.model,
+            metadata_json=json.dumps(
+                metadata if metadata is not None else json.loads(current.metadata_json),
+                sort_keys=True,
+            ),
+            created_at=current.created_at,
+            updated_at=utc_now(),
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                UPDATE sessions
+                SET title = ?, status = ?, model = ?, metadata_json = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    record.title,
+                    record.status,
+                    record.model,
+                    record.metadata_json,
+                    record.updated_at,
+                    record.id,
+                ),
+            )
+            connection.commit()
+        return record
+
     def list_sessions(self) -> list[SessionRecord]:
         with connect_sqlite(self.database_path) as connection:
             rows = connection.execute(
@@ -283,6 +327,40 @@ class SQLiteRepository:
                 (session_id,),
             ).fetchall()
         return [_event_from_row(row) for row in rows]
+
+    def list_events_after(self, session_id: str, sequence: int) -> list[EventRecord]:
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, session_id, turn_id, event_type, data_json, sequence, created_at
+                FROM events
+                WHERE session_id = ? AND sequence > ?
+                ORDER BY sequence ASC, created_at ASC
+                """,
+                (session_id, sequence),
+            ).fetchall()
+        return [_event_from_row(row) for row in rows]
+
+    def get_session_history(self, session_id: str) -> SessionHistory:
+        session = self.get_session(session_id)
+        if session is None:
+            raise KeyError(f"Unknown session: {session_id}")
+        return SessionHistory(
+            session=session,
+            messages=self.list_messages(session_id),
+            events=self.list_events(session_id),
+        )
+
+    def delete_session(self, session_id: str) -> None:
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                DELETE FROM sessions
+                WHERE id = ?
+                """,
+                (session_id,),
+            )
+            connection.commit()
 
     def _touch_session(self, connection: sqlite3.Connection, session_id: str) -> None:
         connection.execute(

--- a/docs/phase-1-session-persistence.md
+++ b/docs/phase-1-session-persistence.md
@@ -1,0 +1,31 @@
+# Phase 1 Session Persistence
+
+This document captures the session persistence slice for `ML Copilot`.
+
+## Task
+
+`ML-7 / Implement persistent sessions messages and events`
+
+## Scope
+
+This slice builds on the SQLite schema by adding the higher-level repository
+operations needed for real session persistence:
+
+- update stored session metadata and status
+- load full session history in one call
+- list events after a known sequence for replay-style access
+- delete sessions cleanly through the root record
+
+## Why This Shape
+
+The schema alone is not enough for the next backend and agent-loop tasks. They
+need storage operations that feel like session primitives rather than raw table
+inserts.
+
+That lets later work focus on behavior instead of re-implementing persistence
+queries in multiple places.
+
+## Notes
+
+This still keeps persistence in one explicit repository. The next steps can now
+build replay, routes, and agent history handling on top of a stable storage API.

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -75,6 +75,78 @@ def test_add_message_and_event_updates_session_history(tmp_path: Path) -> None:
     assert refreshed.updated_at >= session.updated_at
 
 
+def test_update_session_and_load_full_history(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    repository.create_session(
+        session_id="session-1",
+        title="Initial",
+        model="gpt-5.4",
+        metadata={"source": "test"},
+    )
+    repository.add_message(
+        session_id="session-1",
+        turn_id="turn-1",
+        role="user",
+        content="Hello",
+        sequence=1,
+    )
+    repository.add_event(
+        session_id="session-1",
+        turn_id="turn-1",
+        event_type="processing",
+        data={"status": "started"},
+        sequence=1,
+    )
+
+    updated = repository.update_session(
+        "session-1",
+        title="Updated",
+        status="idle",
+        metadata={"source": "updated"},
+    )
+    history = repository.get_session_history("session-1")
+
+    assert updated.title == "Updated"
+    assert updated.status == "idle"
+    assert updated.metadata_json == '{"source": "updated"}'
+    assert history.session == updated
+    assert len(history.messages) == 1
+    assert len(history.events) == 1
+
+
+def test_list_events_after_and_delete_session(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    repository.create_session(
+        session_id="session-1",
+        title="Replay",
+        model="gpt-5.4",
+    )
+    repository.add_event(
+        session_id="session-1",
+        turn_id="turn-1",
+        event_type="processing",
+        data={"status": "started"},
+        sequence=1,
+    )
+    second = repository.add_event(
+        session_id="session-1",
+        turn_id="turn-1",
+        event_type="assistant_message",
+        data={"content": "done"},
+        sequence=2,
+    )
+
+    replay_events = repository.list_events_after("session-1", 1)
+    repository.delete_session("session-1")
+
+    assert replay_events == [second]
+    assert repository.get_session("session-1") is None
+    assert repository.list_messages("session-1") == []
+    assert repository.list_events("session-1") == []
+
+
 def repository_path_tables(database_path: Path) -> list[tuple[str]]:
     import sqlite3
 


### PR DESCRIPTION
## Summary
- add higher-level session persistence operations on top of the SQLite schema
- support session updates, full history loading, replay-style event queries, and deletion
- add docs and focused tests for persistent session behavior

## Testing
- `pytest -q`
- import/API check for `get_session_history`

## Notes
This keeps persistence in one repository layer while making the storage API much more useful for upcoming backend and agent-loop work.

## Reference
Issue: #13