### PR TITLE
ML-102: Fix Bandit suppression formatting

### DIFF
--- a/app/tools/workspace.py
+++ b/app/tools/workspace.py
@@ -6,13 +6,14 @@ import fnmatch
 import os
 import re
 import shutil
-# Bandit B404 is expected here because this module exposes reviewed subprocess wrappers.
 import subprocess  # nosec B404
 import tempfile
 from pathlib import Path
 from typing import Any, Iterator
 
 from app.config import AppSettings
+
+# Bandit B404 is expected here because this module exposes reviewed subprocess wrappers.
 
 IGNORED_PATH_NAMES = {".git", "__pycache__", "node_modules", ".pytest_cache"}
 MAX_READ_LINES = 2000


### PR DESCRIPTION
## Summary
- move the Bandit B404 explanation out of the import block in `app/tools/workspace.py`
- keep the reviewed `subprocess` suppression intact while restoring Ruff import ordering
- fix the formatting/pre-commit/quality failures triggered by the direct `main` push

## Task
Issue: `#38 / Security / Suppress reviewed Bandit subprocess import alert`

## Testing
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pre_commit run --all-files`

## Notes
This is a follow-up fix for commit `90d6ab7`, which resolved the Bandit alert but broke the quality workflows because the explanatory comment sat inside the import block.

Closes #38
