### PR TITLE
ML-100: Implement approval model and pending approval flow

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -183,7 +183,6 @@ jobs:
         run: |
           python -c "
           from app.storage.repository import SQLiteRepository
-          from app.storage.models import SessionRecord
           import tempfile
           from pathlib import Path
 
@@ -201,6 +200,10 @@ jobs:
               retrieved = repo.get_session(session.id)
               assert retrieved is not None, 'Should retrieve session'
               assert retrieved.title == 'Test Session', 'Session title should match'
+
+              del retrieved
+              del session
+              del repo
 
               print('Repository tests passed!')
           "

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Check dependencies
         run: |
           pip install -e ".[dev]"
-          safety check --json --output vulnerability-report.json || true
+          safety check --json > vulnerability-report.json || true
 
       - name: Upload vulnerability report
         uses: actions/upload-artifact@v4

--- a/app/agent/llm.py
+++ b/app/agent/llm.py
@@ -205,7 +205,7 @@ class _ClientContextManager:
     async def __aenter__(self) -> httpx.AsyncClient:
         return self._client
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(self, _exc_type, _exc, _tb) -> None:
         if self._close_on_exit:
             await self._client.aclose()
 

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable
 
-from app.agent.llm import LLMClient, ToolCall
+from app.agent.llm import LLMClient
 from app.config import AppSettings
-from app.storage.models import SessionRecord
+from app.storage.models import MessageRecord, PendingApprovalRecord, SessionRecord
 from app.storage.repository import SQLiteRepository
 from app.tools.registry import ToolRegistry, ToolSpec
 
 logger = logging.getLogger(__name__)
 
 
-# Event types for SSE streaming
 class EventType:
     READY = "ready"
     PROCESSING = "processing"
@@ -25,15 +25,13 @@ class EventType:
     TOOL_CALL = "tool_call"
     TOOL_OUTPUT = "tool_output"
     APPROVAL_REQUIRED = "approval_required"
+    APPROVAL_RESOLVED = "approval_resolved"
     TURN_COMPLETE = "turn_complete"
     ERROR = "error"
     INTERRUPTED = "interrupted"
 
 
-# Maximum iterations per turn to prevent infinite loops
 MAX_ITERATIONS = 50
-
-# Tools that require approval before execution
 APPROVAL_REQUIRED_TOOLS = {"apply_patch", "run_command", "write_file"}
 
 
@@ -75,22 +73,9 @@ class TurnContext:
 
     session_id: str
     turn_id: str
-    user_message: str
-    messages: list[dict[str, Any]] = field(default_factory=list)
-    tool_calls: list[ToolCall] = field(default_factory=list)
-    event_sequence: int = 0
-
-
-@dataclass
-class ToolExecutionResult:
-    """Result of a tool execution."""
-
-    tool_name: str
-    tool_call_id: str
-    success: bool
-    output: str
-    requires_approval: bool = False
-    error: str | None = None
+    messages: list[dict[str, Any]]
+    event_sequence: int
+    message_sequence: int
 
 
 class AgentLoop:
@@ -107,15 +92,11 @@ class AgentLoop:
         self.tools = tool_registry
         self.repo = repository
         self.settings = settings
-
-        # Event handlers (for SSE streaming)
         self._event_handlers: list[Callable[[AgentEvent], None]] = []
-
-        # Interrupt flag
         self._interrupted = False
 
     def add_event_handler(self, handler: Callable[[AgentEvent], None]) -> None:
-        """Add a handler for agent events (e.g., SSE streaming)."""
+        """Add a handler for agent events (e.g. SSE streaming)."""
         self._event_handlers.append(handler)
 
     def remove_event_handler(self, handler: Callable[[AgentEvent], None]) -> None:
@@ -139,7 +120,6 @@ class AgentLoop:
         )
         turn_context.event_sequence += 1
 
-        # Persist event
         self.repo.add_event(
             session_id=event.session_id,
             turn_id=event.turn_id,
@@ -149,12 +129,11 @@ class AgentLoop:
             event_id=event.id,
         )
 
-        # Notify handlers
         for handler in self._event_handlers:
             try:
                 handler(event)
-            except Exception as e:
-                logger.warning(f"Event handler error: {e}")
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning("Event handler error: %s", exc)
 
     async def run_turn(
         self,
@@ -162,51 +141,91 @@ class AgentLoop:
         user_message: str,
         system_prompt: str | None = None,
     ) -> dict[str, Any]:
-        """Run a complete agent turn with user message and tool execution."""
-        turn_id = str(uuid.uuid4())
-
-        # Create turn context
-        ctx = TurnContext(
-            session_id=session.id,
-            turn_id=turn_id,
-            user_message=user_message,
-            messages=_build_messages(
-                user_message=user_message,
-                system_prompt=system_prompt or _default_system_prompt(),
-            ),
-        )
-
-        # Emit ready event
+        """Run a complete turn for a new user message."""
+        ctx = self._build_turn_context(session, system_prompt)
         await self.emit_event(ctx, EventType.READY, {"message": "Agent ready"})
 
