### PR TITLE
ML-101: Implement apply_patch tool

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -770,6 +770,7 @@ def _get_workspace_handler(name: str, settings: AppSettings) -> ToolHandler:
         "search_text": lambda args: ws.search_text_handler(args, settings),
         "git_status": lambda args: ws.git_status_handler(args, settings),
         "git_diff": lambda args: ws.git_diff_handler(args, settings),
+        "apply_patch": lambda args: ws.apply_patch_handler(args, settings),
     }
 
     try:

--- a/app/tools/workspace.py
+++ b/app/tools/workspace.py
@@ -1,10 +1,11 @@
-"""Read-only workspace tools: list files, read file, search text, git status, git diff."""
+"""Workspace tools for reading, searching, git inspection, and safe patch edits."""
 
 from __future__ import annotations
 
 import fnmatch
 import re
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -39,6 +40,18 @@ def _workspace_error(path_value: str, workspace_root: Path) -> str:
     return f"Error: Path {path_value!r} is outside workspace root {workspace_root}"
 
 
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    """Return de-duplicated values while preserving order."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
 def _format_lines(lines: list[str], offset: int = 1) -> list[str]:
     """Add line numbers to lines."""
     result = []
@@ -58,6 +71,62 @@ def _resolve_search_root(
     if not path_filter:
         return workspace_root
     return _safe_path(Path(path_filter), workspace_root)
+
+
+def _extract_patch_paths(patch_text: str) -> list[str]:
+    """Extract referenced file paths from a unified diff patch."""
+    paths: list[str] = []
+    for line in patch_text.splitlines():
+        if line.startswith("diff --git "):
+            match = re.match(r"^diff --git a/(.+) b/(.+)$", line)
+            if not match:
+                raise ValueError(f"Unsupported diff header: {line}")
+            left_path, right_path = match.groups()
+            if left_path != "/dev/null":
+                paths.append(left_path)
+            if right_path != "/dev/null":
+                paths.append(right_path)
+            continue
+        if line.startswith("--- "):
+            candidate = line[4:].strip()
+            if candidate.startswith("a/"):
+                candidate = candidate[2:]
+            if candidate != "/dev/null":
+                paths.append(candidate)
+            continue
+        if line.startswith("+++ "):
+            candidate = line[4:].strip()
+            if candidate.startswith("b/"):
+                candidate = candidate[2:]
+            if candidate != "/dev/null":
+                paths.append(candidate)
+    return _dedupe_preserve_order(paths)
+
+
+def _validate_patch_targets(
+    patch_paths: list[str],
+    workspace_root: Path,
+) -> list[Path]:
+    """Resolve patch paths and ensure every target stays inside the workspace."""
+    if not patch_paths:
+        raise ValueError("Patch does not reference any files.")
+
+    safe_targets: list[Path] = []
+    for patch_path in patch_paths:
+        candidate = Path(patch_path)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError(f"Patch path {patch_path!r} escapes the workspace root.")
+        safe_target = _safe_path(workspace_root / candidate, workspace_root)
+        if safe_target is None:
+            raise ValueError(f"Patch path {patch_path!r} escapes the workspace root.")
+        safe_targets.append(safe_target)
+    return safe_targets
+
+
+def _format_subprocess_error(prefix: str, result: subprocess.CompletedProcess[str]) -> str:
+    """Return a readable error message for a failed subprocess."""
+    details = result.stderr.strip() or result.stdout.strip() or "Unknown error."
+    return f"Error: {prefix} {details}"
 
 
 def _extension_for(file_type: str | None) -> str | None:
@@ -317,6 +386,66 @@ async def git_diff_handler(args: dict[str, Any], settings: AppSettings) -> str:
         return f"Error running git diff: {exc}"
 
 
+async def apply_patch_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Apply an approved unified diff patch within the workspace root."""
+    patch_text = args.get("patch", "")
+    if not isinstance(patch_text, str) or not patch_text.strip():
+        return "Error: No patch provided."
+
+    try:
+        patch_paths = _extract_patch_paths(patch_text)
+        safe_targets = _validate_patch_targets(
+            patch_paths,
+            settings.paths.workspace_root,
+        )
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+    patch_file_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".patch",
+            delete=False,
+            encoding="utf-8",
+        ) as patch_file:
+            patch_file.write(patch_text)
+            patch_file_path = Path(patch_file.name)
+
+        check_result = subprocess.run(
+            ["git", "apply", "--check", "--recount", str(patch_file_path)],
+            cwd=str(settings.paths.workspace_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if check_result.returncode != 0:
+            return _format_subprocess_error("Patch validation failed.", check_result)
+
+        apply_result = subprocess.run(
+            ["git", "apply", "--recount", str(patch_file_path)],
+            cwd=str(settings.paths.workspace_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if apply_result.returncode != 0:
+            return _format_subprocess_error("Failed to apply patch.", apply_result)
+    except subprocess.TimeoutExpired:
+        return "Error: Patch application timed out."
+    except FileNotFoundError:
+        return "Error: Git is not installed or not in PATH."
+    except Exception as exc:
+        return f"Error applying patch: {exc}"
+    finally:
+        if patch_file_path is not None:
+            patch_file_path.unlink(missing_ok=True)
+
+    changed_files = [_format_workspace_relative(path, settings.paths.workspace_root) for path in safe_targets]
+    file_lines = "\n".join(f"  - {path}" for path in changed_files)
+    return f"Patch applied successfully.\nChanged files:\n{file_lines}"
+
+
 def get_tool_specs() -> list[dict[str, Any]]:
     """Return OpenAI-compatible tool specifications."""
     return [
@@ -428,6 +557,23 @@ def get_tool_specs() -> list[dict[str, Any]]:
                         "description": "Show staged changes instead of unstaged (default: false).",
                     },
                 },
+            },
+        },
+        {
+            "name": "apply_patch",
+            "description": (
+                "Apply a unified diff patch inside the workspace root. "
+                "Use only after reading the target files and getting approval."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "patch": {
+                        "type": "string",
+                        "description": ("Unified diff patch text using workspace-relative paths in the diff headers."),
+                    },
+                },
+                "required": ["patch"],
             },
         },
     ]

