### PR TITLE
ML-8 / Build tool registry and ToolSpec model

### DIFF
--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -1,1 +1,17 @@
 """Tooling package for repo, shell, and ML helper tools."""
+
+from app.tools.registry import (
+    DuplicateToolError,
+    ToolRegistry,
+    ToolRegistryError,
+    ToolSpec,
+    UnknownToolError,
+)
+
+__all__ = [
+    "DuplicateToolError",
+    "ToolRegistry",
+    "ToolRegistryError",
+    "ToolSpec",
+    "UnknownToolError",
+]

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -1,0 +1,71 @@
+"""Tool specification and registry primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+
+JsonDict = dict[str, Any]
+ToolHandler = Callable[[JsonDict], Awaitable[str]]
+
+
+class ToolRegistryError(RuntimeError):
+    """Base error for tool registry failures."""
+
+
+class DuplicateToolError(ToolRegistryError):
+    """Raised when a tool name is registered more than once."""
+
+
+class UnknownToolError(ToolRegistryError):
+    """Raised when the requested tool does not exist."""
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Description and callable for a single tool."""
+
+    name: str
+    description: str
+    input_schema: JsonDict
+    handler: ToolHandler = field(repr=False)
+
+    def to_openai_tool(self) -> JsonDict:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.input_schema,
+            },
+        }
+
+
+class ToolRegistry:
+    """In-memory registry for agent tools."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolSpec] = {}
+
+    def register(self, tool: ToolSpec) -> ToolSpec:
+        if tool.name in self._tools:
+            raise DuplicateToolError(f"Tool {tool.name!r} is already registered.")
+        self._tools[tool.name] = tool
+        return tool
+
+    def get(self, name: str) -> ToolSpec:
+        tool = self._tools.get(name)
+        if tool is None:
+            raise UnknownToolError(f"Tool {name!r} is not registered.")
+        return tool
+
+    def list(self) -> list[ToolSpec]:
+        return list(self._tools.values())
+
+    def openai_tools(self) -> list[JsonDict]:
+        return [tool.to_openai_tool() for tool in self._tools.values()]
+
+    async def call(self, name: str, arguments: JsonDict | None = None) -> str:
+        tool = self.get(name)
+        return await tool.handler(arguments or {})

--- a/docs/phase-1-tools-registry.md
+++ b/docs/phase-1-tools-registry.md
@@ -1,0 +1,22 @@
+# Phase 1: Tool Registry
+
+`ML-8` adds the minimal tool abstraction that later agent work will build on.
+
+## Scope
+
+- define a shared `ToolSpec` model for tool metadata and handlers
+- export tool metadata in OpenAI-compatible function format
+- register tools by name in a central in-memory registry
+- dispatch tool handlers asynchronously with clear duplicate and unknown-tool errors
+
+## Why this shape
+
+The registry stays intentionally small in Phase 1.
+
+We only need enough structure to:
+
+- expose tool definitions to the LLM client
+- route tool calls by name
+- keep later tool tasks consistent
+
+This avoids pulling orchestration, approvals, or provider-specific behavior into the base tool layer too early.

--- a/tests/unit/test_tools_registry.py
+++ b/tests/unit/test_tools_registry.py
@@ -1,0 +1,104 @@
+import asyncio
+
+from app.tools import DuplicateToolError, ToolRegistry, ToolSpec, UnknownToolError
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+async def list_files_handler(arguments: dict[str, object]) -> str:
+    return f"listing:{arguments['path']}"
+
+
+def test_toolspec_exports_openai_function_shape() -> None:
+    spec = ToolSpec(
+        name="list_files",
+        description="List files in a workspace path.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+            },
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+        handler=list_files_handler,
+    )
+
+    assert spec.to_openai_tool() == {
+        "type": "function",
+        "function": {
+            "name": "list_files",
+            "description": "List files in a workspace path.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def test_registry_registers_lists_and_calls_tools() -> None:
+    registry = ToolRegistry()
+    spec = ToolSpec(
+        name="list_files",
+        description="List files in a workspace path.",
+        input_schema={"type": "object"},
+        handler=list_files_handler,
+    )
+
+    registry.register(spec)
+
+    assert registry.get("list_files") == spec
+    assert registry.list() == [spec]
+    assert registry.openai_tools() == [spec.to_openai_tool()]
+    assert run(registry.call("list_files", {"path": "."})) == "listing:."
+
+
+def test_registry_rejects_duplicate_names() -> None:
+    registry = ToolRegistry()
+    registry.register(
+        ToolSpec(
+            name="list_files",
+            description="List files.",
+            input_schema={"type": "object"},
+            handler=list_files_handler,
+        )
+    )
+
+    try:
+        registry.register(
+            ToolSpec(
+                name="list_files",
+                description="Duplicate list files.",
+                input_schema={"type": "object"},
+                handler=list_files_handler,
+            )
+        )
+    except DuplicateToolError as exc:
+        assert "already registered" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate registration to raise DuplicateToolError.")
+
+
+def test_registry_raises_for_unknown_tool_lookup_and_call() -> None:
+    registry = ToolRegistry()
+
+    try:
+        registry.get("missing_tool")
+    except UnknownToolError as exc:
+        assert "missing_tool" in str(exc)
+    else:
+        raise AssertionError("Expected get() to raise UnknownToolError.")
+
+    try:
+        run(registry.call("missing_tool"))
+    except UnknownToolError as exc:
+        assert "missing_tool" in str(exc)
+    else:
+        raise AssertionError("Expected call() to raise UnknownToolError.")


### PR DESCRIPTION
## Summary
- add a shared `ToolSpec` model for tool metadata, async handlers, and OpenAI-compatible function export
- add an in-memory `ToolRegistry` with registration, lookup, listing, duplicate protection, and async dispatch
- add focused unit tests and a short Phase 1 doc so the next tool tasks can build on one stable abstraction

## Testing
- `pytest -q`
- `python -c "from app.tools import ToolRegistry, ToolSpec; print(ToolRegistry.__name__, ToolSpec.__name__)"`

## Notes
This keeps the base tool layer intentionally small. Concrete workspace tools, approvals, and orchestration should build on top of this registry instead of being mixed into it.

## Reference
Issue: #15
