### PR TITLE
ML-104: Add SSE events with replay

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -6,6 +6,7 @@ import json
 from typing import Annotated, Any, Callable
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
 
 from app.agent.loop import AgentLoop, create_agent_loop
 from app.config import AppSettings
@@ -23,6 +24,7 @@ from .schemas import (
     ToolCallPayload,
     TurnResultPayload,
 )
+from .streaming import SessionEventStreamManager, create_event_stream_response
 
 RepositoryFactory = Callable[[AppSettings], SQLiteRepository]
 LoopFactory = Callable[[AppSettings, SQLiteRepository], AgentLoop]
@@ -40,6 +42,7 @@ def create_app(
     app.state.settings = resolved_settings
     app.state.repository_factory = repository_factory or _default_repository_factory
     app.state.loop_factory = loop_factory or _default_loop_factory
+    app.state.event_stream_manager = SessionEventStreamManager()
 
     router = APIRouter(prefix="/api", tags=["sessions"])
 
@@ -78,16 +81,33 @@ def create_app(
         _get_session_or_404(repo, session_id)
         return [_serialize_message(message) for message in repo.list_messages(session_id)]
 
+    @router.get("/events/{session_id}")
+    async def stream_session_events(
+        session_id: str,
+        request: Request,
+        repo: RepositoryDep,
+    ) -> StreamingResponse:
+        _get_session_or_404(repo, session_id)
+        return create_event_stream_response(
+            request=request,
+            session_id=session_id,
+            repository=repo,
+            stream_manager=get_event_stream_manager(request),
+        )
+
     @router.post("/chat/{session_id}", response_model=ChatResponse)
     async def chat_session(
         session_id: str,
         payload: ChatRequest,
+        request: Request,
         repo: RepositoryDep,
         loop: LoopDep,
     ) -> ChatResponse:
         session = _get_session_or_404(repo, session_id)
         repo.update_session(session_id, status="processing")
         session = _get_session_or_404(repo, session_id)
+        event_stream_manager = get_event_stream_manager(request)
+        loop.add_event_handler(event_stream_manager.publish)
 
         try:
             result = await loop.run_turn(
@@ -98,6 +118,8 @@ def create_app(
         except Exception:
             repo.update_session(session_id, status="error")
             raise
+        finally:
+            loop.remove_event_handler(event_stream_manager.publish)
 
         updated_session = repo.update_session(session_id, status=_status_for_turn_result(result["status"]))
         return ChatResponse(
@@ -112,6 +134,10 @@ def create_app(
 
 def get_settings(request: Request) -> AppSettings:
     return request.app.state.settings
+
+
+def get_event_stream_manager(request: Request) -> SessionEventStreamManager:
+    return request.app.state.event_stream_manager
 
 
 def get_repository(

--- a/app/api/streaming.py
+++ b/app/api/streaming.py
@@ -1,0 +1,154 @@
+"""Helpers for replayable SSE session event streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import queue
+import threading
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+
+from app.agent.loop import AgentEvent
+from app.storage.models import EventRecord
+from app.storage.repository import SQLiteRepository
+
+TERMINAL_EVENT_TYPES = {
+    "turn_complete",
+    "approval_required",
+    "error",
+    "interrupted",
+}
+KEEPALIVE_INTERVAL_SECONDS = 15
+
+
+class SessionEventStreamManager:
+    """Fan out live agent events to per-session SSE subscribers."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._next_subscription_id = 0
+        self._subscribers: dict[str, dict[int, queue.Queue[AgentEvent]]] = {}
+
+    def subscribe(self, session_id: str) -> tuple[int, queue.Queue[AgentEvent]]:
+        subscription_queue: queue.Queue[AgentEvent] = queue.Queue()
+        with self._lock:
+            self._next_subscription_id += 1
+            subscription_id = self._next_subscription_id
+            session_subscribers = self._subscribers.setdefault(session_id, {})
+            session_subscribers[subscription_id] = subscription_queue
+        return subscription_id, subscription_queue
+
+    def unsubscribe(self, session_id: str, subscription_id: int) -> None:
+        with self._lock:
+            session_subscribers = self._subscribers.get(session_id)
+            if not session_subscribers:
+                return
+            session_subscribers.pop(subscription_id, None)
+            if not session_subscribers:
+                self._subscribers.pop(session_id, None)
+
+    def publish(self, event: AgentEvent) -> None:
+        with self._lock:
+            queues = list(self._subscribers.get(event.session_id, {}).values())
+        for subscriber_queue in queues:
+            subscriber_queue.put_nowait(event)
+
+
+def create_event_stream_response(
+    *,
+    request: Request,
+    session_id: str,
+    repository: SQLiteRepository,
+    stream_manager: SessionEventStreamManager,
+) -> StreamingResponse:
+    """Create an SSE response that replays persisted events then follows live ones."""
+    after_sequence = _last_event_sequence(request)
+    subscription_id, live_queue = stream_manager.subscribe(session_id)
+    replay_events = repository.list_events_after(session_id, after_sequence)
+
+    async def event_generator():
+        last_sequence = after_sequence
+        try:
+            for record in replay_events:
+                payload = _event_payload_from_record(record)
+                if payload["sequence"] <= last_sequence:
+                    continue
+                last_sequence = payload["sequence"]
+                yield _format_sse(payload)
+                if payload["event_type"] in TERMINAL_EVENT_TYPES:
+                    return
+
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    event = await asyncio.to_thread(
+                        live_queue.get,
+                        True,
+                        KEEPALIVE_INTERVAL_SECONDS,
+                    )
+                except queue.Empty:
+                    yield ": keepalive\n\n"
+                    continue
+
+                payload = _event_payload_from_agent_event(event)
+                if payload["sequence"] <= last_sequence:
+                    continue
+                last_sequence = payload["sequence"]
+                yield _format_sse(payload)
+                if payload["event_type"] in TERMINAL_EVENT_TYPES:
+                    return
+        finally:
+            stream_manager.unsubscribe(session_id, subscription_id)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+def _last_event_sequence(request: Request) -> int:
+    raw_value = request.headers.get("last-event-id") or request.query_params.get("after")
+    if raw_value is None:
+        return -1
+    try:
+        return max(-1, int(raw_value))
+    except (TypeError, ValueError):
+        return -1
+
+
+def _format_sse(payload: dict[str, Any]) -> str:
+    sequence = payload["sequence"]
+    return f"id: {sequence}\ndata: {json.dumps(payload)}\n\n"
+
+
+def _event_payload_from_record(record: EventRecord) -> dict[str, Any]:
+    return {
+        "id": record.id,
+        "session_id": record.session_id,
+        "turn_id": record.turn_id,
+        "event_type": record.event_type,
+        "data": json.loads(record.data_json),
+        "sequence": record.sequence,
+        "created_at": record.created_at,
+    }
+
+
+def _event_payload_from_agent_event(event: AgentEvent) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "session_id": event.session_id,
+        "turn_id": event.turn_id,
+        "event_type": event.event_type,
+        "data": event.data,
+        "sequence": event.sequence,
+        "created_at": event.created_at,
+    }

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import threading
+import time
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -101,3 +104,114 @@ def test_missing_session_returns_404(tmp_path: Path) -> None:
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Session not found"}
+
+
+def test_event_stream_receives_live_events_for_chat_turn(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+
+    def loop_factory(app_settings: AppSettings, repository: SQLiteRepository):
+        from app.agent.loop import create_agent_loop
+
+        return create_agent_loop(
+            app_settings,
+            repository=repository,
+            llm_client=FakeLLMClient(content="Repository summary ready."),
+        )
+
+    app = create_app(settings, loop_factory=loop_factory)
+    stream_client = TestClient(app)
+    chat_client = TestClient(app)
+
+    created = chat_client.post("/api/session", json={"title": "Streaming Session"})
+    session_id = created.json()["id"]
+
+    captured: dict[str, object] = {}
+
+    def consume_events() -> None:
+        with stream_client.stream("GET", f"/api/events/{session_id}") as response:
+            captured["status_code"] = response.status_code
+            captured["events"] = _parse_sse_events(response.iter_text())
+
+    consumer = threading.Thread(target=consume_events)
+    consumer.start()
+    time.sleep(0.1)
+
+    chat_response = chat_client.post(
+        f"/api/chat/{session_id}",
+        json={"message": "Analyze the repository layout"},
+    )
+
+    consumer.join(timeout=5)
+    assert not consumer.is_alive()
+    assert chat_response.status_code == 200
+    assert captured["status_code"] == 200
+
+    events = captured["events"]
+    assert isinstance(events, list)
+    assert [event["event_type"] for event in events] == [
+        "ready",
+        "processing",
+        "assistant_chunk",
+        "assistant_message",
+        "turn_complete",
+    ]
+    assert [event["sequence"] for event in events] == [0, 1, 2, 3, 4]
+    assert {event["session_id"] for event in events} == {session_id}
+    assert events[-1]["data"] == {"iterations": 1}
+
+
+def test_event_stream_replays_events_after_last_event_id(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+
+    def loop_factory(app_settings: AppSettings, repository: SQLiteRepository):
+        from app.agent.loop import create_agent_loop
+
+        return create_agent_loop(
+            app_settings,
+            repository=repository,
+            llm_client=FakeLLMClient(content="Repository summary ready."),
+        )
+
+    app = create_app(settings, loop_factory=loop_factory)
+    client = TestClient(app)
+
+    created = client.post("/api/session", json={"title": "Replay Session"})
+    session_id = created.json()["id"]
+    client.post(
+        f"/api/chat/{session_id}",
+        json={"message": "Analyze the repository layout"},
+    )
+
+    with client.stream(
+        "GET",
+        f"/api/events/{session_id}",
+        headers={"Last-Event-ID": "1"},
+    ) as response:
+        assert response.status_code == 200
+        events = _parse_sse_events(response.iter_text())
+
+    assert [event["event_type"] for event in events] == [
+        "assistant_chunk",
+        "assistant_message",
+        "turn_complete",
+    ]
+    assert [event["sequence"] for event in events] == [2, 3, 4]
+    assert events[0]["data"]["content"] == "Repository summary ready."
+
+
+def _parse_sse_events(chunks) -> list[dict[str, object]]:
+    buffer = "".join(chunks)
+    events: list[dict[str, object]] = []
+
+    for block in buffer.split("\n\n"):
+        lines = [line for line in block.splitlines() if line and not line.startswith(":")]
+        if not lines:
+            continue
+
+        payload_lines = [line[5:].strip() for line in lines if line.startswith("data:")]
+        if not payload_lines:
+            continue
+
+        events.append(json.loads("\n".join(payload_lines)))
+
+    return events


### PR DESCRIPTION
## Summary
- add a replay-first `/api/events/{session_id}` SSE endpoint for session event delivery
- broadcast live agent events through an app-level session stream manager while keeping the existing synchronous `/api/chat/{session_id}` response intact
- add API coverage for live SSE delivery and `Last-Event-ID` replay behavior

## Verification
- `python -m pytest tests/unit/test_api.py -q`
- `python -m mypy app --ignore-missing-imports --follow-imports=skip`
- `pyright app/ --outputjson`
- `python -m pre_commit run --files app/api/app.py app/api/streaming.py tests/unit/test_api.py`
- `python -m pytest tests -q` from a canonical `ml-copilot` checkout path

## Reference
- `.codex-reference/ml-intern/backend/routes/agent.py`
- `.codex-reference/ml-intern/backend/session_manager.py`
- `.codex-reference/ml-intern/frontend/src/lib/sse-chat-transport.ts`

## Notes
- The clean task worktree here is named `ml-copilot-ML-104`, so the existing `test_settings_wrap_default_paths` assertion about the repo directory name only passes from a canonical `ml-copilot` checkout path; the feature code itself is unaffected.

Closes #36