--- a/app/tools/workspace.py
+++ b/app/tools/workspace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 import re
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -127,6 +128,32 @@ def _format_subprocess_error(prefix: str, result: subprocess.CompletedProcess[st
     """Return a readable error message for a failed subprocess."""
     details = result.stderr.strip() or result.stdout.strip() or "Unknown error."
     return f"Error: {prefix} {details}"
+
+
+def _resolve_git_executable() -> str:
+    """Return an absolute path to the git executable."""
+    git_executable = shutil.which("git")
+    if not git_executable:
+        raise FileNotFoundError("Git executable not found in PATH.")
+    return git_executable
+
+
+def _run_git_command(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command with a resolved executable inside the workspace."""
+    git_executable = _resolve_git_executable()
+    command = [git_executable, *args]
+    return subprocess.run(  # nosec B603
+        command,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
 
 
 def _extension_for(file_type: str | None) -> str | None:
@@ -326,13 +353,7 @@ async def git_status_handler(args: dict[str, Any], settings: AppSettings) -> str
         return f"Error: Path {work_dir!r} is outside workspace root"
 
     try:
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=str(safe),
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        result = _run_git_command(["status", "--porcelain"], cwd=safe)
         output = result.stdout.strip()
         if not output:
             return "Git working tree is clean."
@@ -365,13 +386,7 @@ async def git_diff_handler(args: dict[str, Any], settings: AppSettings) -> str:
         cmd.extend(["--", file_path])
 
     try:
-        result = subprocess.run(
-            cmd,
-            cwd=str(safe),
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        result = _run_git_command(cmd[1:], cwd=safe)
         output = result.stdout.strip()
         if not output:
             if staged:
@@ -412,22 +427,16 @@ async def apply_patch_handler(args: dict[str, Any], settings: AppSettings) -> st
             patch_file.write(patch_text)
             patch_file_path = Path(patch_file.name)
 
-        check_result = subprocess.run(
-            ["git", "apply", "--check", "--recount", str(patch_file_path)],
-            cwd=str(settings.paths.workspace_root),
-            capture_output=True,
-            text=True,
-            timeout=30,
+        check_result = _run_git_command(
+            ["apply", "--check", "--recount", str(patch_file_path)],
+            cwd=settings.paths.workspace_root,
         )
         if check_result.returncode != 0:
             return _format_subprocess_error("Patch validation failed.", check_result)
 
-        apply_result = subprocess.run(
-            ["git", "apply", "--recount", str(patch_file_path)],
-            cwd=str(settings.paths.workspace_root),
-            capture_output=True,
-            text=True,
-            timeout=30,
+        apply_result = _run_git_command(
+            ["apply", "--recount", str(patch_file_path)],
+            cwd=settings.paths.workspace_root,
         )
         if apply_result.returncode != 0:
             return _format_subprocess_error("Failed to apply patch.", apply_result)

--- a/tests/unit/test_workspace_tools.py
+++ b/tests/unit/test_workspace_tools.py
@@ -233,6 +233,55 @@ class TestGitStatus:
         assert "git status" in result.lower() or "git" in result.lower()
 
 
+class TestApplyPatch:
+    """Tests for apply_patch_handler."""
+
+    @pytest.mark.asyncio
+    async def test_applies_patch_and_reports_changed_files(self, mock_settings):
+        """Should apply a valid patch and list changed files."""
+        (mock_settings.paths.workspace_root / "file1.py").write_text("print('hello')\n")
+        patch = """--- a/file1.py
++++ b/file1.py
+@@ -1 +1 @@
+-print('hello')
++print('patched')
+"""
+
+        result = await workspace.apply_patch_handler({"patch": patch}, mock_settings)
+
+        assert result.startswith("Patch applied successfully.")
+        assert "file1.py" in result
+        assert (mock_settings.paths.workspace_root / "file1.py").read_text() == "print('patched')\n"
+
+    @pytest.mark.asyncio
+    async def test_rejects_patch_paths_outside_workspace(self, mock_settings):
+        """Should reject patches that try to escape the workspace root."""
+        patch = """--- a/../outside.txt
++++ b/../outside.txt
+@@ -0,0 +1 @@
++malicious
+"""
+
+        result = await workspace.apply_patch_handler({"patch": patch}, mock_settings)
+
+        assert result.startswith("Error:")
+        assert "escapes the workspace root" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_patch(self, mock_settings):
+        """Should surface git apply validation errors."""
+        patch = """--- a/file1.py
++++ b/file1.py
+@@ -99 +99 @@
+-missing
++replacement
+"""
+
+        result = await workspace.apply_patch_handler({"patch": patch}, mock_settings)
+
+        assert result.startswith("Error: Patch validation failed.")
+
+
 class TestToolSpecs:
     """Tests for tool specifications."""
 
@@ -240,10 +289,10 @@ class TestToolSpecs:
         """Should return valid OpenAI tool specifications."""
         specs = workspace.get_tool_specs()
 
-        assert len(specs) == 5
+        assert len(specs) == 6
 
         tool_names = {s["name"] for s in specs}
-        expected = {"list_files", "read_file", "search_text", "git_status", "git_diff"}
+        expected = {"list_files", "read_file", "search_text", "git_status", "git_diff", "apply_patch"}
         assert tool_names == expected
 
         # Check structure


### PR DESCRIPTION
## Summary
- add a workspace-scoped apply_patch tool that validates patch targets, checks patches with git, and reports changed files
- register apply_patch in the default agent tool registry so approval-gated tool calls can execute after approval
- add workspace tests for successful patch application, invalid patches, and workspace escape rejection

## Testing
- python -m pre_commit run --all-files
- python -m ruff check app tests
- python -m ruff format --check app tests
- python -m pytest tests -q
- python -m mypy app --ignore-missing-imports --follow-imports=skip
- pyright app/ --outputjson

Closes #28
