### PR TITLE
ML-103: Add FastAPI sessions and messages routes

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,1 +1,5 @@
-"""API package for future HTTP routes."""
+"""FastAPI application surface for ML Copilot."""
+
+from app.api.app import create_app
+
+__all__ = ["create_app"]

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -1,0 +1,241 @@
+"""FastAPI app and route handlers for ML Copilot sessions and messages."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any, Callable
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+
+from app.agent.loop import AgentLoop, create_agent_loop
+from app.config import AppSettings
+from app.storage.models import MessageRecord, PendingApprovalRecord, SessionRecord, ToolCallRecord
+from app.storage.repository import SQLiteRepository
+
+from .schemas import (
+    ChatRequest,
+    ChatResponse,
+    CreateSessionRequest,
+    MessagePayload,
+    PendingApprovalPayload,
+    SessionDetail,
+    SessionSummary,
+    ToolCallPayload,
+    TurnResultPayload,
+)
+
+RepositoryFactory = Callable[[AppSettings], SQLiteRepository]
+LoopFactory = Callable[[AppSettings, SQLiteRepository], AgentLoop]
+
+
+def create_app(
+    settings: AppSettings | None = None,
+    *,
+    repository_factory: RepositoryFactory | None = None,
+    loop_factory: LoopFactory | None = None,
+) -> FastAPI:
+    """Create the FastAPI application for ML Copilot."""
+    resolved_settings = settings or AppSettings.load()
+    app = FastAPI(title=resolved_settings.app_name, version=resolved_settings.version)
+    app.state.settings = resolved_settings
+    app.state.repository_factory = repository_factory or _default_repository_factory
+    app.state.loop_factory = loop_factory or _default_loop_factory
+
+    router = APIRouter(prefix="/api", tags=["sessions"])
+
+    @router.post("/session", response_model=SessionSummary, status_code=status.HTTP_201_CREATED)
+    async def create_session(
+        payload: CreateSessionRequest,
+        repo: RepositoryDep,
+        current_settings: SettingsDep,
+    ) -> SessionSummary:
+        record = repo.create_session(
+            model=payload.model or current_settings.llm.model,
+            title=payload.title,
+            metadata=payload.metadata,
+        )
+        return _serialize_session_summary(repo, record)
+
+    @router.get("/sessions", response_model=list[SessionSummary])
+    async def list_sessions(
+        repo: RepositoryDep,
+    ) -> list[SessionSummary]:
+        return [_serialize_session_summary(repo, session) for session in repo.list_sessions()]
+
+    @router.get("/session/{session_id}", response_model=SessionDetail)
+    async def get_session(
+        session_id: str,
+        repo: RepositoryDep,
+    ) -> SessionDetail:
+        session = _get_session_or_404(repo, session_id)
+        return _serialize_session_detail(repo, session)
+
+    @router.get("/session/{session_id}/messages", response_model=list[MessagePayload])
+    async def get_session_messages(
+        session_id: str,
+        repo: RepositoryDep,
+    ) -> list[MessagePayload]:
+        _get_session_or_404(repo, session_id)
+        return [_serialize_message(message) for message in repo.list_messages(session_id)]
+
+    @router.post("/chat/{session_id}", response_model=ChatResponse)
+    async def chat_session(
+        session_id: str,
+        payload: ChatRequest,
+        repo: RepositoryDep,
+        loop: LoopDep,
+    ) -> ChatResponse:
+        session = _get_session_or_404(repo, session_id)
+        repo.update_session(session_id, status="processing")
+        session = _get_session_or_404(repo, session_id)
+
+        try:
+            result = await loop.run_turn(
+                session=session,
+                user_message=payload.message,
+                system_prompt=payload.system_prompt,
+            )
+        except Exception:
+            repo.update_session(session_id, status="error")
+            raise
+
+        updated_session = repo.update_session(session_id, status=_status_for_turn_result(result["status"]))
+        return ChatResponse(
+            session=_serialize_session_detail(repo, updated_session),
+            result=_serialize_turn_result(result),
+            messages=[_serialize_message(message) for message in repo.list_messages(session_id)],
+        )
+
+    app.include_router(router)
+    return app
+
+
+def get_settings(request: Request) -> AppSettings:
+    return request.app.state.settings
+
+
+def get_repository(
+    request: Request,
+    settings: Annotated[AppSettings, Depends(get_settings)],
+) -> SQLiteRepository:
+    factory: RepositoryFactory = request.app.state.repository_factory
+    return factory(settings)
+
+
+def get_agent_loop(
+    request: Request,
+    settings: Annotated[AppSettings, Depends(get_settings)],
+    repo: Annotated[SQLiteRepository, Depends(get_repository)],
+) -> AgentLoop:
+    factory: LoopFactory = request.app.state.loop_factory
+    return factory(settings, repo)
+
+
+def _default_repository_factory(settings: AppSettings) -> SQLiteRepository:
+    repository = SQLiteRepository(settings.db_path)
+    repository.initialize()
+    return repository
+
+
+def _default_loop_factory(settings: AppSettings, repository: SQLiteRepository) -> AgentLoop:
+    return create_agent_loop(settings, repository=repository)
+
+
+RepositoryDep = Annotated[SQLiteRepository, Depends(get_repository)]
+SettingsDep = Annotated[AppSettings, Depends(get_settings)]
+LoopDep = Annotated[AgentLoop, Depends(get_agent_loop)]
+
+
+def _get_session_or_404(repo: SQLiteRepository, session_id: str) -> SessionRecord:
+    session = repo.get_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+    return session
+
+
+def _serialize_session_summary(repo: SQLiteRepository, session: SessionRecord) -> SessionSummary:
+    return SessionSummary(
+        id=session.id,
+        title=session.title,
+        status=session.status,
+        model=session.model,
+        metadata=json.loads(session.metadata_json),
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        message_count=len(repo.list_messages(session.id)),
+        event_count=len(repo.list_events(session.id)),
+        pending_approval_count=len(repo.list_pending_approvals(session.id)),
+    )
+
+
+def _serialize_session_detail(repo: SQLiteRepository, session: SessionRecord) -> SessionDetail:
+    summary = _serialize_session_summary(repo, session)
+    return SessionDetail(
+        **summary.model_dump(),
+        pending_approvals=[_serialize_pending_approval(item) for item in repo.list_pending_approvals(session.id)],
+        tool_calls=[_serialize_tool_call(tool_call) for tool_call in repo.list_tool_calls(session.id)],
+    )
+
+
+def _serialize_pending_approval(record: PendingApprovalRecord) -> PendingApprovalPayload:
+    return PendingApprovalPayload(
+        approval_id=record.approval.id,
+        tool_call_id=record.tool_call.id,
+        tool_name=record.tool_call.tool_name,
+        arguments=json.loads(record.tool_call.arguments_json),
+    )
+
+
+def _serialize_tool_call(record: ToolCallRecord) -> ToolCallPayload:
+    return ToolCallPayload(
+        id=record.id,
+        session_id=record.session_id,
+        turn_id=record.turn_id,
+        tool_name=record.tool_name,
+        arguments=json.loads(record.arguments_json),
+        status=record.status,
+        requires_approval=record.requires_approval,
+        approval_id=record.approval_id,
+        started_at=record.started_at,
+        finished_at=record.finished_at,
+        output=record.output,
+        success=record.success,
+        error=record.error,
+    )
+
+
+def _serialize_message(record: MessageRecord) -> MessagePayload:
+    return MessagePayload(
+        id=record.id,
+        session_id=record.session_id,
+        turn_id=record.turn_id,
+        role=record.role,
+        content=record.content,
+        tool_call_id=record.tool_call_id,
+        name=record.name,
+        raw=json.loads(record.raw_json) if record.raw_json else {},
+        sequence=record.sequence,
+        created_at=record.created_at,
+    )
+
+
+def _serialize_turn_result(payload: dict[str, Any]) -> TurnResultPayload:
+    pending = payload.get("pending_approvals") or []
+    return TurnResultPayload(
+        status=str(payload.get("status", "")),
+        content=payload.get("content"),
+        iterations=payload.get("iterations"),
+        approval_ids=[str(item) for item in payload.get("approval_ids") or []],
+        pending_approvals=[PendingApprovalPayload.model_validate(item) for item in pending],
+        resolved_approval_id=payload.get("resolved_approval_id"),
+    )
+
+
+def _status_for_turn_result(result_status: str) -> str:
+    if result_status == "approval_required":
+        return "waiting_approval"
+    if result_status == "interrupted":
+        return "interrupted"
+    if result_status == "max_iterations":
+        return "attention_required"
+    return "idle"

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,0 +1,87 @@
+"""Pydantic schemas for the ML Copilot HTTP API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CreateSessionRequest(BaseModel):
+    title: str | None = None
+    model: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatRequest(BaseModel):
+    message: str = Field(min_length=1)
+    system_prompt: str | None = None
+
+
+class PendingApprovalPayload(BaseModel):
+    approval_id: str
+    tool_call_id: str
+    tool_name: str
+    arguments: dict[str, Any]
+
+
+class ToolCallPayload(BaseModel):
+    id: str
+    session_id: str
+    turn_id: str
+    tool_name: str
+    arguments: dict[str, Any]
+    status: str
+    requires_approval: bool
+    approval_id: str | None
+    started_at: str | None
+    finished_at: str | None
+    output: str | None
+    success: bool | None
+    error: str | None
+
+
+class MessagePayload(BaseModel):
+    id: str
+    session_id: str
+    turn_id: str
+    role: str
+    content: str
+    tool_call_id: str | None
+    name: str | None
+    raw: dict[str, Any]
+    sequence: int
+    created_at: str
+
+
+class SessionSummary(BaseModel):
+    id: str
+    title: str | None
+    status: str
+    model: str
+    metadata: dict[str, Any]
+    created_at: str
+    updated_at: str
+    message_count: int
+    event_count: int
+    pending_approval_count: int
+
+
+class SessionDetail(SessionSummary):
+    pending_approvals: list[PendingApprovalPayload] = Field(default_factory=list)
+    tool_calls: list[ToolCallPayload] = Field(default_factory=list)
+
+
+class TurnResultPayload(BaseModel):
+    status: str
+    content: str | None = None
+    iterations: int | None = None
+    approval_ids: list[str] = Field(default_factory=list)
+    pending_approvals: list[PendingApprovalPayload] = Field(default_factory=list)
+    resolved_approval_id: str | None = None
+
+
+class ChatResponse(BaseModel):
+    session: SessionDetail
+    result: TurnResultPayload
+    messages: list[MessagePayload]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Focused ML engineering agent with safe tools, durable sessions, a
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "fastapi>=0.121.0,<0.122.0",
     "httpx>=0.28.0,<0.29.0",
 ]
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.agent.llm import LLMResponse
+from app.api import create_app
+from app.config import AppSettings
+from app.storage.repository import SQLiteRepository
+
+
+class FakeLLMClient:
+    def __init__(self, content: str = "Working on it.") -> None:
+        self._content = content
+
+    async def chat(self, **kwargs) -> LLMResponse:
+        return LLMResponse(model="gpt-test", content=self._content)
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.load(
+        environ={
+            "ML_COPILOT_WORKSPACE_ROOT": str(tmp_path),
+            "ML_COPILOT_DB_PATH": str(tmp_path / "api.db"),
+            "LLM_MODEL": "gpt-test",
+        }
+    )
+
+
+def test_create_and_list_sessions_via_api(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+
+    created = client.post(
+        "/api/session",
+        json={"title": "API Session", "metadata": {"source": "test"}},
+    )
+    listed = client.get("/api/sessions")
+
+    assert created.status_code == 201
+    created_body = created.json()
+    assert created_body["title"] == "API Session"
+    assert created_body["metadata"] == {"source": "test"}
+
+    assert listed.status_code == 200
+    listed_body = listed.json()
+    assert len(listed_body) == 1
+    assert listed_body[0]["id"] == created_body["id"]
+    assert listed_body[0]["message_count"] == 0
+
+
+def test_chat_route_persists_messages_and_session_state(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+
+    def loop_factory(app_settings: AppSettings, repository: SQLiteRepository):
+        from app.agent.loop import create_agent_loop
+
+        return create_agent_loop(
+            app_settings,
+            repository=repository,
+            llm_client=FakeLLMClient(content="Repository summary ready."),
+        )
+
+    app = create_app(settings, loop_factory=loop_factory)
+    client = TestClient(app)
+
+    created = client.post("/api/session", json={"title": "Chat Session"})
+    session_id = created.json()["id"]
+
+    response = client.post(
+        f"/api/chat/{session_id}",
+        json={"message": "Analyze the repository layout"},
+    )
+    messages = client.get(f"/api/session/{session_id}/messages")
+    session = client.get(f"/api/session/{session_id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["status"] == "complete"
+    assert body["result"]["content"] == "Repository summary ready."
+    assert body["session"]["status"] == "idle"
+    assert [message["role"] for message in body["messages"]] == ["user", "assistant"]
+
+    assert messages.status_code == 200
+    assert [message["content"] for message in messages.json()] == [
+        "Analyze the repository layout",
+        "Repository summary ready.",
+    ]
+
+    assert session.status_code == 200
+    assert session.json()["message_count"] == 2
+    assert session.json()["event_count"] >= 3
+
+
+def test_missing_session_returns_404(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+
+    response = client.get("/api/session/missing-session")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Session not found"}


### PR DESCRIPTION
## Summary
- add a FastAPI application surface for sessions and messages
- create session, list sessions, fetch session detail, fetch message history, and submit chat turns
- serialize persisted repository state so the HTTP layer reflects approvals, tool calls, and message history
- add API unit coverage with a fake LLM-backed route integration test

## Verification
- python -m pre_commit run --all-files
- python -m pytest tests -q
- python -m mypy app --ignore-missing-imports --follow-imports=skip
- pyright app/ --outputjson

## Reference
- .codex-reference/ml-intern/backend/routes/agent.py
- .codex-reference/ml-intern/backend/session_manager.py

Closes #34