-        # Store user message
-        self.repo.add_message(
-            session_id=ctx.session_id,
-            turn_id=ctx.turn_id,
+        pending_approvals = self.repo.list_pending_approvals(session.id)
+        if pending_approvals:
+            await self._abandon_pending_approvals(ctx, pending_approvals)
+
+        self._append_message(
+            ctx,
             role="user",
             content=user_message,
-            sequence=0,
         )
-        ctx.messages.append({"role": "user", "content": user_message})
+        await self.emit_event(ctx, EventType.PROCESSING, {})
+        return await self._run_loop(session, ctx)
 
-        # Emit processing event
+    async def resume_pending_approval(
+        self,
+        session: SessionRecord,
+        approval_id: str,
+        *,
+        approved: bool,
+        user_feedback: str | None = None,
+        edited_arguments: dict[str, Any] | None = None,
+        system_prompt: str | None = None,
+    ) -> dict[str, Any]:
+        """Apply an approval decision and continue the agent loop."""
+        ctx = self._build_turn_context(session, system_prompt)
+        await self.emit_event(ctx, EventType.READY, {"message": "Approval decision received"})
         await self.emit_event(ctx, EventType.PROCESSING, {})
 
-        # Get tool specs for LLM
-        tool_specs = self.tools.openai_tools()
+        pending_approval = self._get_pending_approval(session.id, approval_id)
+        if approved:
+            await self._approve_pending_tool(
+                ctx,
+                pending_approval,
+                user_feedback=user_feedback,
+                edited_arguments=edited_arguments,
+            )
+        else:
+            await self._reject_pending_tool(
+                ctx,
+                pending_approval,
+                status="rejected",
+                message=_approval_rejection_message(user_feedback),
+                user_feedback=user_feedback,
+                edited_arguments=edited_arguments,
+            )
 
-        # Track iterations
+        return await self._run_loop(session, ctx)
+
+    def interrupt(self) -> None:
+        """Signal the agent to stop after the current operation."""
+        self._interrupted = True
+
+    def _build_turn_context(
+        self,
+        session: SessionRecord,
+        system_prompt: str | None,
+    ) -> TurnContext:
+        prompt = system_prompt or _default_system_prompt()
+        history = [_message_to_llm_dict(record) for record in self.repo.list_messages(session.id)]
+        return TurnContext(
+            session_id=session.id,
+            turn_id=str(uuid.uuid4()),
+            messages=[{"role": "system", "content": prompt}, *history],
+            event_sequence=self.repo.next_event_sequence(session.id),
+            message_sequence=self.repo.next_message_sequence(session.id),
+        )
+
+    async def _run_loop(
+        self,
+        session: SessionRecord,
+        ctx: TurnContext,
+    ) -> dict[str, Any]:
+        tool_specs = self.tools.openai_tools()
         iterations = 0
-        tool_results: list[dict[str, Any]] = []
 
         while iterations < MAX_ITERATIONS:
             if self._interrupted:
                 await self.emit_event(ctx, EventType.INTERRUPTED, {})
-                break
+                return {"status": "interrupted", "iterations": iterations}
 
             iterations += 1
 
-            # Call LLM
             try:
                 response = await self.llm.chat(
                     messages=ctx.messages,
@@ -214,15 +233,13 @@ class AgentLoop:
                     tool_choice="auto" if tool_specs else None,
                     stream=True,
                 )
-            except Exception as e:
-                await self.emit_event(ctx, EventType.ERROR, {"error": str(e)})
+            except Exception as exc:
+                await self.emit_event(ctx, EventType.ERROR, {"error": str(exc)})
                 raise
 
-            # Process response
             full_content = response.content
             tool_calls = response.tool_calls
 
-            # Emit assistant chunk (for streaming display)
             if full_content:
                 await self.emit_event(
                     ctx,
@@ -230,124 +247,368 @@ class AgentLoop:
                     {"content": full_content, "finish_reason": response.finish_reason},
                 )
 
-            # Store assistant message
-            assistant_content = full_content or ""
+            assistant_content = "" if tool_calls else (full_content or "")
+            assistant_raw = (
+                {
+                    "tool_calls": [
+                        {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+                        for tc in tool_calls
+                    ]
+                }
+                if tool_calls
+                else None
+            )
+            assistant_message: dict[str, Any] = {
+                "role": "assistant",
+                "content": assistant_content,
+            }
             if tool_calls:
-                assistant_content = ""  # Tool calls are in raw_json
-
-            self.repo.add_message(
-                session_id=ctx.session_id,
-                turn_id=ctx.turn_id,
+                assistant_message["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": tc.type,
+                        "function": {"name": tc.name, "arguments": tc.arguments},
+                    }
+                    for tc in tool_calls
+                ]
+            self._append_message(
+                ctx,
                 role="assistant",
                 content=assistant_content,
-                sequence=len(ctx.messages),
-                raw=(
-                    {"tool_calls": [{"id": tc.id, "name": tc.name, "arguments": tc.arguments} for tc in tool_calls]}
-                    if tool_calls
-                    else None
-                ),
-            )
-            ctx.messages.append(
-                {
-                    "role": "assistant",
-                    "content": assistant_content,
-                    **(
-                        {
-                            "tool_calls": [
-                                {"id": tc.id, "type": tc.type, "function": {"name": tc.name, "arguments": tc.arguments}}
-                                for tc in tool_calls
-                            ]
-                        }
-                        if tool_calls
-                        else {}
-                    ),
-                }
+                raw=assistant_raw,
+                llm_message=assistant_message,
             )
 
-            # If no tool calls, we're done
             if not tool_calls:
                 await self.emit_event(ctx, EventType.ASSISTANT_MESSAGE, {"content": full_content or ""})
                 await self.emit_event(ctx, EventType.TURN_COMPLETE, {"iterations": iterations})
                 return {"status": "complete", "content": full_content, "iterations": iterations}
 
-            # Process tool calls
-            for tc in tool_calls:
+            pending_payloads: list[dict[str, Any]] = []
+            approval_ids: list[str] = []
+
+            for tool_call in tool_calls:
                 await self.emit_event(
                     ctx,
                     EventType.TOOL_CALL,
                     {
-                        "id": tc.id,
-                        "name": tc.name,
-                        "arguments": tc.arguments,
+                        "id": tool_call.id,
+                        "name": tool_call.name,
+                        "arguments": tool_call.arguments,
                     },
                 )
 
-                # Check if approval is required
-                requires_approval = tc.name in APPROVAL_REQUIRED_TOOLS
-
-                if requires_approval and self.settings.safety.require_tool_approval:
-                    # Emit approval required event and wait
-                    await self.emit_event(
-                        ctx,
-                        EventType.APPROVAL_REQUIRED,
-                        {
-                            "tool_call_id": tc.id,
-                            "tool_name": tc.name,
-                            "arguments": tc.arguments,
-                        },
+                try:
+                    arguments = tool_call.arguments_as_json()
+                except Exception as exc:
+                    error_message = f"Tool execution error: {exc}"
+                    self.repo.add_tool_call(
+                        session_id=ctx.session_id,
+                        turn_id=ctx.turn_id,
+                        tool_name=tool_call.name,
+                        arguments={},
+                        status="failed",
+                        requires_approval=False,
+                        started_at=_utc_now(),
+                        finished_at=_utc_now(),
+                        output=error_message,
+                        success=False,
+                        error=error_message,
+                        tool_call_id=tool_call.id,
                     )
-                    # For now, auto-reject if approval not granted
-                    # In full implementation, this would wait for user approval
-                    tool_result = {
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": ("Approval required. Tool execution skipped pending user approval."),
-                    }
-                    tool_results.append(tool_result)
-                    ctx.messages.append(tool_result)
+                    await self._record_tool_output(
+                        ctx,
+                        tool_call_id=tool_call.id,
+                        tool_name=tool_call.name,
+                        output=error_message,
+                        success=False,
+                    )
                     continue
 
-                # Execute tool
-                try:
-                    args = tc.arguments_as_json()
-                    tool_output = await self.tools.call(tc.name, args)
-                except Exception as e:
-                    tool_output = f"Tool execution error: {e}"
+                requires_approval = (
+                    self.settings.safety.require_tool_approval
+                    and tool_call.name in APPROVAL_REQUIRED_TOOLS
+                )
+                if requires_approval:
+                    self.repo.add_tool_call(
+                        session_id=ctx.session_id,
+                        turn_id=ctx.turn_id,
+                        tool_name=tool_call.name,
+                        arguments=arguments,
+                        status="pending_approval",
+                        requires_approval=True,
+                        started_at=_utc_now(),
+                        tool_call_id=tool_call.id,
+                    )
+                    approval = self.repo.create_approval(
+                        session_id=ctx.session_id,
+                        turn_id=ctx.turn_id,
+                        tool_call_id=tool_call.id,
+                    )
+                    self.repo.update_tool_call(tool_call.id, approval_id=approval.id)
+                    approval_ids.append(approval.id)
+                    pending_payloads.append(
+                        {
+                            "approval_id": approval.id,
+                            "tool_call_id": tool_call.id,
+                            "tool_name": tool_call.name,
+                            "arguments": arguments,
+                        }
+                    )
+                    continue
 
-                # Store tool result
-                tool_result = {
-                    "role": "tool",
-                    "tool_call_id": tc.id,
-                    "content": tool_output,
-                }
-                tool_results.append(tool_result)
-                ctx.messages.append(tool_result)
-
-                await self.emit_event(
+                await self._execute_tool_call(
                     ctx,
-                    EventType.TOOL_OUTPUT,
-                    {
-                        "tool_call_id": tc.id,
-                        "tool_name": tc.name,
-                        "output": tool_output,
-                        "success": "error" not in tool_output.lower(),
-                    },
+                    tool_call_id=tool_call.id,
+                    tool_name=tool_call.name,
+                    arguments=arguments,
                 )
 
-        # Max iterations reached
+            if pending_payloads:
+                await self.emit_event(
+                    ctx,
+                    EventType.APPROVAL_REQUIRED,
+                    {"tools": pending_payloads, "count": len(pending_payloads)},
+                )
+                return {
+                    "status": "approval_required",
+                    "iterations": iterations,
+                    "pending_approvals": pending_payloads,
+                    "approval_ids": approval_ids,
+                }
+
         await self.emit_event(ctx, EventType.TURN_COMPLETE, {"iterations": iterations, "max_reached": True})
         return {"status": "max_iterations", "iterations": iterations}
 
-    def interrupt(self) -> None:
-        """Signal the agent to stop after current operation."""
-        self._interrupted = True
+    async def _execute_tool_call(
+        self,
+        ctx: TurnContext,
+        *,
+        tool_call_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> None:
+        now = _utc_now()
+        existing = self.repo.get_tool_call(tool_call_id)
+        if existing is None:
+            self.repo.add_tool_call(
+                session_id=ctx.session_id,
+                turn_id=ctx.turn_id,
+                tool_name=tool_name,
+                arguments=arguments,
+                status="running",
+                requires_approval=False,
+                started_at=now,
+                tool_call_id=tool_call_id,
+            )
+        else:
+            self.repo.update_tool_call(
+                tool_call_id,
+                status="running",
+                arguments=arguments,
+                started_at=existing.started_at or now,
+                error=None,
+            )
 
+        try:
+            tool_output = await self.tools.call(tool_name, arguments)
+            success = True
+            error = None
+        except Exception as exc:
+            tool_output = f"Tool execution error: {exc}"
+            success = False
+            error = str(exc)
 
-# ── Helper Functions ─────────────────────────────────────────────────────────────
+        self.repo.update_tool_call(
+            tool_call_id,
+            status="completed" if success else "failed",
+            arguments=arguments,
+            finished_at=_utc_now(),
+            output=tool_output,
+            success=success,
+            error=error,
+        )
+        await self._record_tool_output(
+            ctx,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            output=tool_output,
+            success=success,
+        )
+
+    async def _record_tool_output(
+        self,
+        ctx: TurnContext,
+        *,
+        tool_call_id: str,
+        tool_name: str,
+        output: str,
+        success: bool,
+    ) -> None:
+        tool_message = {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": output,
+            "name": tool_name,
+        }
+        self._append_message(
+            ctx,
+            role="tool",
+            content=output,
+            tool_call_id=tool_call_id,
+            name=tool_name,
+            llm_message=tool_message,
+        )
+        await self.emit_event(
+            ctx,
+            EventType.TOOL_OUTPUT,
+            {
+                "tool_call_id": tool_call_id,
+                "tool_name": tool_name,
+                "output": output,
+                "success": success,
+            },
+        )
+
+    async def _abandon_pending_approvals(
+        self,
+        ctx: TurnContext,
+        pending_approvals: list[PendingApprovalRecord],
+    ) -> None:
+        for pending_approval in pending_approvals:
+            await self._reject_pending_tool(
+                ctx,
+                pending_approval,
+                status="abandoned",
+                message="Tool execution abandoned because the user continued the conversation.",
+                user_feedback=None,
+                edited_arguments=None,
+            )
+
+    async def _approve_pending_tool(
+        self,
+        ctx: TurnContext,
+        pending_approval: PendingApprovalRecord,
+        *,
+        user_feedback: str | None,
+        edited_arguments: dict[str, Any] | None,
+    ) -> None:
+        original_arguments = json.loads(pending_approval.tool_call.arguments_json)
+        arguments = edited_arguments if edited_arguments is not None else original_arguments
+        self.repo.update_approval(
+            pending_approval.approval.id,
+            status="approved",
+            responded_at=_utc_now(),
+            user_feedback=user_feedback,
+            edited_payload=edited_arguments,
+        )
+        self.repo.update_tool_call(
+            pending_approval.tool_call.id,
+            status="approved",
+            arguments=arguments,
+        )
+        await self.emit_event(
+            ctx,
+            EventType.APPROVAL_RESOLVED,
+            {
+                "approval_id": pending_approval.approval.id,
+                "tool_call_id": pending_approval.tool_call.id,
+                "tool_name": pending_approval.tool_call.tool_name,
+                "decision": "approved",
+            },
+        )
+        await self._execute_tool_call(
+            ctx,
+            tool_call_id=pending_approval.tool_call.id,
+            tool_name=pending_approval.tool_call.tool_name,
+            arguments=arguments,
+        )
+
+    async def _reject_pending_tool(
+        self,
+        ctx: TurnContext,
+        pending_approval: PendingApprovalRecord,
+        *,
+        status: str,
+        message: str,
+        user_feedback: str | None,
+        edited_arguments: dict[str, Any] | None,
+    ) -> None:
+        self.repo.update_approval(
+            pending_approval.approval.id,
+            status=status,
+            responded_at=_utc_now(),
+            user_feedback=user_feedback,
+            edited_payload=edited_arguments,
+        )
+        self.repo.update_tool_call(
+            pending_approval.tool_call.id,
+            status=status,
+            finished_at=_utc_now(),
+            output=message,
+            success=False,
+            error=message,
+        )
+        await self.emit_event(
+            ctx,
+            EventType.APPROVAL_RESOLVED,
+            {
+                "approval_id": pending_approval.approval.id,
+                "tool_call_id": pending_approval.tool_call.id,
+                "tool_name": pending_approval.tool_call.tool_name,
+                "decision": status,
+            },
+        )
+        await self._record_tool_output(
+            ctx,
+            tool_call_id=pending_approval.tool_call.id,
+            tool_name=pending_approval.tool_call.tool_name,
+            output=message,
+            success=False,
+        )
+
+    def _append_message(
+        self,
+        ctx: TurnContext,
+        *,
+        role: str,
+        content: str,
+        tool_call_id: str | None = None,
+        name: str | None = None,
+        raw: dict[str, Any] | None = None,
+        llm_message: dict[str, Any] | None = None,
+    ) -> None:
+        self.repo.add_message(
+            session_id=ctx.session_id,
+            turn_id=ctx.turn_id,
+            role=role,
+            content=content,
+            sequence=ctx.message_sequence,
+            tool_call_id=tool_call_id,
+            name=name,
+            raw=raw,
+        )
+        ctx.message_sequence += 1
+        ctx.messages.append(
+            llm_message
+            if llm_message is not None
+            else _message_payload(
+                role=role,
+                content=content,
+                tool_call_id=tool_call_id,
+                name=name,
+            )
+        )
+
+    def _get_pending_approval(self, session_id: str, approval_id: str) -> PendingApprovalRecord:
+        for pending_approval in self.repo.list_pending_approvals(session_id):
+            if pending_approval.approval.id == approval_id:
+                return pending_approval
+        raise KeyError(f"Unknown pending approval: {approval_id}")
 
 
 def _utc_now() -> str:
-    """Return current UTC time as ISO string."""
+    """Return current UTC time as an ISO string."""
     from datetime import UTC, datetime
 
     return datetime.now(UTC).isoformat()
@@ -388,12 +649,48 @@ Safety:
 """
 
 
-def _build_messages(user_message: str, system_prompt: str) -> list[dict[str, Any]]:
-    """Build the message list for LLM completion."""
-    return [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": user_message},
-    ]
+def _message_to_llm_dict(record: MessageRecord) -> dict[str, Any]:
+    raw = json.loads(record.raw_json) if record.raw_json else {}
+    message = _message_payload(
+        role=record.role,
+        content=record.content,
+        tool_call_id=record.tool_call_id,
+        name=record.name,
+    )
+    if record.role == "assistant" and raw.get("tool_calls"):
+        message["tool_calls"] = [
+            {
+                "id": item["id"],
+                "type": "function",
+                "function": {
+                    "name": item["name"],
+                    "arguments": item["arguments"],
+                },
+            }
+            for item in raw["tool_calls"]
+        ]
+    return message
+
+
+def _message_payload(
+    *,
+    role: str,
+    content: str,
+    tool_call_id: str | None = None,
+    name: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"role": role, "content": content}
+    if tool_call_id:
+        payload["tool_call_id"] = tool_call_id
+    if name:
+        payload["name"] = name
+    return payload
+
+
+def _approval_rejection_message(user_feedback: str | None) -> str:
+    if user_feedback:
+        return f"Tool execution rejected by user. Feedback: {user_feedback}"
+    return "Tool execution rejected by user."
 
 
 def create_agent_loop(
@@ -424,8 +721,6 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
     from app.tools import workspace
 
     registry = ToolRegistry()
-
-    # Register workspace tools
     workspace_specs = workspace.get_tool_specs()
 
     for spec in workspace_specs:

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -249,12 +249,7 @@ class AgentLoop:
 
             assistant_content = "" if tool_calls else (full_content or "")
             assistant_raw = (
-                {
-                    "tool_calls": [
-                        {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-                        for tc in tool_calls
-                    ]
-                }
+                {"tool_calls": [{"id": tc.id, "name": tc.name, "arguments": tc.arguments} for tc in tool_calls]}
                 if tool_calls
                 else None
             )
@@ -326,8 +321,7 @@ class AgentLoop:
                     continue
 
                 requires_approval = (
-                    self.settings.safety.require_tool_approval
-                    and tool_call.name in APPROVAL_REQUIRED_TOOLS
+                    self.settings.safety.require_tool_approval and tool_call.name in APPROVAL_REQUIRED_TOOLS
                 )
                 if requires_approval:
                     self.repo.add_tool_call(

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -190,6 +190,21 @@ class AgentLoop:
                 edited_arguments=edited_arguments,
             )
 
+        remaining_approvals = self.repo.list_pending_approvals(session.id)
+        if remaining_approvals:
+            pending_payloads = _serialize_pending_approvals(remaining_approvals)
+            await self.emit_event(
+                ctx,
+                EventType.APPROVAL_REQUIRED,
+                {"tools": pending_payloads, "count": len(pending_payloads)},
+            )
+            return {
+                "status": "approval_required",
+                "pending_approvals": pending_payloads,
+                "approval_ids": [item["approval_id"] for item in pending_payloads],
+                "resolved_approval_id": approval_id,
+            }
+
         return await self._run_loop(session, ctx)
 
     def interrupt(self) -> None:
@@ -685,6 +700,20 @@ def _approval_rejection_message(user_feedback: str | None) -> str:
     if user_feedback:
         return f"Tool execution rejected by user. Feedback: {user_feedback}"
     return "Tool execution rejected by user."
+
+
+def _serialize_pending_approvals(
+    pending_approvals: list[PendingApprovalRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "approval_id": pending_approval.approval.id,
+            "tool_call_id": pending_approval.tool_call.id,
+            "tool_name": pending_approval.tool_call.tool_name,
+            "arguments": json.loads(pending_approval.tool_call.arguments_json),
+        }
+        for pending_approval in pending_approvals
+    ]
 
 
 def create_agent_loop(

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -12,7 +12,7 @@ from app.agent.llm import LLMClient
 from app.config import AppSettings
 from app.storage.models import MessageRecord, PendingApprovalRecord, SessionRecord
 from app.storage.repository import SQLiteRepository
-from app.tools.registry import ToolRegistry, ToolSpec
+from app.tools.registry import ToolHandler, ToolRegistry, ToolSpec, UnknownToolError
 
 logger = logging.getLogger(__name__)
 
@@ -731,11 +731,11 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
     return registry
 
 
-def _get_workspace_handler(name: str, settings: AppSettings):
+def _get_workspace_handler(name: str, settings: AppSettings) -> ToolHandler:
     """Get the handler function for a workspace tool."""
     from app.tools import workspace as ws
 
-    handlers = {
+    handlers: dict[str, ToolHandler] = {
         "list_files": lambda args: ws.list_files_handler(args, settings),
         "read_file": lambda args: ws.read_file_handler(args, settings),
         "search_text": lambda args: ws.search_text_handler(args, settings),
@@ -743,4 +743,7 @@ def _get_workspace_handler(name: str, settings: AppSettings):
         "git_diff": lambda args: ws.git_diff_handler(args, settings),
     }
 
-    return handlers.get(name)
+    try:
+        return handlers[name]
+    except KeyError as exc:
+        raise UnknownToolError(f"Workspace tool handler is not registered for {name!r}.") from exc

--- a/app/db.py
+++ b/app/db.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 
-def connect_sqlite(database_path: Path) -> sqlite3.Connection:
+@contextmanager
+def connect_sqlite(database_path: Path) -> Iterator[sqlite3.Connection]:
     database_path.parent.mkdir(parents=True, exist_ok=True)
     connection = sqlite3.connect(database_path)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
-    return connection
+    try:
+        yield connection
+    finally:
+        connection.close()

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 
 from app.agent.loop import create_agent_loop
@@ -85,6 +86,46 @@ def build_parser() -> argparse.ArgumentParser:
         "--prompt",
         type=str,
         help="Optional new prompt to send",
+    )
+
+    approvals_parser = subparsers.add_parser("approvals", help="List pending tool approvals")
+    approvals_parser.add_argument(
+        "--session",
+        type=str,
+        help="Filter pending approvals to a single session",
+    )
+
+    approve_parser = subparsers.add_parser("approve", help="Approve a pending tool call")
+    approve_parser.add_argument("approval_id", type=str, help="Approval ID to approve")
+    approve_parser.add_argument(
+        "--session",
+        type=str,
+        required=True,
+        help="Session ID that owns the approval",
+    )
+    approve_parser.add_argument(
+        "--feedback",
+        type=str,
+        help="Optional feedback to persist with the approval decision",
+    )
+    approve_parser.add_argument(
+        "--edited-args",
+        type=str,
+        help="Optional JSON object to replace the tool arguments before execution",
+    )
+
+    reject_parser = subparsers.add_parser("reject", help="Reject a pending tool call")
+    reject_parser.add_argument("approval_id", type=str, help="Approval ID to reject")
+    reject_parser.add_argument(
+        "--session",
+        type=str,
+        required=True,
+        help="Session ID that owns the approval",
+    )
+    reject_parser.add_argument(
+        "--feedback",
+        type=str,
+        help="Optional feedback to persist with the rejection",
     )
 
     return parser
@@ -174,6 +215,23 @@ async def list_sessions(repository) -> None:
         print(f"{s.id:<40} {title[:28]:<30} {s.status:<10} {s.created_at:<30}")
 
 
+async def list_pending_approvals(repository, session_id: str | None = None) -> None:
+    """List pending tool approvals."""
+    pending = repository.list_pending_approvals(session_id)
+    if not pending:
+        print("No pending approvals found.")
+        return
+
+    print(f"{'Approval ID':<40} {'Session ID':<40} {'Tool':<20} {'Requested'}")
+    print("-" * 130)
+    for item in pending:
+        print(
+            f"{item.approval.id:<40} {item.approval.session_id:<40} "
+            f"{item.tool_call.tool_name:<20} {item.approval.requested_at}"
+        )
+        print(f"  arguments={item.tool_call.arguments_json}")
+
+
 async def cmd_run(args: argparse.Namespace, settings: AppSettings) -> int:
     """Execute the 'run' command."""
     # Combine prompt arguments
@@ -254,6 +312,62 @@ async def cmd_resume(args: argparse.Namespace, settings: AppSettings) -> int:
     return 0
 
 
+async def cmd_approvals(args: argparse.Namespace, settings: AppSettings) -> int:
+    """Execute the 'approvals' command."""
+    repo = _get_sync_repo(settings)
+    await list_pending_approvals(repo, args.session)
+    return 0
+
+
+async def cmd_approve(args: argparse.Namespace, settings: AppSettings) -> int:
+    """Execute the 'approve' command."""
+    loop = create_agent_loop(settings)
+    session = loop.repo.get_session(args.session)
+    if not session:
+        print(f"Error: Session {args.session} not found")
+        return 1
+
+    edited_arguments = None
+    if args.edited_args:
+        try:
+            parsed = json.loads(args.edited_args)
+        except json.JSONDecodeError as exc:
+            print(f"Error: --edited-args must be valid JSON: {exc}")
+            return 1
+        if not isinstance(parsed, dict):
+            print("Error: --edited-args must decode to a JSON object")
+            return 1
+        edited_arguments = parsed
+
+    result = await loop.resume_pending_approval(
+        session,
+        args.approval_id,
+        approved=True,
+        user_feedback=args.feedback,
+        edited_arguments=edited_arguments,
+    )
+    print(f"Approval processed. Status: {result['status']}")
+    return 0
+
+
+async def cmd_reject(args: argparse.Namespace, settings: AppSettings) -> int:
+    """Execute the 'reject' command."""
+    loop = create_agent_loop(settings)
+    session = loop.repo.get_session(args.session)
+    if not session:
+        print(f"Error: Session {args.session} not found")
+        return 1
+
+    result = await loop.resume_pending_approval(
+        session,
+        args.approval_id,
+        approved=False,
+        user_feedback=args.feedback,
+    )
+    print(f"Approval processed. Status: {result['status']}")
+    return 0
+
+
 def _get_sync_repo(settings: AppSettings):
     """Get a synchronous repository for simple operations."""
     from app.storage.repository import SQLiteRepository
@@ -290,6 +404,12 @@ def main() -> int:
             return asyncio.run(cmd_sessions(args, settings))
         elif args.command == "resume":
             return asyncio.run(cmd_resume(args, settings))
+        elif args.command == "approvals":
+            return asyncio.run(cmd_approvals(args, settings))
+        elif args.command == "approve":
+            return asyncio.run(cmd_approve(args, settings))
+        elif args.command == "reject":
+            return asyncio.run(cmd_reject(args, settings))
         else:
             parser.print_help()
             return 0

--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -47,6 +47,42 @@ class EventRecord:
 
 
 @dataclass(frozen=True)
+class ToolCallRecord:
+    id: str
+    session_id: str
+    turn_id: str
+    tool_name: str
+    arguments_json: str
+    status: str
+    requires_approval: bool
+    approval_id: str | None
+    started_at: str | None
+    finished_at: str | None
+    output: str | None
+    success: bool | None
+    error: str | None
+
+
+@dataclass(frozen=True)
+class ApprovalRecord:
+    id: str
+    session_id: str
+    turn_id: str
+    tool_call_id: str
+    status: str
+    requested_at: str
+    responded_at: str | None
+    user_feedback: str | None
+    edited_payload_json: str | None
+
+
+@dataclass(frozen=True)
+class PendingApprovalRecord:
+    approval: ApprovalRecord
+    tool_call: ToolCallRecord
+
+
+@dataclass(frozen=True)
 class SessionHistory:
     session: SessionRecord
     messages: list[MessageRecord]

--- a/app/storage/repository.py
+++ b/app/storage/repository.py
@@ -527,11 +527,7 @@ class SQLiteRepository:
             session_id=current.session_id,
             turn_id=current.turn_id,
             tool_name=current.tool_name,
-            arguments_json=(
-                json.dumps(arguments, sort_keys=True)
-                if arguments is not None
-                else current.arguments_json
-            ),
+            arguments_json=(json.dumps(arguments, sort_keys=True) if arguments is not None else current.arguments_json),
             status=status if status is not None else current.status,
             requires_approval=current.requires_approval,
             approval_id=approval_id if approval_id is not None else current.approval_id,
@@ -620,11 +616,7 @@ class SQLiteRepository:
             requested_at=requested_at or utc_now(),
             responded_at=responded_at,
             user_feedback=user_feedback,
-            edited_payload_json=(
-                json.dumps(edited_payload, sort_keys=True)
-                if edited_payload is not None
-                else None
-            ),
+            edited_payload_json=(json.dumps(edited_payload, sort_keys=True) if edited_payload is not None else None),
         )
         with connect_sqlite(self.database_path) as connection:
             connection.execute(

--- a/app/storage/repository.py
+++ b/app/storage/repository.py
@@ -8,7 +8,16 @@ import uuid
 from pathlib import Path
 
 from app.db import connect_sqlite
-from app.storage.models import EventRecord, MessageRecord, SessionHistory, SessionRecord, utc_now
+from app.storage.models import (
+    ApprovalRecord,
+    EventRecord,
+    MessageRecord,
+    PendingApprovalRecord,
+    SessionHistory,
+    SessionRecord,
+    ToolCallRecord,
+    utc_now,
+)
 
 SCHEMA_STATEMENTS = (
     """
@@ -302,6 +311,18 @@ class SQLiteRepository:
             ).fetchall()
         return [_message_from_row(row) for row in rows]
 
+    def next_message_sequence(self, session_id: str) -> int:
+        with connect_sqlite(self.database_path) as connection:
+            row = connection.execute(
+                """
+                SELECT COALESCE(MAX(sequence), -1) AS max_sequence
+                FROM messages
+                WHERE session_id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        return int(row["max_sequence"]) + 1
+
     def add_event(
         self,
         *,
@@ -375,6 +396,379 @@ class SQLiteRepository:
             ).fetchall()
         return [_event_from_row(row) for row in rows]
 
+    def next_event_sequence(self, session_id: str) -> int:
+        with connect_sqlite(self.database_path) as connection:
+            row = connection.execute(
+                """
+                SELECT COALESCE(MAX(sequence), -1) AS max_sequence
+                FROM events
+                WHERE session_id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        return int(row["max_sequence"]) + 1
+
+    def add_tool_call(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        tool_name: str,
+        arguments: dict | None,
+        status: str,
+        requires_approval: bool,
+        approval_id: str | None = None,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+        output: str | None = None,
+        success: bool | None = None,
+        error: str | None = None,
+        tool_call_id: str | None = None,
+    ) -> ToolCallRecord:
+        record = ToolCallRecord(
+            id=tool_call_id or str(uuid.uuid4()),
+            session_id=session_id,
+            turn_id=turn_id,
+            tool_name=tool_name,
+            arguments_json=json.dumps(arguments or {}, sort_keys=True),
+            status=status,
+            requires_approval=requires_approval,
+            approval_id=approval_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            output=output,
+            success=success,
+            error=error,
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO tool_calls (
+                    id,
+                    session_id,
+                    turn_id,
+                    tool_name,
+                    arguments_json,
+                    status,
+                    requires_approval,
+                    approval_id,
+                    started_at,
+                    finished_at,
+                    output,
+                    success,
+                    error
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.id,
+                    record.session_id,
+                    record.turn_id,
+                    record.tool_name,
+                    record.arguments_json,
+                    record.status,
+                    1 if record.requires_approval else 0,
+                    record.approval_id,
+                    record.started_at,
+                    record.finished_at,
+                    record.output,
+                    None if record.success is None else int(record.success),
+                    record.error,
+                ),
+            )
+            self._touch_session(connection, session_id)
+            connection.commit()
+        return record
+
+    def get_tool_call(self, tool_call_id: str) -> ToolCallRecord | None:
+        with connect_sqlite(self.database_path) as connection:
+            row = connection.execute(
+                """
+                SELECT
+                    id,
+                    session_id,
+                    turn_id,
+                    tool_name,
+                    arguments_json,
+                    status,
+                    requires_approval,
+                    approval_id,
+                    started_at,
+                    finished_at,
+                    output,
+                    success,
+                    error
+                FROM tool_calls
+                WHERE id = ?
+                """,
+                (tool_call_id,),
+            ).fetchone()
+        return _tool_call_from_row(row) if row else None
+
+    def update_tool_call(
+        self,
+        tool_call_id: str,
+        *,
+        status: str | None = None,
+        approval_id: str | None = None,
+        arguments: dict | None = None,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+        output: str | None = None,
+        success: bool | None = None,
+        error: str | None = None,
+    ) -> ToolCallRecord:
+        current = self.get_tool_call(tool_call_id)
+        if current is None:
+            raise KeyError(f"Unknown tool call: {tool_call_id}")
+
+        record = ToolCallRecord(
+            id=current.id,
+            session_id=current.session_id,
+            turn_id=current.turn_id,
+            tool_name=current.tool_name,
+            arguments_json=(
+                json.dumps(arguments, sort_keys=True)
+                if arguments is not None
+                else current.arguments_json
+            ),
+            status=status if status is not None else current.status,
+            requires_approval=current.requires_approval,
+            approval_id=approval_id if approval_id is not None else current.approval_id,
+            started_at=started_at if started_at is not None else current.started_at,
+            finished_at=finished_at if finished_at is not None else current.finished_at,
+            output=output if output is not None else current.output,
+            success=success if success is not None else current.success,
+            error=error if error is not None else current.error,
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                UPDATE tool_calls
+                SET
+                    arguments_json = ?,
+                    status = ?,
+                    approval_id = ?,
+                    started_at = ?,
+                    finished_at = ?,
+                    output = ?,
+                    success = ?,
+                    error = ?
+                WHERE id = ?
+                """,
+                (
+                    record.arguments_json,
+                    record.status,
+                    record.approval_id,
+                    record.started_at,
+                    record.finished_at,
+                    record.output,
+                    None if record.success is None else int(record.success),
+                    record.error,
+                    record.id,
+                ),
+            )
+            self._touch_session(connection, record.session_id)
+            connection.commit()
+        return record
+
+    def list_tool_calls(self, session_id: str) -> list[ToolCallRecord]:
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    id,
+                    session_id,
+                    turn_id,
+                    tool_name,
+                    arguments_json,
+                    status,
+                    requires_approval,
+                    approval_id,
+                    started_at,
+                    finished_at,
+                    output,
+                    success,
+                    error
+                FROM tool_calls
+                WHERE session_id = ?
+                ORDER BY started_at ASC, id ASC
+                """,
+                (session_id,),
+            ).fetchall()
+        return [_tool_call_from_row(row) for row in rows]
+
+    def create_approval(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        tool_call_id: str,
+        status: str = "pending",
+        requested_at: str | None = None,
+        responded_at: str | None = None,
+        user_feedback: str | None = None,
+        edited_payload: dict | None = None,
+        approval_id: str | None = None,
+    ) -> ApprovalRecord:
+        record = ApprovalRecord(
+            id=approval_id or str(uuid.uuid4()),
+            session_id=session_id,
+            turn_id=turn_id,
+            tool_call_id=tool_call_id,
+            status=status,
+            requested_at=requested_at or utc_now(),
+            responded_at=responded_at,
+            user_feedback=user_feedback,
+            edited_payload_json=(
+                json.dumps(edited_payload, sort_keys=True)
+                if edited_payload is not None
+                else None
+            ),
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO approvals (
+                    id,
+                    session_id,
+                    turn_id,
+                    tool_call_id,
+                    status,
+                    requested_at,
+                    responded_at,
+                    user_feedback,
+                    edited_payload_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.id,
+                    record.session_id,
+                    record.turn_id,
+                    record.tool_call_id,
+                    record.status,
+                    record.requested_at,
+                    record.responded_at,
+                    record.user_feedback,
+                    record.edited_payload_json,
+                ),
+            )
+            self._touch_session(connection, session_id)
+            connection.commit()
+        return record
+
+    def get_approval(self, approval_id: str) -> ApprovalRecord | None:
+        with connect_sqlite(self.database_path) as connection:
+            row = connection.execute(
+                """
+                SELECT
+                    id,
+                    session_id,
+                    turn_id,
+                    tool_call_id,
+                    status,
+                    requested_at,
+                    responded_at,
+                    user_feedback,
+                    edited_payload_json
+                FROM approvals
+                WHERE id = ?
+                """,
+                (approval_id,),
+            ).fetchone()
+        return _approval_from_row(row) if row else None
+
+    def update_approval(
+        self,
+        approval_id: str,
+        *,
+        status: str | None = None,
+        responded_at: str | None = None,
+        user_feedback: str | None = None,
+        edited_payload: dict | None = None,
+    ) -> ApprovalRecord:
+        current = self.get_approval(approval_id)
+        if current is None:
+            raise KeyError(f"Unknown approval: {approval_id}")
+
+        record = ApprovalRecord(
+            id=current.id,
+            session_id=current.session_id,
+            turn_id=current.turn_id,
+            tool_call_id=current.tool_call_id,
+            status=status if status is not None else current.status,
+            requested_at=current.requested_at,
+            responded_at=responded_at if responded_at is not None else current.responded_at,
+            user_feedback=user_feedback if user_feedback is not None else current.user_feedback,
+            edited_payload_json=(
+                json.dumps(edited_payload, sort_keys=True)
+                if edited_payload is not None
+                else current.edited_payload_json
+            ),
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                UPDATE approvals
+                SET
+                    status = ?,
+                    responded_at = ?,
+                    user_feedback = ?,
+                    edited_payload_json = ?
+                WHERE id = ?
+                """,
+                (
+                    record.status,
+                    record.responded_at,
+                    record.user_feedback,
+                    record.edited_payload_json,
+                    record.id,
+                ),
+            )
+            self._touch_session(connection, record.session_id)
+            connection.commit()
+        return record
+
+    def list_pending_approvals(self, session_id: str | None = None) -> list[PendingApprovalRecord]:
+        query = """
+            SELECT
+                a.id AS approval_id,
+                a.session_id AS approval_session_id,
+                a.turn_id AS approval_turn_id,
+                a.tool_call_id AS approval_tool_call_id,
+                a.status AS approval_status,
+                a.requested_at AS approval_requested_at,
+                a.responded_at AS approval_responded_at,
+                a.user_feedback AS approval_user_feedback,
+                a.edited_payload_json AS approval_edited_payload_json,
+                tc.id AS tool_call_id,
+                tc.session_id AS tool_call_session_id,
+                tc.turn_id AS tool_call_turn_id,
+                tc.tool_name AS tool_call_tool_name,
+                tc.arguments_json AS tool_call_arguments_json,
+                tc.status AS tool_call_status,
+                tc.requires_approval AS tool_call_requires_approval,
+                tc.approval_id AS tool_call_approval_id,
+                tc.started_at AS tool_call_started_at,
+                tc.finished_at AS tool_call_finished_at,
+                tc.output AS tool_call_output,
+                tc.success AS tool_call_success,
+                tc.error AS tool_call_error
+            FROM approvals a
+            INNER JOIN tool_calls tc ON tc.id = a.tool_call_id
+            WHERE a.status = 'pending'
+        """
+        params: tuple[str, ...] = ()
+        if session_id is not None:
+            query += " AND a.session_id = ?"
+            params = (session_id,)
+        query += " ORDER BY a.requested_at ASC, a.id ASC"
+
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(query, params).fetchall()
+        return [_pending_approval_from_row(row) for row in rows]
+
     def get_session_history(self, session_id: str) -> SessionHistory:
         session = self.get_session(session_id)
         if session is None:
@@ -443,4 +837,67 @@ def _event_from_row(row: sqlite3.Row) -> EventRecord:
         data_json=row["data_json"],
         sequence=row["sequence"],
         created_at=row["created_at"],
+    )
+
+
+def _tool_call_from_row(row: sqlite3.Row) -> ToolCallRecord:
+    return ToolCallRecord(
+        id=row["id"],
+        session_id=row["session_id"],
+        turn_id=row["turn_id"],
+        tool_name=row["tool_name"],
+        arguments_json=row["arguments_json"],
+        status=row["status"],
+        requires_approval=bool(row["requires_approval"]),
+        approval_id=row["approval_id"],
+        started_at=row["started_at"],
+        finished_at=row["finished_at"],
+        output=row["output"],
+        success=None if row["success"] is None else bool(row["success"]),
+        error=row["error"],
+    )
+
+
+def _approval_from_row(row: sqlite3.Row) -> ApprovalRecord:
+    return ApprovalRecord(
+        id=row["id"],
+        session_id=row["session_id"],
+        turn_id=row["turn_id"],
+        tool_call_id=row["tool_call_id"],
+        status=row["status"],
+        requested_at=row["requested_at"],
+        responded_at=row["responded_at"],
+        user_feedback=row["user_feedback"],
+        edited_payload_json=row["edited_payload_json"],
+    )
+
+
+def _pending_approval_from_row(row: sqlite3.Row) -> PendingApprovalRecord:
+    return PendingApprovalRecord(
+        approval=ApprovalRecord(
+            id=row["approval_id"],
+            session_id=row["approval_session_id"],
+            turn_id=row["approval_turn_id"],
+            tool_call_id=row["approval_tool_call_id"],
+            status=row["approval_status"],
+            requested_at=row["approval_requested_at"],
+            responded_at=row["approval_responded_at"],
+            user_feedback=row["approval_user_feedback"],
+            edited_payload_json=row["approval_edited_payload_json"],
+        ),
+        tool_call=ToolCallRecord(
+            id=row["tool_call_id"],
+            session_id=row["tool_call_session_id"],
+            turn_id=row["tool_call_turn_id"],
+            tool_name=row["tool_call_tool_name"],
+            arguments_json=row["tool_call_arguments_json"],
+            status=row["tool_call_status"],
+            requires_approval=bool(row["tool_call_requires_approval"]),
+            approval_id=row["tool_call_approval_id"],
+            started_at=row["tool_call_started_at"],
+            finished_at=row["tool_call_finished_at"],
+            output=row["tool_call_output"],
+            success=None if row["tool_call_success"] is None else bool(row["tool_call_success"]),
+            error=row["tool_call_error"],
+        ),
     )

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.agent.llm import LLMResponse, ToolCall
+from app.agent.loop import AgentLoop
+from app.config import AppPaths, AppSettings
+from app.storage.repository import SQLiteRepository
+from app.tools.registry import ToolRegistry, ToolSpec
+
+
+class DummyLLM:
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, object]] = []
+
+    async def chat(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._responses.pop(0)
+
+
+async def _async_handler(output: str, calls: list[dict[str, object]], args: dict[str, object]) -> str:
+    calls.append(args)
+    return output
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+def _repository(tmp_path: Path) -> SQLiteRepository:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    return repository
+
+
+def _registry(tool_output: str, tool_calls: list[dict[str, object]]) -> ToolRegistry:
+    registry = ToolRegistry()
+
+    async def run_command_handler(args: dict[str, object]) -> str:
+        return await _async_handler(tool_output, tool_calls, args)
+
+    registry.register(
+        ToolSpec(
+            name="run_command",
+            description="Run a command",
+            input_schema={"type": "object"},
+            handler=run_command_handler,
+        )
+    )
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_run_turn_persists_pending_approval_and_resumes_after_approval(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    session = repository.create_session(session_id="session-1", title="Approval", model="gpt-5.4")
+    tool_invocations: list[dict[str, object]] = []
+    llm = DummyLLM(
+        responses=[
+            LLMResponse(
+                model="gpt-5.4",
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="call-1",
+                        name="run_command",
+                        arguments='{"command":"pytest"}',
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                model="gpt-5.4",
+                content="Command executed successfully.",
+                finish_reason="stop",
+            ),
+        ]
+    )
+    loop = AgentLoop(
+        llm_client=llm,
+        tool_registry=_registry("pytest ok", tool_invocations),
+        repository=repository,
+        settings=_settings(tmp_path),
+    )
+
+    first_result = await loop.run_turn(session, "Run the tests")
+    pending = repository.list_pending_approvals(session.id)
+
+    assert first_result["status"] == "approval_required"
+    assert len(pending) == 1
+    assert repository.list_messages(session.id)[-1].role == "assistant"
+
+    final_result = await loop.resume_pending_approval(
+        session,
+        pending[0].approval.id,
+        approved=True,
+        user_feedback="approved",
+    )
+
+    updated_approval = repository.get_approval(pending[0].approval.id)
+    updated_tool_call = repository.get_tool_call("call-1")
+    second_call_messages = llm.calls[1]["messages"]
+
+    assert final_result["status"] == "complete"
+    assert updated_approval is not None
+    assert updated_approval.status == "approved"
+    assert updated_tool_call is not None
+    assert updated_tool_call.status == "completed"
+    assert tool_invocations == [{"command": "pytest"}]
+    assert repository.list_pending_approvals(session.id) == []
+    assert any(message["role"] == "tool" and message["content"] == "pytest ok" for message in second_call_messages)
+    assert any(message["role"] == "assistant" and message.get("tool_calls") for message in second_call_messages)
+
+
+@pytest.mark.asyncio
+async def test_rejecting_pending_approval_resumes_loop_with_tool_feedback(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    session = repository.create_session(session_id="session-1", title="Reject", model="gpt-5.4")
+    tool_invocations: list[dict[str, object]] = []
+    llm = DummyLLM(
+        responses=[
+            LLMResponse(
+                model="gpt-5.4",
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="call-1",
+                        name="run_command",
+                        arguments='{"command":"rm -rf ."}',
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                model="gpt-5.4",
+                content="Understood. I will not run that command.",
+                finish_reason="stop",
+            ),
+        ]
+    )
+    loop = AgentLoop(
+        llm_client=llm,
+        tool_registry=_registry("should not run", tool_invocations),
+        repository=repository,
+        settings=_settings(tmp_path),
+    )
+
+    await loop.run_turn(session, "Clean the repo")
+    pending = repository.list_pending_approvals(session.id)
+    result = await loop.resume_pending_approval(
+        session,
+        pending[0].approval.id,
+        approved=False,
+        user_feedback="skip it",
+    )
+
+    updated_approval = repository.get_approval(pending[0].approval.id)
+    updated_tool_call = repository.get_tool_call("call-1")
+    second_call_messages = llm.calls[1]["messages"]
+
+    assert result["status"] == "complete"
+    assert updated_approval is not None
+    assert updated_approval.status == "rejected"
+    assert updated_tool_call is not None
+    assert updated_tool_call.status == "rejected"
+    assert tool_invocations == []
+    assert any(
+        message["role"] == "tool" and "rejected by user" in message["content"]
+        for message in second_call_messages
+    )

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -168,6 +168,5 @@ async def test_rejecting_pending_approval_resumes_loop_with_tool_feedback(tmp_pa
     assert updated_tool_call.status == "rejected"
     assert tool_invocations == []
     assert any(
-        message["role"] == "tool" and "rejected by user" in message["content"]
-        for message in second_call_messages
+        message["role"] == "tool" and "rejected by user" in message["content"] for message in second_call_messages
     )

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -170,3 +170,79 @@ async def test_rejecting_pending_approval_resumes_loop_with_tool_feedback(tmp_pa
     assert any(
         message["role"] == "tool" and "rejected by user" in message["content"] for message in second_call_messages
     )
+
+
+@pytest.mark.asyncio
+async def test_multiple_pending_approvals_wait_until_all_decisions_are_recorded(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    session = repository.create_session(session_id="session-1", title="Batch", model="gpt-5.4")
+    tool_invocations: list[dict[str, object]] = []
+    llm = DummyLLM(
+        responses=[
+            LLMResponse(
+                model="gpt-5.4",
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="call-1",
+                        name="run_command",
+                        arguments='{"command":"pytest"}',
+                    ),
+                    ToolCall(
+                        id="call-2",
+                        name="run_command",
+                        arguments='{"command":"ruff check app"}',
+                    ),
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                model="gpt-5.4",
+                content="Both approved commands completed.",
+                finish_reason="stop",
+            ),
+        ]
+    )
+    loop = AgentLoop(
+        llm_client=llm,
+        tool_registry=_registry("command ok", tool_invocations),
+        repository=repository,
+        settings=_settings(tmp_path),
+    )
+
+    first_result = await loop.run_turn(session, "Run both checks")
+    pending = repository.list_pending_approvals(session.id)
+
+    assert first_result["status"] == "approval_required"
+    assert len(pending) == 2
+    assert len(llm.calls) == 1
+
+    second_result = await loop.resume_pending_approval(
+        session,
+        pending[0].approval.id,
+        approved=True,
+        user_feedback="approve first",
+    )
+
+    remaining_pending = repository.list_pending_approvals(session.id)
+    assert second_result["status"] == "approval_required"
+    assert len(second_result["pending_approvals"]) == 1
+    assert len(remaining_pending) == 1
+    assert remaining_pending[0].tool_call.id == "call-2"
+    assert len(llm.calls) == 1
+    assert tool_invocations == [{"command": "pytest"}]
+
+    final_result = await loop.resume_pending_approval(
+        session,
+        remaining_pending[0].approval.id,
+        approved=True,
+        user_feedback="approve second",
+    )
+
+    final_messages = llm.calls[1]["messages"]
+
+    assert final_result["status"] == "complete"
+    assert repository.list_pending_approvals(session.id) == []
+    assert len(llm.calls) == 2
+    assert tool_invocations == [{"command": "pytest"}, {"command": "ruff check app"}]
+    assert any(message["role"] == "tool" and message["content"] == "command ok" for message in final_messages)

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -144,6 +144,90 @@ def test_list_events_after_and_delete_session(tmp_path: Path) -> None:
     assert repository.list_events("session-1") == []
 
 
+def test_tool_call_and_approval_lifecycle(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    repository.create_session(
+        session_id="session-1",
+        title="Approvals",
+        model="gpt-5.4",
+    )
+
+    tool_call = repository.add_tool_call(
+        session_id="session-1",
+        turn_id="turn-1",
+        tool_name="run_command",
+        arguments={"command": "pytest"},
+        status="pending_approval",
+        requires_approval=True,
+        tool_call_id="call-1",
+    )
+    approval = repository.create_approval(
+        session_id="session-1",
+        turn_id="turn-1",
+        tool_call_id=tool_call.id,
+        approval_id="approval-1",
+    )
+    repository.update_tool_call(tool_call.id, approval_id=approval.id)
+
+    pending = repository.list_pending_approvals("session-1")
+    resolved_approval = repository.update_approval(
+        approval.id,
+        status="approved",
+        responded_at="2026-05-09T00:00:00+00:00",
+        user_feedback="looks good",
+        edited_payload={"command": "pytest -q"},
+    )
+    resolved_tool_call = repository.update_tool_call(
+        tool_call.id,
+        status="completed",
+        arguments={"command": "pytest -q"},
+        finished_at="2026-05-09T00:00:01+00:00",
+        output="ok",
+        success=True,
+    )
+
+    assert len(pending) == 1
+    assert pending[0].approval.id == "approval-1"
+    assert pending[0].tool_call.id == "call-1"
+    assert resolved_approval.status == "approved"
+    assert resolved_approval.edited_payload_json == '{"command": "pytest -q"}'
+    assert resolved_tool_call.status == "completed"
+    assert resolved_tool_call.output == "ok"
+    assert repository.list_pending_approvals("session-1") == []
+
+
+def test_next_sequences_advance_with_history(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    repository.create_session(
+        session_id="session-1",
+        title="Sequence",
+        model="gpt-5.4",
+    )
+
+    assert repository.next_message_sequence("session-1") == 0
+    assert repository.next_event_sequence("session-1") == 0
+
+    repository.add_message(
+        session_id="session-1",
+        turn_id="turn-1",
+        role="user",
+        content="hello",
+        sequence=0,
+    )
+    repository.add_event(
+        session_id="session-1",
+        turn_id="turn-1",
+        event_type="processing",
+        data={},
+        sequence=0,
+    )
+
+    assert repository.next_message_sequence("session-1") == 1
+    assert repository.next_event_sequence("session-1") == 1
+
+
 def repository_path_tables(database_path: Path) -> list[tuple[str]]:
     import sqlite3
 


### PR DESCRIPTION
## Summary
- persist tool call and approval records in the SQLite repository
- resume or reject pending approvals through the agent loop and CLI commands
- add approval lifecycle tests for repository and loop behavior

## Verification
- python -m ruff check app tests
- python -m pytest -q
- python -m mypy app

## Notes
- Phase 1 audit looks complete in code, but the Notion connector token is currently revoked again, so I could not write back the Phase 1/ML-100 note updates from this session.

Closes #24