### PR TITLE
ML-105 / Add interrupt and cancel handling

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -154,8 +155,12 @@ class AgentLoop:
             role="user",
             content=user_message,
         )
-        await self.emit_event(ctx, EventType.PROCESSING, {})
-        return await self._run_loop(session, ctx)
+        try:
+            await self.emit_event(ctx, EventType.PROCESSING, {})
+            return await self._run_loop(session, ctx)
+        except asyncio.CancelledError:
+            await self.emit_event(ctx, EventType.INTERRUPTED, {"message": "Turn interrupted."})
+            raise
 
     async def resume_pending_approval(
         self,
@@ -205,7 +210,11 @@ class AgentLoop:
                 "resolved_approval_id": approval_id,
             }
 
-        return await self._run_loop(session, ctx)
+        try:
+            return await self._run_loop(session, ctx)
+        except asyncio.CancelledError:
+            await self.emit_event(ctx, EventType.INTERRUPTED, {"message": "Turn interrupted."})
+            raise
 
     def interrupt(self) -> None:
         """Signal the agent to stop after the current operation."""
@@ -423,6 +432,25 @@ class AgentLoop:
             tool_output = await self.tools.call(tool_name, arguments)
             success = True
             error = None
+        except asyncio.CancelledError:
+            tool_output = "Tool execution interrupted."
+            self.repo.update_tool_call(
+                tool_call_id,
+                status="interrupted",
+                arguments=arguments,
+                finished_at=_utc_now(),
+                output=tool_output,
+                success=False,
+                error=tool_output,
+            )
+            await self._record_tool_output(
+                ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                output=tool_output,
+                success=False,
+            )
+            raise
         except Exception as exc:
             tool_output = f"Tool execution error: {exc}"
             success = False

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Annotated, Any, Callable
 
@@ -13,10 +14,12 @@ from app.config import AppSettings
 from app.storage.models import MessageRecord, PendingApprovalRecord, SessionRecord, ToolCallRecord
 from app.storage.repository import SQLiteRepository
 
