### PR TITLE
ML-102: Fix security workflow SARIF permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   secrets-scan:
     name: Secret Scanning
@@ -109,9 +113,6 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant the Security workflow the shared permissions needed for SARIF upload on push runs
- let Bandit and Trivy inherit `security-events: write` and `contents: read` instead of only CodeQL having them
- keep the fix scoped to the workflow so the failing post-merge Security checks can succeed

## Testing
- python -m pre_commit run --files .github/workflows/security.yml
- python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/security.yml').read_text()); print('YAML OK')"

Closes #30
