### PR TITLE
ML-106: Add git status and diff reporting

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -768,8 +768,8 @@ def create_agent_loop(
 
 
 def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
-    """Create and populate the tool registry with workspace tools."""
-    from app.tools import workspace
+    """Create and populate the tool registry with workspace and reporting tools."""
+    from app.tools import reporting, workspace
 
     registry = ToolRegistry()
     workspace_specs = workspace.get_tool_specs()
@@ -782,6 +782,15 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
             handler=handler,
+        )
+        registry.register(tool_spec)
+
+    for spec in reporting.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_report_handler(settings),
         )
         registry.register(tool_spec)
 
@@ -806,3 +815,13 @@ def _get_workspace_handler(name: str, settings: AppSettings) -> ToolHandler:
         return handlers[name]
     except KeyError as exc:
         raise UnknownToolError(f"Workspace tool handler is not registered for {name!r}.") from exc
+
+
+def _make_report_handler(settings: AppSettings) -> ToolHandler:
+    """Create a handler for the git_report tool."""
+    from app.tools import reporting
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await reporting.git_report_handler(args, settings)
+
+    return _handler

--- a/app/tools/reporting.py
+++ b/app/tools/reporting.py
@@ -1,0 +1,125 @@
+"""Git status and diff reporting for agent reports and PR descriptions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from app.config import AppSettings
+from app.tools.workspace import _run_git_command, _safe_path
+
+MAX_DIFF_CHARS = 8000
+
+
+def _gather_status(workspace_root: Path) -> list[str]:
+    """Return porcelain status lines for the workspace."""
+    try:
+        result = _run_git_command(["status", "--porcelain"], cwd=workspace_root)
+        if result.returncode != 0:
+            return []
+        return [line for line in result.stdout.splitlines() if line.strip()]
+    except Exception:
+        return []
+
+
+def _gather_diff(workspace_root: Path, staged: bool = False) -> str:
+    """Return diff text for the workspace, truncated if too large."""
+    try:
+        args = ["diff", "--stat"]
+        if staged:
+            args.append("--staged")
+        stat_result = _run_git_command(args, cwd=workspace_root)
+
+        args_full = ["diff"]
+        if staged:
+            args_full.append("--staged")
+        full_result = _run_git_command(args_full, cwd=workspace_root)
+
+        stat_text = stat_result.stdout.strip() if stat_result.returncode == 0 else ""
+        full_text = full_result.stdout.strip() if full_result.returncode == 0 else ""
+
+        if len(full_text) > MAX_DIFF_CHARS:
+            full_text = full_text[:MAX_DIFF_CHARS] + "\n... [diff truncated]"
+
+        return f"{stat_text}\n\n{full_text}".strip() if stat_text else full_text
+    except Exception:
+        return ""
+
+
+def _gather_branch(workspace_root: Path) -> str:
+    """Return the current branch name."""
+    try:
+        result = _run_git_command(["rev-parse", "--abbrev-ref", "HEAD"], cwd=workspace_root)
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def format_git_report(workspace_root: Path) -> str:
+    """Format a complete git report section as Markdown.
+
+    Combines branch, status, and diff information into a structured
+    report section suitable for final agent reports and PR descriptions.
+    """
+    branch = _gather_branch(workspace_root)
+    status_lines = _gather_status(workspace_root)
+    unstaged_diff = _gather_diff(workspace_root, staged=False)
+    staged_diff = _gather_diff(workspace_root, staged=True)
+
+    sections: list[str] = ["## Git Changes"]
+
+    if branch:
+        sections.append(f"\n**Branch:** `{branch}`")
+
+    if not status_lines and not unstaged_diff and not staged_diff:
+        sections.append("\nWorking tree is clean — no uncommitted changes.")
+        return "\n".join(sections)
+
+    if status_lines:
+        sections.append("\n### Modified Files")
+        sections.append("")
+        for line in status_lines:
+            sections.append(f"- `{line.strip()}`")
+
+    if staged_diff:
+        sections.append("\n### Staged Changes")
+        sections.append(f"\n```diff\n{staged_diff}\n```")
+
+    if unstaged_diff:
+        sections.append("\n### Unstaged Changes")
+        sections.append(f"\n```diff\n{unstaged_diff}\n```")
+
+    return "\n".join(sections)
+
+
+async def git_report_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Tool handler: generate a formatted git changes report."""
+    work_dir = args.get("work_dir", str(settings.paths.workspace_root))
+    safe = _safe_path(Path(work_dir), settings.paths.workspace_root)
+    if safe is None:
+        return f"Error: Path {work_dir!r} is outside workspace root"
+
+    return format_git_report(safe)
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return OpenAI-compatible tool specifications for reporting tools."""
+    return [
+        {
+            "name": "git_report",
+            "description": (
+                "Generate a formatted Markdown report of current git changes "
+                "including branch, modified files, staged and unstaged diffs. "
+                "Use this to summarize repository state for reports or PR descriptions."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "work_dir": {
+                        "type": "string",
+                        "description": "Working directory (default: workspace root).",
+                    },
+                },
+            },
+        },
+    ]

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -1,0 +1,154 @@
+"""Tests for app.tools.reporting module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.tools.reporting import (
+    MAX_DIFF_CHARS,
+    _gather_branch,
+    _gather_diff,
+    _gather_status,
+    format_git_report,
+    get_tool_specs,
+    git_report_handler,
+)
+
+
+def _make_completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestGatherStatus:
+    def test_returns_lines(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.return_value = _make_completed("M  file.py\nA  new.py\n")
+            lines = _gather_status(tmp_path)
+        assert lines == ["M  file.py", "A  new.py"]
+
+    def test_clean_repo(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.return_value = _make_completed("")
+            lines = _gather_status(tmp_path)
+        assert lines == []
+
+    def test_git_failure(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.return_value = _make_completed("", returncode=128)
+            lines = _gather_status(tmp_path)
+        assert lines == []
+
+    def test_exception(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command", side_effect=FileNotFoundError):
+            lines = _gather_status(tmp_path)
+        assert lines == []
+
+
+class TestGatherDiff:
+    def test_returns_diff(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.side_effect = [
+                _make_completed(" file.py | 2 +-"),
+                _make_completed("-old\n+new"),
+            ]
+            result = _gather_diff(tmp_path)
+        assert "file.py" in result
+        assert "+new" in result
+
+    def test_empty_diff(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.side_effect = [_make_completed(""), _make_completed("")]
+            result = _gather_diff(tmp_path)
+        assert result == ""
+
+    def test_truncates_large_diff(self, tmp_path: Path) -> None:
+        large = "x" * (MAX_DIFF_CHARS + 500)
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.side_effect = [_make_completed(""), _make_completed(large)]
+            result = _gather_diff(tmp_path)
+        assert "[diff truncated]" in result
+        assert len(result) < MAX_DIFF_CHARS + 100
+
+    def test_exception(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command", side_effect=OSError):
+            result = _gather_diff(tmp_path)
+        assert result == ""
+
+
+class TestGatherBranch:
+    def test_returns_branch(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.return_value = _make_completed("feature/test\n")
+            assert _gather_branch(tmp_path) == "feature/test"
+
+    def test_failure(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._run_git_command") as mock:
+            mock.return_value = _make_completed("", returncode=128)
+            assert _gather_branch(tmp_path) == ""
+
+
+class TestFormatGitReport:
+    def test_clean_workspace(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._gather_branch", return_value="main"):
+            with patch("app.tools.reporting._gather_status", return_value=[]):
+                with patch("app.tools.reporting._gather_diff", return_value=""):
+                    report = format_git_report(tmp_path)
+        assert "## Git Changes" in report
+        assert "clean" in report
+        assert "`main`" in report
+
+    def test_with_changes(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._gather_branch", return_value="feature/x"):
+            with patch("app.tools.reporting._gather_status", return_value=["M file.py"]):
+                with patch("app.tools.reporting._gather_diff", side_effect=["unstaged-diff", ""]):
+                    report = format_git_report(tmp_path)
+        assert "## Git Changes" in report
+        assert "`feature/x`" in report
+        assert "### Modified Files" in report
+        assert "`M file.py`" in report
+        assert "### Unstaged Changes" in report
+        assert "unstaged-diff" in report
+
+    def test_staged_only(self, tmp_path: Path) -> None:
+        with patch("app.tools.reporting._gather_branch", return_value="main"):
+            with patch("app.tools.reporting._gather_status", return_value=["A new.py"]):
+                with patch("app.tools.reporting._gather_diff", side_effect=["", "staged-diff"]):
+                    report = format_git_report(tmp_path)
+        assert "### Staged Changes" in report
+        assert "staged-diff" in report
+        assert "### Unstaged Changes" not in report
+
+
+class TestGitReportHandler:
+    @pytest.mark.asyncio
+    async def test_default_workspace(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path)
+        with patch("app.tools.reporting.format_git_report", return_value="## Git Changes\nclean"):
+            result = await git_report_handler({}, settings)
+        assert "Git Changes" in result
+
+    @pytest.mark.asyncio
+    async def test_workspace_escape(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path)
+        result = await git_report_handler({"work_dir": "/etc/secrets"}, settings)
+        assert "Error" in result
+        assert "outside workspace" in result
+
+
+class TestGetToolSpecs:
+    def test_returns_git_report(self) -> None:
+        specs = get_tool_specs()
+        assert len(specs) == 1
+        assert specs[0]["name"] == "git_report"
+        assert "parameters" in specs[0]
+
+
+def _make_settings(workspace_root: Path):
+    """Create minimal AppSettings for testing."""
+    from app.config import AppPaths, AppSettings
+
+    return AppSettings.from_paths(AppPaths.from_workspace_root(workspace_root))


### PR DESCRIPTION
## Summary
- add app/tools/reporting.py with a git_report tool that gathers branch name, porcelain status, and staged/unstaged diffs into a structured Markdown report section
- register the tool in the agent loop registry (read-only, no approval required)
- add 16 unit tests covering status gathering, diff truncation, branch detection, clean-workspace formatting, workspace-escape rejection, and tool spec validation

## Testing
- python -m pytest tests/ -q`n- python -m ruff check app/ tests/`n- python -m ruff format --check app/ tests/`n- python -m mypy app/ --ignore-missing-imports --follow-imports=skip`n- python -m bandit -q -r app/`n
## Notes
The tool reuses _run_git_command and _safe_path from workspace.py to keep git interaction consistent and workspace-safe. Large diffs are truncated at 8 KB.

## Reference
Issue: #42