+from .runtime import ActiveTurnManager
 from .schemas import (
     ChatRequest,
     ChatResponse,
     CreateSessionRequest,
+    InterruptResponse,
     MessagePayload,
     PendingApprovalPayload,
     SessionDetail,
@@ -43,6 +46,7 @@ def create_app(
     app.state.repository_factory = repository_factory or _default_repository_factory
     app.state.loop_factory = loop_factory or _default_loop_factory
     app.state.event_stream_manager = SessionEventStreamManager()
+    app.state.active_turn_manager = ActiveTurnManager()
 
     router = APIRouter(prefix="/api", tags=["sessions"])
 
@@ -104,10 +108,18 @@ def create_app(
         loop: LoopDep,
     ) -> ChatResponse:
         session = _get_session_or_404(repo, session_id)
+        active_turn_manager = get_active_turn_manager(request)
+        if not active_turn_manager.register(session_id, loop):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Session already has an active turn",
+            )
+
         repo.update_session(session_id, status="processing")
         session = _get_session_or_404(repo, session_id)
         event_stream_manager = get_event_stream_manager(request)
         loop.add_event_handler(event_stream_manager.publish)
+        current_task = asyncio.current_task()
 
         try:
             result = await loop.run_turn(
@@ -115,10 +127,13 @@ def create_app(
                 user_message=payload.message,
                 system_prompt=payload.system_prompt,
             )
+        except asyncio.CancelledError:
+            result = {"status": "interrupted"}
         except Exception:
             repo.update_session(session_id, status="error")
             raise
         finally:
+            active_turn_manager.unregister(session_id, current_task)
             loop.remove_event_handler(event_stream_manager.publish)
 
         updated_session = repo.update_session(session_id, status=_status_for_turn_result(result["status"]))
@@ -126,6 +141,31 @@ def create_app(
             session=_serialize_session_detail(repo, updated_session),
             result=_serialize_turn_result(result),
             messages=[_serialize_message(message) for message in repo.list_messages(session_id)],
+        )
+
+    @router.post("/interrupt/{session_id}", response_model=InterruptResponse)
+    async def interrupt_session(
+        session_id: str,
+        request: Request,
+        repo: RepositoryDep,
+    ) -> InterruptResponse:
+        session = _get_session_or_404(repo, session_id)
+        active_turn_manager = get_active_turn_manager(request)
+
+        if not active_turn_manager.interrupt(session_id):
+            return InterruptResponse(
+                session_id=session_id,
+                status=session.status,
+                interrupted=False,
+                message="No active turn to interrupt.",
+            )
+
+        repo.update_session(session_id, status="interrupted")
+        return InterruptResponse(
+            session_id=session_id,
+            status="interrupt_requested",
+            interrupted=True,
+            message="Active turn interruption requested.",
         )
 
     app.include_router(router)
@@ -138,6 +178,10 @@ def get_settings(request: Request) -> AppSettings:
 
 def get_event_stream_manager(request: Request) -> SessionEventStreamManager:
     return request.app.state.event_stream_manager
+
+
+def get_active_turn_manager(request: Request) -> ActiveTurnManager:
+    return request.app.state.active_turn_manager
 
 
 def get_repository(

--- a/app/api/runtime.py
+++ b/app/api/runtime.py
@@ -1,0 +1,68 @@
+"""Runtime coordination helpers for active API requests."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from app.agent.loop import AgentLoop
+
+
+@dataclass(frozen=True)
+class ActiveTurn:
+    """A currently running agent turn for a session."""
+
+    session_id: str
+    loop: AgentLoop
+    task: asyncio.Task[Any]
+    event_loop: asyncio.AbstractEventLoop
+
+
+class ActiveTurnManager:
+    """Track running turns so another request can interrupt them safely."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._turns: dict[str, ActiveTurn] = {}
+
+    def register(self, session_id: str, loop: AgentLoop) -> bool:
+        """Register the current task as the active turn for a session."""
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("Cannot register an active turn outside an asyncio task.")
+
+        active_turn = ActiveTurn(
+            session_id=session_id,
+            loop=loop,
+            task=task,
+            event_loop=asyncio.get_running_loop(),
+        )
+        with self._lock:
+            if session_id in self._turns:
+                return False
+            self._turns[session_id] = active_turn
+        return True
+
+    def unregister(self, session_id: str, task: asyncio.Task[Any] | None = None) -> None:
+        """Remove an active turn if it still belongs to the given task."""
+        with self._lock:
+            active_turn = self._turns.get(session_id)
+            if active_turn is None:
+                return
+            if task is not None and active_turn.task is not task:
+                return
+            self._turns.pop(session_id, None)
+
+    def interrupt(self, session_id: str) -> bool:
+        """Request interruption of an active session turn."""
+        with self._lock:
+            active_turn = self._turns.get(session_id)
+
+        if active_turn is None:
+            return False
+
+        active_turn.loop.interrupt()
+        active_turn.event_loop.call_soon_threadsafe(active_turn.task.cancel)
+        return True

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -85,3 +85,10 @@ class ChatResponse(BaseModel):
     session: SessionDetail
     result: TurnResultPayload
     messages: list[MessagePayload]
+
+
+class InterruptResponse(BaseModel):
+    session_id: str
+    status: str
+    interrupted: bool
+    message: str

--- a/app/tools/workspace.py
+++ b/app/tools/workspace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import fnmatch
 import os
 import re
@@ -243,6 +245,63 @@ def _format_command_result(
     if not cleaned_stdout and not cleaned_stderr:
         output_lines.extend(["", "(no output)"])
     return "\n".join(output_lines)
+
+
+def _decode_process_output(value: bytes | str | None) -> str:
+    """Decode subprocess pipe output."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(encoding="utf-8", errors="replace")
+    return value
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    """Terminate a child process, escalating to kill if it does not exit."""
+    if process.returncode is not None:
+        return
+
+    process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=5)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+
+
+async def _run_shell_command(
+    command_parts: list[str],
+    *,
+    cwd: Path,
+    timeout: int,
+) -> tuple[str, str, int | None, bool]:
+    """Run a shell command asynchronously with timeout and cancellation support."""
+    process = await asyncio.create_subprocess_exec(
+        *command_parts,
+        cwd=str(cwd),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    communicate_task = asyncio.create_task(process.communicate())
+
+    try:
+        done, _pending = await asyncio.wait({communicate_task}, timeout=timeout)
+        timed_out = communicate_task not in done
+        if timed_out:
+            await _stop_process(process)
+        stdout, stderr = await communicate_task
+        return (
+            _decode_process_output(stdout),
+            _decode_process_output(stderr),
+            process.returncode,
+            timed_out,
+        )
+    except asyncio.CancelledError:
+        await _stop_process(process)
+        communicate_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await communicate_task
+        raise
 
 
 def _resolve_git_executable() -> str:
@@ -548,16 +607,19 @@ async def run_command_handler(args: dict[str, Any], settings: AppSettings) -> st
     try:
         shell_command = _resolve_command_shell()
         prepared_command = _prepare_shell_command(command)
-        result = subprocess.run(  # nosec B603
+        stdout, stderr, exit_code, timed_out = await _run_shell_command(
             [*shell_command, prepared_command],
-            cwd=str(safe),
-            capture_output=True,
-            text=True,
+            cwd=safe,
             timeout=timeout,
         )
-    except subprocess.TimeoutExpired as exc:
-        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
-        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+    except asyncio.CancelledError:
+        raise
+    except FileNotFoundError as exc:
+        return f"Error: {exc}"
+    except Exception as exc:
+        return f"Error running command: {exc}"
+
+    if timed_out:
         return _format_command_result(
             command=command,
             work_dir=safe,
@@ -565,22 +627,18 @@ async def run_command_handler(args: dict[str, Any], settings: AppSettings) -> st
             timeout=timeout,
             stdout=stdout,
             stderr=stderr,
-            exit_code=None,
+            exit_code=exit_code,
             timed_out=True,
         )
-    except FileNotFoundError as exc:
-        return f"Error: {exc}"
-    except Exception as exc:
-        return f"Error running command: {exc}"
 
     return _format_command_result(
         command=command,
         work_dir=safe,
         workspace_root=settings.paths.workspace_root,
         timeout=timeout,
-        stdout=result.stdout,
-        stderr=result.stderr,
-        exit_code=result.returncode,
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=exit_code,
     )
 
 

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -353,3 +354,63 @@ async def test_new_user_message_abandons_pending_approvals_before_continuing(tmp
         message["role"] == "tool" and "abandoned because the user continued the conversation" in message["content"]
         for message in latest_messages
     )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_tool_call_is_recorded_as_interrupted(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    session = repository.create_session(session_id="session-1", title="Cancel Tool", model="gpt-5.4")
+    tool_started = asyncio.Event()
+
+    async def slow_tool_handler(args: dict[str, object]) -> str:
+        tool_started.set()
+        await asyncio.sleep(30)
+        return "should not complete"
+
+    registry = ToolRegistry()
+    registry.register(
+        ToolSpec(
+            name="slow_tool",
+            description="Slow test tool",
+            input_schema={"type": "object"},
+            handler=slow_tool_handler,
+        )
+    )
+    llm = DummyLLM(
+        responses=[
+            LLMResponse(
+                model="gpt-5.4",
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="call-1",
+                        name="slow_tool",
+                        arguments="{}",
+                    )
+                ],
+                finish_reason="tool_calls",
+            )
+        ]
+    )
+    loop = AgentLoop(
+        llm_client=llm,
+        tool_registry=registry,
+        repository=repository,
+        settings=_settings(tmp_path),
+    )
+
+    task = asyncio.create_task(loop.run_turn(session, "Run the slow tool"))
+    await asyncio.wait_for(tool_started.wait(), timeout=2)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    tool_call = repository.get_tool_call("call-1")
+    event_types = [event.event_type for event in repository.list_events(session.id)]
+
+    assert tool_call is not None
+    assert tool_call.status == "interrupted"
+    assert tool_call.output == "Tool execution interrupted."
+    assert "tool_output" in event_types
+    assert event_types[-1] == "interrupted"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 import time
@@ -19,6 +20,16 @@ class FakeLLMClient:
 
     async def chat(self, **kwargs) -> LLMResponse:
         return LLMResponse(model="gpt-test", content=self._content)
+
+
+class BlockingLLMClient:
+    def __init__(self) -> None:
+        self.started = threading.Event()
+
+    async def chat(self, **kwargs) -> LLMResponse:
+        self.started.set()
+        await asyncio.sleep(30)
+        return LLMResponse(model="gpt-test", content="Too late.")
 
 
 def _settings(tmp_path: Path) -> AppSettings:
@@ -197,6 +208,75 @@ def test_event_stream_replays_events_after_last_event_id(tmp_path: Path) -> None
     ]
     assert [event["sequence"] for event in events] == [2, 3, 4]
     assert events[0]["data"]["content"] == "Repository summary ready."
+
+
+def test_interrupt_route_reports_idle_session(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+
+    created = client.post("/api/session", json={"title": "Idle Session"})
+    session_id = created.json()["id"]
+
+    response = client.post(f"/api/interrupt/{session_id}")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "session_id": session_id,
+        "status": created.json()["status"],
+        "interrupted": False,
+        "message": "No active turn to interrupt.",
+    }
+
+
+def test_interrupt_route_cancels_active_chat_turn_and_preserves_event(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    llm = BlockingLLMClient()
+
+    def loop_factory(app_settings: AppSettings, repository: SQLiteRepository):
+        from app.agent.loop import create_agent_loop
+
+        return create_agent_loop(
+            app_settings,
+            repository=repository,
+            llm_client=llm,
+        )
+
+    app = create_app(settings, loop_factory=loop_factory)
+    chat_client = TestClient(app)
+    interrupt_client = TestClient(app)
+
+    created = interrupt_client.post("/api/session", json={"title": "Interrupt Session"})
+    session_id = created.json()["id"]
+    captured: dict[str, object] = {}
+
+    def run_chat() -> None:
+        captured["response"] = chat_client.post(
+            f"/api/chat/{session_id}",
+            json={"message": "Start a long turn"},
+        )
+
+    worker = threading.Thread(target=run_chat)
+    worker.start()
+
+    assert llm.started.wait(timeout=5)
+    interrupt_response = interrupt_client.post(f"/api/interrupt/{session_id}")
+
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert interrupt_response.status_code == 200
+    assert interrupt_response.json()["interrupted"] is True
+
+    chat_response = captured["response"]
+    assert chat_response.status_code == 200
+    body = chat_response.json()
+    assert body["result"]["status"] == "interrupted"
+    assert body["session"]["status"] == "interrupted"
+
+    with interrupt_client.stream("GET", f"/api/events/{session_id}") as response:
+        events = _parse_sse_events(response.iter_text())
+
+    assert response.status_code == 200
+    assert events[-1]["event_type"] == "interrupted"
 
 
 def _parse_sse_events(chunks) -> list[dict[str, object]]:

--- a/tests/unit/test_workspace_tools.py
+++ b/tests/unit/test_workspace_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -322,9 +323,14 @@ class TestRunCommand:
     @pytest.mark.asyncio
     async def test_reports_command_timeout(self, mock_settings):
         """Should report timed out commands cleanly."""
-        script = mock_settings.paths.workspace_root / "timeout_command.py"
-        script.write_text("import time\nprint('partial stdout', flush=True)\ntime.sleep(2)\n")
-        command = f"python {script.name}"
+        if os.name == "nt":
+            script = mock_settings.paths.workspace_root / "timeout_command.bat"
+            script.write_text("@echo partial stdout\r\n@ping 127.0.0.1 -n 3 > nul\r\n")
+            command = script.name
+        else:
+            script = mock_settings.paths.workspace_root / "timeout_command.sh"
+            script.write_text("printf 'partial stdout\\n'\nsleep 2\n")
+            command = f"sh {script.name}"
 
         result = await workspace.run_command_handler(
             {"command": command, "timeout": 1},
@@ -337,9 +343,14 @@ class TestRunCommand:
     @pytest.mark.asyncio
     async def test_truncates_large_command_output(self, mock_settings):
         """Should truncate oversized command output."""
-        script = mock_settings.paths.workspace_root / "large_output.py"
-        script.write_text("print('x' * 25000)\n")
-        command = f"python {script.name}"
+        if os.name == "nt":
+            script = mock_settings.paths.workspace_root / "large_output.bat"
+            script.write_text("@powershell -NoProfile -Command \"Write-Output ('x' * 25000)\"\r\n")
+            command = script.name
+        else:
+            script = mock_settings.paths.workspace_root / "large_output.sh"
+            script.write_text("printf '%*s' 25000 '' | tr ' ' x\n")
+            command = f"sh {script.name}"
 
         result = await workspace.run_command_handler({"command": command}, mock_settings)
 

--- a/tests/unit/test_workspace_tools.py
+++ b/tests/unit/test_workspace_tools.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from subprocess import CompletedProcess, TimeoutExpired
 
 import pytest
 
@@ -321,14 +320,11 @@ class TestRunCommand:
         assert "recursive deletion via rm" in result
 
     @pytest.mark.asyncio
-    async def test_reports_command_timeout(self, mock_settings, monkeypatch):
+    async def test_reports_command_timeout(self, mock_settings):
         """Should report timed out commands cleanly."""
-
-        def fake_run(*_args, **_kwargs):
-            raise TimeoutExpired(cmd="sleep", timeout=1, output="partial stdout", stderr="partial stderr")
-
-        monkeypatch.setattr(workspace.subprocess, "run", fake_run)
-        command = "sleep 2"
+        script = mock_settings.paths.workspace_root / "timeout_command.py"
+        script.write_text("import time\nprint('partial stdout', flush=True)\ntime.sleep(2)\n")
+        command = f"python {script.name}"
 
         result = await workspace.run_command_handler(
             {"command": command, "timeout": 1},
@@ -339,19 +335,11 @@ class TestRunCommand:
         assert "Timeout: 1s" in result
 
     @pytest.mark.asyncio
-    async def test_truncates_large_command_output(self, mock_settings, monkeypatch):
+    async def test_truncates_large_command_output(self, mock_settings):
         """Should truncate oversized command output."""
-
-        def fake_run(*_args, **_kwargs):
-            return CompletedProcess(
-                args=["shell"],
-                returncode=0,
-                stdout="x" * 25000,
-                stderr="",
-            )
-
-        monkeypatch.setattr(workspace.subprocess, "run", fake_run)
-        command = "echo placeholder"
+        script = mock_settings.paths.workspace_root / "large_output.py"
+        script.write_text("print('x' * 25000)\n")
+        command = f"python {script.name}"
 
         result = await workspace.run_command_handler({"command": command}, mock_settings)
 


### PR DESCRIPTION
## Summary
- Adds an active-turn manager so the API can interrupt a running session turn from a separate request.
- Adds `POST /api/interrupt/{session_id}` with idle and active-turn responses.
- Persists `interrupted` terminal events and marks cancelled tool calls as interrupted.
- Moves `run_command` onto async subprocess execution so command tools can be terminated on timeout or cancellation.

## Testing
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `pytest tests/ -q`
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `pyright app/`
- `bandit -q -r app/`
- `pre-commit run --all-files`

Closes #40
