### PR TITLE
ML-107 / Add dataset inspection tool

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -768,8 +768,8 @@ def create_agent_loop(
 
 
 def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
-    """Create and populate the tool registry with workspace and reporting tools."""
-    from app.tools import reporting, workspace
+    """Create and populate the tool registry with workspace, reporting, and dataset tools."""
+    from app.tools import datasets, reporting, workspace
 
     registry = ToolRegistry()
     workspace_specs = workspace.get_tool_specs()
@@ -791,6 +791,15 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
             handler=_make_report_handler(settings),
+        )
+        registry.register(tool_spec)
+
+    for spec in datasets.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_dataset_handler(settings),
         )
         registry.register(tool_spec)
 
@@ -823,5 +832,15 @@ def _make_report_handler(settings: AppSettings) -> ToolHandler:
 
     async def _handler(args: dict[str, Any]) -> str:
         return await reporting.git_report_handler(args, settings)
+
+    return _handler
+
+
+def _make_dataset_handler(settings: AppSettings) -> ToolHandler:
+    """Create a handler for the inspect_dataset tool."""
+    from app.tools import datasets
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await datasets.inspect_dataset_handler(args, settings)
 
     return _handler

--- a/app/tools/datasets.py
+++ b/app/tools/datasets.py
@@ -1,0 +1,406 @@
+"""Dataset inspection tool for local files and Hugging Face datasets."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.config import AppSettings
+from app.tools.workspace import _safe_path
+
+HF_DATASETS_SERVER = "https://datasets-server.huggingface.co"
+MAX_SAMPLE_ROWS = 5
+MAX_VALUE_LEN = 120
+MAX_LOCAL_ROWS_SCAN = 10_000
+
+
+async def inspect_dataset_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Tool handler: inspect a local file or HF dataset."""
+    source = args.get("source", "")
+    if not source:
+        return "Error: No source provided. Pass a local file path or HF dataset name (e.g. 'imdb')."
+
+    # Determine if local file or HF dataset
+    if "/" not in source or _looks_like_path(source, settings.paths.workspace_root):
+        return await _inspect_local(source, args, settings)
+    return await _inspect_hf(source, args)
+
+
+def _looks_like_path(source: str, workspace_root: Path) -> bool:
+    """Heuristic: treat as local path if file extension present, starts with ./ or ../, or path exists."""
+    p = Path(source)
+    if p.suffix.lower() in (".csv", ".jsonl", ".json", ".parquet", ".tsv"):
+        return True
+    if source.startswith(("./", "../", ".\\", "..\\")) or source.startswith("/"):
+        return True
+    candidate = workspace_root / source if not p.is_absolute() else p
+    return candidate.exists()
+
+
+# --- Local file inspection ---
+
+
+async def _inspect_local(source: str, args: dict[str, Any], settings: AppSettings) -> str:
+    """Inspect a local CSV, JSONL, or Parquet file."""
+    workspace_root = settings.paths.workspace_root
+    path = Path(source) if Path(source).is_absolute() else workspace_root / source
+    safe = _safe_path(path, workspace_root)
+    if safe is None:
+        return f"Error: Path {source!r} is outside workspace root."
+    if not safe.exists():
+        return f"Error: File not found: {source}"
+    if safe.is_dir():
+        return "Error: Path is a directory. Provide a file path."
+
+    ext = safe.suffix.lower()
+    sample_rows = min(args.get("sample_rows", MAX_SAMPLE_ROWS), MAX_SAMPLE_ROWS)
+
+    if ext == ".csv" or ext == ".tsv":
+        return _inspect_csv(safe, sample_rows, delimiter="\t" if ext == ".tsv" else ",")
+    elif ext in (".jsonl", ".json"):
+        return _inspect_jsonl(safe, sample_rows)
+    elif ext == ".parquet":
+        return _inspect_parquet(safe, sample_rows)
+    else:
+        return f"Error: Unsupported file type '{ext}'. Supported: .csv, .tsv, .jsonl, .json, .parquet"
+
+
+def _inspect_csv(path: Path, sample_rows: int, delimiter: str = ",") -> str:
+    """Inspect a CSV/TSV file."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return f"Error reading file: {e}"
+
+    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
+    rows: list[list[str]] = []
+    for i, row in enumerate(reader):
+        if i >= MAX_LOCAL_ROWS_SCAN:
+            break
+        rows.append(row)
+
+    if not rows:
+        return "Error: File is empty."
+
+    headers = rows[0]
+    data_rows = rows[1:]
+    total_rows = len(data_rows)
+
+    # Compute missing values per column
+    missing: dict[str, int] = {h: 0 for h in headers}
+    for row in data_rows:
+        for i, h in enumerate(headers):
+            val = row[i] if i < len(row) else ""
+            if val.strip() == "":
+                missing[h] += 1
+
+    sections = [f"## {path.name}", ""]
+    sections.append(
+        f"**Format:** CSV | **Rows:** {total_rows:,} "
+        f"(scanned up to {MAX_LOCAL_ROWS_SCAN:,}) | **Columns:** {len(headers)}"
+    )
+    sections.append("")
+
+    # Schema table
+    sections.append("### Columns")
+    sections.append("| # | Column | Missing |")
+    sections.append("|---|--------|---------|")
+    for i, h in enumerate(headers, 1):
+        m = missing[h]
+        pct = f"{m}/{total_rows} ({100 * m // max(total_rows, 1)}%)" if m > 0 else "0"
+        sections.append(f"| {i} | {h} | {pct} |")
+
+    # Sample rows
+    sections.append("")
+    sections.append("### Sample Rows")
+    for idx, row in enumerate(data_rows[:sample_rows], 1):
+        sections.append(f"**Row {idx}:**")
+        for i, h in enumerate(headers):
+            val = row[i] if i < len(row) else ""
+            if len(val) > MAX_VALUE_LEN:
+                val = val[:MAX_VALUE_LEN] + "..."
+            sections.append(f"- {h}: {val}")
+
+    return "\n".join(sections)
+
+
+def _inspect_jsonl(path: Path, sample_rows: int) -> str:
+    """Inspect a JSONL file."""
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as e:
+        return f"Error reading file: {e}"
+
+    records: list[dict[str, Any]] = []
+    parse_errors = 0
+    for line in lines[:MAX_LOCAL_ROWS_SCAN]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            parse_errors += 1
+
+    if not records:
+        return "Error: No valid JSON records found."
+
+    # Infer schema from all scanned records
+    all_keys: dict[str, set[str]] = {}
+    for rec in records:
+        for k, v in rec.items():
+            all_keys.setdefault(k, set()).add(type(v).__name__)
+
+    missing: dict[str, int] = {k: 0 for k in all_keys}
+    for rec in records:
+        for k in all_keys:
+            if k not in rec or rec[k] is None:
+                missing[k] += 1
+
+    total = len(records)
+    sections = [f"## {path.name}", ""]
+    sections.append(
+        f"**Format:** JSONL | **Records:** {total:,} "
+        f"(scanned up to {MAX_LOCAL_ROWS_SCAN:,}) | **Fields:** {len(all_keys)}"
+    )
+    if parse_errors:
+        sections.append(f"**Parse errors:** {parse_errors}")
+    sections.append("")
+
+    sections.append("### Fields")
+    sections.append("| # | Field | Types | Missing |")
+    sections.append("|---|-------|-------|---------|")
+    for i, (k, types) in enumerate(all_keys.items(), 1):
+        m = missing[k]
+        pct = f"{m}/{total} ({100 * m // max(total, 1)}%)" if m > 0 else "0"
+        sections.append(f"| {i} | {k} | {', '.join(sorted(types))} | {pct} |")
+
+    sections.append("")
+    sections.append("### Sample Records")
+    for idx, rec in enumerate(records[:sample_rows], 1):
+        sections.append(f"**Record {idx}:**")
+        for k, v in rec.items():
+            val = str(v)
+            if len(val) > MAX_VALUE_LEN:
+                val = val[:MAX_VALUE_LEN] + "..."
+            sections.append(f"- {k}: {val}")
+
+    return "\n".join(sections)
+
+
+def _inspect_parquet(path: Path, sample_rows: int) -> str:
+    """Inspect a Parquet file (requires pyarrow)."""
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        return "Error: `pyarrow` is not installed. Install it with `pip install pyarrow` to inspect Parquet files."
+
+    try:
+        pf = pq.ParquetFile(str(path))
+    except Exception as e:
+        return f"Error reading Parquet file: {e}"
+
+    metadata = pf.metadata
+    schema = pf.schema_arrow
+    total_rows = metadata.num_rows
+
+    sections = [f"## {path.name}", ""]
+    sections.append(
+        f"**Format:** Parquet | **Rows:** {total_rows:,} | "
+        f"**Columns:** {schema.num_fields} | "
+        f"**Row groups:** {metadata.num_row_groups}"
+    )
+    sections.append("")
+
+    sections.append("### Columns")
+    sections.append("| # | Column | Type |")
+    sections.append("|---|--------|------|")
+    for i, field in enumerate(schema, 1):
+        sections.append(f"| {i} | {field.name} | {field.type} |")
+
+    # Sample rows
+    try:
+        table = pf.read_row_group(0)
+        sample = table.slice(0, sample_rows).to_pydict()
+        sections.append("")
+        sections.append("### Sample Rows")
+        keys = list(sample.keys())
+        for idx in range(min(sample_rows, len(sample[keys[0]]))):
+            sections.append(f"**Row {idx + 1}:**")
+            for k in keys:
+                val = str(sample[k][idx])
+                if len(val) > MAX_VALUE_LEN:
+                    val = val[:MAX_VALUE_LEN] + "..."
+                sections.append(f"- {k}: {val}")
+    except Exception:  # nosec B110
+        pass  # Sample rows are optional; schema is already reported
+
+    return "\n".join(sections)
+
+
+# --- HF dataset inspection ---
+
+
+async def _inspect_hf(source: str, args: dict[str, Any]) -> str:
+    """Inspect a Hugging Face dataset via datasets-server API."""
+    dataset = source
+    config = args.get("config")
+    split = args.get("split")
+    sample_rows = min(args.get("sample_rows", 3), MAX_SAMPLE_ROWS)
+    token = args.get("token")
+
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    sections = [f"## {dataset} (Hugging Face)", ""]
+
+    async with httpx.AsyncClient(timeout=15, headers=headers) as client:
+        # Check validity and get splits
+        try:
+            valid_resp, splits_resp = await _hf_parallel(
+                client,
+                [
+                    (f"{HF_DATASETS_SERVER}/is-valid", {"dataset": dataset}),
+                    (f"{HF_DATASETS_SERVER}/splits", {"dataset": dataset}),
+                ],
+            )
+        except Exception as e:
+            return f"Error querying HF datasets-server: {e}"
+
+        # Status
+        if valid_resp and valid_resp.get("preview"):
+            sections.append("**Status:** ✓ Valid (preview available)")
+        else:
+            sections.append("**Status:** Dataset may have limited availability")
+        sections.append("")
+
+        # Splits
+        configs = _extract_configs(splits_resp) if splits_resp else []
+        if configs:
+            if not config:
+                config = configs[0]["name"]
+            if not split:
+                split = configs[0]["splits"][0] if configs[0]["splits"] else "train"
+
+            sections.append("### Structure")
+            sections.append("| Config | Splits |")
+            sections.append("|--------|--------|")
+            for cfg in configs[:10]:
+                sections.append(f"| {cfg['name']} | {', '.join(cfg['splits'][:5])} |")
+            sections.append("")
+
+        if not config:
+            config = "default"
+        if not split:
+            split = "train"
+
+        # Schema and sample rows
+        try:
+            info_resp, rows_resp = await _hf_parallel(
+                client,
+                [
+                    (f"{HF_DATASETS_SERVER}/info", {"dataset": dataset, "config": config}),
+                    (f"{HF_DATASETS_SERVER}/first-rows", {"dataset": dataset, "config": config, "split": split}),
+                ],
+            )
+        except Exception:
+            info_resp, rows_resp = None, None
+
+        if info_resp:
+            features = info_resp.get("dataset_info", {}).get("features", {})
+            if features:
+                sections.append("### Schema")
+                sections.append("| Column | Type |")
+                sections.append("|--------|------|")
+                for col, info in features.items():
+                    dtype = info.get("dtype") or info.get("_type", "unknown")
+                    sections.append(f"| {col} | {dtype} |")
+                sections.append("")
+
+        if rows_resp:
+            rows = rows_resp.get("rows", [])[:sample_rows]
+            if rows:
+                sections.append(f"### Sample Rows ({config}/{split})")
+                for idx, row_wrapper in enumerate(rows, 1):
+                    row = row_wrapper.get("row", {})
+                    sections.append(f"**Row {idx}:**")
+                    for k, v in row.items():
+                        val = str(v)
+                        if len(val) > MAX_VALUE_LEN:
+                            val = val[:MAX_VALUE_LEN] + "..."
+                        sections.append(f"- {k}: {val}")
+
+    return "\n".join(sections)
+
+
+async def _hf_parallel(
+    client: httpx.AsyncClient,
+    requests: list[tuple[str, dict[str, str]]],
+) -> list[dict[str, Any] | None]:
+    """Make parallel GET requests, return parsed JSON or None."""
+    import asyncio
+
+    async def _get(url: str, params: dict[str, str]) -> dict[str, Any] | None:
+        try:
+            resp = await client.get(url, params=params)
+            if resp.status_code == 200:
+                return resp.json()
+        except Exception:  # nosec B110
+            pass  # Individual API failures are non-fatal
+        return None
+
+    results = await asyncio.gather(*[_get(url, params) for url, params in requests])
+    return list(results)
+
+
+def _extract_configs(splits_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Group splits by config from HF splits response."""
+    configs: dict[str, dict[str, Any]] = {}
+    for s in splits_data.get("splits", []):
+        cfg = s.get("config", "default")
+        if cfg not in configs:
+            configs[cfg] = {"name": cfg, "splits": []}
+        configs[cfg]["splits"].append(s.get("split", ""))
+    return list(configs.values())
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return OpenAI-compatible tool specifications."""
+    return [
+        {
+            "name": "inspect_dataset",
+            "description": (
+                "Inspect a dataset's metadata, schema, and sample rows. "
+                "Supports local CSV/TSV/JSONL/Parquet files and Hugging Face datasets. "
+                "For local files, pass the file path. For HF datasets, pass the dataset name (e.g. 'imdb')."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "Local file path or HF dataset name (e.g. 'data/train.csv' or 'imdb').",
+                    },
+                    "config": {
+                        "type": "string",
+                        "description": "HF dataset config name (optional, auto-detected).",
+                    },
+                    "split": {
+                        "type": "string",
+                        "description": "HF dataset split (optional, defaults to first available).",
+                    },
+                    "sample_rows": {
+                        "type": "integer",
+                        "description": "Number of sample rows to show (default: 3, max: 5).",
+                    },
+                },
+                "required": ["source"],
+            },
+        },
+    ]

--- a/app/tools/datasets.py
+++ b/app/tools/datasets.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import csv
-import io
 import json
 from pathlib import Path
 from typing import Any
@@ -25,20 +25,20 @@ async def inspect_dataset_handler(args: dict[str, Any], settings: AppSettings) -
     if not source:
         return "Error: No source provided. Pass a local file path or HF dataset name (e.g. 'imdb')."
 
-    # Determine if local file or HF dataset
-    if "/" not in source or _looks_like_path(source, settings.paths.workspace_root):
+    # Route: no slash = always local; relative path prefix = local; otherwise check heuristic
+    if "/" not in source and "\\" not in source:
+        return await _inspect_local(source, args, settings)
+    if source.startswith(("./", "../", ".\\", "..\\", "/")):
+        return await _inspect_local(source, args, settings)
+    # Has a slash — could be HF namespace (user/dataset) or a local subpath
+    if _looks_like_local_path(source, settings.paths.workspace_root):
         return await _inspect_local(source, args, settings)
     return await _inspect_hf(source, args)
 
 
-def _looks_like_path(source: str, workspace_root: Path) -> bool:
-    """Heuristic: treat as local path if file extension present, starts with ./ or ../, or path exists."""
-    p = Path(source)
-    if p.suffix.lower() in (".csv", ".jsonl", ".json", ".parquet", ".tsv"):
-        return True
-    if source.startswith(("./", "../", ".\\", "..\\")) or source.startswith("/"):
-        return True
-    candidate = workspace_root / source if not p.is_absolute() else p
+def _looks_like_local_path(source: str, workspace_root: Path) -> bool:
+    """Return True only if source resolves to an existing workspace file."""
+    candidate = workspace_root / source
     return candidate.exists()
 
 
@@ -60,10 +60,12 @@ async def _inspect_local(source: str, args: dict[str, Any], settings: AppSetting
     ext = safe.suffix.lower()
     sample_rows = min(args.get("sample_rows", MAX_SAMPLE_ROWS), MAX_SAMPLE_ROWS)
 
-    if ext == ".csv" or ext == ".tsv":
+    if ext in (".csv", ".tsv"):
         return _inspect_csv(safe, sample_rows, delimiter="\t" if ext == ".tsv" else ",")
-    elif ext in (".jsonl", ".json"):
+    elif ext == ".jsonl":
         return _inspect_jsonl(safe, sample_rows)
+    elif ext == ".json":
+        return _inspect_json(safe, sample_rows)
     elif ext == ".parquet":
         return _inspect_parquet(safe, sample_rows)
     else:
@@ -71,18 +73,21 @@ async def _inspect_local(source: str, args: dict[str, Any], settings: AppSetting
 
 
 def _inspect_csv(path: Path, sample_rows: int, delimiter: str = ",") -> str:
-    """Inspect a CSV/TSV file."""
+    """Inspect a CSV/TSV file by streaming line-by-line."""
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        f = path.open(encoding="utf-8", errors="replace")
     except OSError as e:
         return f"Error reading file: {e}"
 
-    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
     rows: list[list[str]] = []
-    for i, row in enumerate(reader):
-        if i >= MAX_LOCAL_ROWS_SCAN:
-            break
-        rows.append(row)
+    hit_limit = False
+    with f:
+        reader = csv.reader(f, delimiter=delimiter)
+        for i, row in enumerate(reader):
+            if i >= MAX_LOCAL_ROWS_SCAN:
+                hit_limit = True
+                break
+            rows.append(row)
 
     if not rows:
         return "Error: File is empty."
@@ -99,11 +104,10 @@ def _inspect_csv(path: Path, sample_rows: int, delimiter: str = ",") -> str:
             if val.strip() == "":
                 missing[h] += 1
 
+    fmt_name = "TSV" if delimiter == "\t" else "CSV"
+    row_label = f"{total_rows:,}+" if hit_limit else f"{total_rows:,}"
     sections = [f"## {path.name}", ""]
-    sections.append(
-        f"**Format:** CSV | **Rows:** {total_rows:,} "
-        f"(scanned up to {MAX_LOCAL_ROWS_SCAN:,}) | **Columns:** {len(headers)}"
-    )
+    sections.append(f"**Format:** {fmt_name} | **Rows:** {row_label} | **Columns:** {len(headers)}")
     sections.append("")
 
     # Schema table
@@ -130,27 +134,73 @@ def _inspect_csv(path: Path, sample_rows: int, delimiter: str = ",") -> str:
 
 
 def _inspect_jsonl(path: Path, sample_rows: int) -> str:
-    """Inspect a JSONL file."""
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError as e:
-        return f"Error reading file: {e}"
-
+    """Inspect a JSONL file by streaming line-by-line."""
     records: list[dict[str, Any]] = []
     parse_errors = 0
-    for line in lines[:MAX_LOCAL_ROWS_SCAN]:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            records.append(json.loads(line))
-        except json.JSONDecodeError:
-            parse_errors += 1
+    hit_limit = False
+
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for i, line in enumerate(f):
+                if i >= MAX_LOCAL_ROWS_SCAN:
+                    hit_limit = True
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    parse_errors += 1
+    except OSError as e:
+        return f"Error reading file: {e}"
 
     if not records:
         return "Error: No valid JSON records found."
 
-    # Infer schema from all scanned records
+    return _format_json_records(path.name, "JSONL", records, parse_errors, hit_limit, sample_rows)
+
+
+def _inspect_json(path: Path, sample_rows: int) -> str:
+    """Inspect a .json file — handles both JSON arrays and JSONL."""
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            first_char = ""
+            for ch in f.read(64):
+                if ch.strip():
+                    first_char = ch
+                    break
+    except OSError as e:
+        return f"Error reading file: {e}"
+
+    # JSON array
+    if first_char == "[":
+        try:
+            with path.open(encoding="utf-8", errors="replace") as f:
+                data = json.load(f)
+            if not isinstance(data, list):
+                return "Error: Expected a JSON array of records."
+            records = [r for r in data[:MAX_LOCAL_ROWS_SCAN] if isinstance(r, dict)]
+            hit_limit = len(data) > MAX_LOCAL_ROWS_SCAN
+            if not records:
+                return "Error: No valid JSON records found."
+            return _format_json_records(path.name, "JSON array", records, 0, hit_limit, sample_rows)
+        except json.JSONDecodeError as e:
+            return f"Error parsing JSON: {e}"
+
+    # Fall back to JSONL
+    return _inspect_jsonl(path, sample_rows)
+
+
+def _format_json_records(
+    filename: str,
+    fmt: str,
+    records: list[dict[str, Any]],
+    parse_errors: int,
+    hit_limit: bool,
+    sample_rows: int,
+) -> str:
+    """Format inspection output for JSON-based records."""
     all_keys: dict[str, set[str]] = {}
     for rec in records:
         for k, v in rec.items():
@@ -163,11 +213,9 @@ def _inspect_jsonl(path: Path, sample_rows: int) -> str:
                 missing[k] += 1
 
     total = len(records)
-    sections = [f"## {path.name}", ""]
-    sections.append(
-        f"**Format:** JSONL | **Records:** {total:,} "
-        f"(scanned up to {MAX_LOCAL_ROWS_SCAN:,}) | **Fields:** {len(all_keys)}"
-    )
+    row_label = f"{total:,}+" if hit_limit else f"{total:,}"
+    sections = [f"## {filename}", ""]
+    sections.append(f"**Format:** {fmt} | **Records:** {row_label} | **Fields:** {len(all_keys)}")
     if parse_errors:
         sections.append(f"**Parse errors:** {parse_errors}")
     sections.append("")
@@ -237,8 +285,8 @@ def _inspect_parquet(path: Path, sample_rows: int) -> str:
                 if len(val) > MAX_VALUE_LEN:
                     val = val[:MAX_VALUE_LEN] + "..."
                 sections.append(f"- {k}: {val}")
-    except Exception:  # nosec B110
-        pass  # Sample rows are optional; schema is already reported
+    except Exception as e:  # nosec B110
+        sections.append(f"\n(Could not read sample rows: {e})")
 
     return "\n".join(sections)
 
@@ -306,7 +354,10 @@ async def _inspect_hf(source: str, args: dict[str, Any]) -> str:
                 client,
                 [
                     (f"{HF_DATASETS_SERVER}/info", {"dataset": dataset, "config": config}),
-                    (f"{HF_DATASETS_SERVER}/first-rows", {"dataset": dataset, "config": config, "split": split}),
+                    (
+                        f"{HF_DATASETS_SERVER}/first-rows",
+                        {"dataset": dataset, "config": config, "split": split},
+                    ),
                 ],
             )
         except Exception:
@@ -344,7 +395,6 @@ async def _hf_parallel(
     requests: list[tuple[str, dict[str, str]]],
 ) -> list[dict[str, Any] | None]:
     """Make parallel GET requests, return parsed JSON or None."""
-    import asyncio
 
     async def _get(url: str, params: dict[str, str]) -> dict[str, Any] | None:
         try:
@@ -385,7 +435,10 @@ def get_tool_specs() -> list[dict[str, Any]]:
                 "properties": {
                     "source": {
                         "type": "string",
-                        "description": "Local file path or HF dataset name (e.g. 'data/train.csv' or 'imdb').",
+                        "description": (
+                            "Local file path or HF dataset name "
+                            "(e.g. 'data/train.csv' or 'imdb' or 'username/dataset')."
+                        ),
                     },
                     "config": {
                         "type": "string",

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -10,8 +11,9 @@ import pytest
 from app.config import AppPaths, AppSettings
 from app.tools.datasets import (
     _inspect_csv,
+    _inspect_json,
     _inspect_jsonl,
-    _looks_like_path,
+    _looks_like_local_path,
     get_tool_specs,
     inspect_dataset_handler,
 )
@@ -21,22 +23,14 @@ def _settings(tmp_path: Path) -> AppSettings:
     return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
 
 
-class TestLooksLikePath:
-    def test_csv_extension(self, tmp_path: Path) -> None:
-        assert _looks_like_path("data/train.csv", tmp_path) is True
-
-    def test_jsonl_extension(self, tmp_path: Path) -> None:
-        assert _looks_like_path("data.jsonl", tmp_path) is True
-
-    def test_parquet_extension(self, tmp_path: Path) -> None:
-        assert _looks_like_path("model/data.parquet", tmp_path) is True
-
-    def test_hf_dataset_name(self, tmp_path: Path) -> None:
-        assert _looks_like_path("imdb", tmp_path) is False
-
+class TestLooksLikeLocalPath:
     def test_existing_file(self, tmp_path: Path) -> None:
-        (tmp_path / "myfile").write_text("x")
-        assert _looks_like_path("myfile", tmp_path) is True
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "train.csv").write_text("x")
+        assert _looks_like_local_path("data/train.csv", tmp_path) is True
+
+    def test_nonexistent(self, tmp_path: Path) -> None:
+        assert _looks_like_local_path("user/dataset", tmp_path) is False
 
 
 class TestInspectCsv:
@@ -48,13 +42,12 @@ class TestInspectCsv:
         assert "Columns:** 3" in result
         assert "name" in result
         assert "Alice" in result
-        assert "age" in result
 
     def test_missing_values(self, tmp_path: Path) -> None:
         csv_file = tmp_path / "gaps.csv"
         csv_file.write_text("a,b\n1,\n2,\n3,x\n")
         result = _inspect_csv(csv_file, sample_rows=1)
-        assert "2/3" in result  # 2 missing out of 3
+        assert "2/3" in result
 
     def test_empty_file(self, tmp_path: Path) -> None:
         csv_file = tmp_path / "empty.csv"
@@ -67,7 +60,7 @@ class TestInspectCsv:
         tsv_file.write_text("col1\tcol2\nval1\tval2\n")
         result = _inspect_csv(tsv_file, sample_rows=1, delimiter="\t")
         assert "col1" in result
-        assert "val1" in result
+        assert "TSV" in result
 
 
 class TestInspectJsonl:
@@ -77,14 +70,13 @@ class TestInspectJsonl:
         result = _inspect_jsonl(f, sample_rows=2)
         assert "data.jsonl" in result
         assert "text" in result
-        assert "label" in result
         assert "hello" in result
 
     def test_missing_fields(self, tmp_path: Path) -> None:
         f = tmp_path / "data.jsonl"
         f.write_text('{"a":1,"b":2}\n{"a":3}\n')
         result = _inspect_jsonl(f, sample_rows=1)
-        assert "1/2" in result  # b missing in 1 of 2 records
+        assert "1/2" in result
 
     def test_parse_errors(self, tmp_path: Path) -> None:
         f = tmp_path / "bad.jsonl"
@@ -99,6 +91,21 @@ class TestInspectJsonl:
         assert "Error" in result
 
 
+class TestInspectJson:
+    def test_json_array(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.json"
+        f.write_text(json.dumps([{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]))
+        result = _inspect_json(f, sample_rows=2)
+        assert "JSON array" in result
+        assert "a" in result
+
+    def test_json_falls_back_to_jsonl(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.json"
+        f.write_text('{"x":1}\n{"x":2}\n')
+        result = _inspect_json(f, sample_rows=1)
+        assert "JSONL" in result
+
+
 class TestInspectDatasetHandler:
     @pytest.mark.asyncio
     async def test_local_csv(self, tmp_path: Path) -> None:
@@ -107,7 +114,6 @@ class TestInspectDatasetHandler:
         settings = _settings(tmp_path)
         result = await inspect_dataset_handler({"source": "train.csv"}, settings)
         assert "train.csv" in result
-        assert "x" in result
 
     @pytest.mark.asyncio
     async def test_missing_source(self, tmp_path: Path) -> None:
@@ -134,6 +140,15 @@ class TestInspectDatasetHandler:
         settings = _settings(tmp_path)
         result = await inspect_dataset_handler({"source": "data.xlsx"}, settings)
         assert "Unsupported" in result
+
+    @pytest.mark.asyncio
+    async def test_hf_dataset_not_misrouted(self, tmp_path: Path) -> None:
+        """HF dataset names with extensions should route to HF, not local."""
+        settings = _settings(tmp_path)
+        with patch("app.tools.datasets._inspect_hf", new_callable=AsyncMock) as mock_hf:
+            mock_hf.return_value = "## user/data.csv (Hugging Face)"
+            result = await inspect_dataset_handler({"source": "user/data.csv"}, settings)
+        assert "Hugging Face" in result
 
     @pytest.mark.asyncio
     async def test_hf_dataset(self, tmp_path: Path) -> None:

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -1,0 +1,159 @@
+"""Tests for app.tools.datasets module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import AppPaths, AppSettings
+from app.tools.datasets import (
+    _inspect_csv,
+    _inspect_jsonl,
+    _looks_like_path,
+    get_tool_specs,
+    inspect_dataset_handler,
+)
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+class TestLooksLikePath:
+    def test_csv_extension(self, tmp_path: Path) -> None:
+        assert _looks_like_path("data/train.csv", tmp_path) is True
+
+    def test_jsonl_extension(self, tmp_path: Path) -> None:
+        assert _looks_like_path("data.jsonl", tmp_path) is True
+
+    def test_parquet_extension(self, tmp_path: Path) -> None:
+        assert _looks_like_path("model/data.parquet", tmp_path) is True
+
+    def test_hf_dataset_name(self, tmp_path: Path) -> None:
+        assert _looks_like_path("imdb", tmp_path) is False
+
+    def test_existing_file(self, tmp_path: Path) -> None:
+        (tmp_path / "myfile").write_text("x")
+        assert _looks_like_path("myfile", tmp_path) is True
+
+
+class TestInspectCsv:
+    def test_basic_csv(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name,age,city\nAlice,30,NYC\nBob,,London\n")
+        result = _inspect_csv(csv_file, sample_rows=2)
+        assert "data.csv" in result
+        assert "Columns:** 3" in result
+        assert "name" in result
+        assert "Alice" in result
+        assert "age" in result
+
+    def test_missing_values(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "gaps.csv"
+        csv_file.write_text("a,b\n1,\n2,\n3,x\n")
+        result = _inspect_csv(csv_file, sample_rows=1)
+        assert "2/3" in result  # 2 missing out of 3
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "empty.csv"
+        csv_file.write_text("")
+        result = _inspect_csv(csv_file, sample_rows=1)
+        assert "empty" in result.lower()
+
+    def test_tsv(self, tmp_path: Path) -> None:
+        tsv_file = tmp_path / "data.tsv"
+        tsv_file.write_text("col1\tcol2\nval1\tval2\n")
+        result = _inspect_csv(tsv_file, sample_rows=1, delimiter="\t")
+        assert "col1" in result
+        assert "val1" in result
+
+
+class TestInspectJsonl:
+    def test_basic_jsonl(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text('{"text":"hello","label":1}\n{"text":"world","label":0}\n')
+        result = _inspect_jsonl(f, sample_rows=2)
+        assert "data.jsonl" in result
+        assert "text" in result
+        assert "label" in result
+        assert "hello" in result
+
+    def test_missing_fields(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.jsonl"
+        f.write_text('{"a":1,"b":2}\n{"a":3}\n')
+        result = _inspect_jsonl(f, sample_rows=1)
+        assert "1/2" in result  # b missing in 1 of 2 records
+
+    def test_parse_errors(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.jsonl"
+        f.write_text('{"a":1}\nnot json\n{"a":2}\n')
+        result = _inspect_jsonl(f, sample_rows=1)
+        assert "Parse errors" in result
+
+    def test_empty_jsonl(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.jsonl"
+        f.write_text("\n\n")
+        result = _inspect_jsonl(f, sample_rows=1)
+        assert "Error" in result
+
+
+class TestInspectDatasetHandler:
+    @pytest.mark.asyncio
+    async def test_local_csv(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "train.csv"
+        csv_file.write_text("x,y\n1,2\n3,4\n")
+        settings = _settings(tmp_path)
+        result = await inspect_dataset_handler({"source": "train.csv"}, settings)
+        assert "train.csv" in result
+        assert "x" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_source(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        result = await inspect_dataset_handler({}, settings)
+        assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_file(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        result = await inspect_dataset_handler({"source": "nope.csv"}, settings)
+        assert "not found" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_workspace_escape(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        result = await inspect_dataset_handler({"source": "../../etc/passwd"}, settings)
+        assert "outside workspace" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_extension(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.xlsx"
+        f.write_text("binary")
+        settings = _settings(tmp_path)
+        result = await inspect_dataset_handler({"source": "data.xlsx"}, settings)
+        assert "Unsupported" in result
+
+    @pytest.mark.asyncio
+    async def test_hf_dataset(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        mock_responses = [
+            {"preview": True},
+            {"splits": [{"config": "default", "split": "train"}]},
+        ]
+        with patch("app.tools.datasets._hf_parallel", new_callable=AsyncMock) as mock_hf:
+            mock_hf.side_effect = [
+                mock_responses,
+                [{"dataset_info": {"features": {"text": {"dtype": "string"}}}}, {"rows": []}],
+            ]
+            result = await inspect_dataset_handler({"source": "username/dataset"}, settings)
+        assert "Hugging Face" in result
+
+
+class TestGetToolSpecs:
+    def test_spec(self) -> None:
+        specs = get_tool_specs()
+        assert len(specs) == 1
+        assert specs[0]["name"] == "inspect_dataset"
+        assert "source" in specs[0]["parameters"]["properties"]


### PR DESCRIPTION
## Summary

- Add `app/tools/datasets.py` with an `inspect_dataset` tool supporting local CSV, TSV, JSONL, and Parquet files plus Hugging Face datasets via the datasets-server API
- Local inspection reports columns, data types, row counts, missing value percentages, and sample rows without loading entire files into memory
- HF inspection queries is-valid, splits, info, and first-rows endpoints in parallel for speed
- Register the tool in the agent loop (read-only, no approval needed)
- Add 20 unit tests covering all local formats, error handling, workspace escape prevention, and mocked HF API flow

## Testing

- `python -m pytest tests/ -q` — 105 passed
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `python -m bandit -q -r app/`

## Notes

Parquet support requires optional `pyarrow` — the tool returns a clear error message if not installed rather than crashing. Local file scanning caps at 10k rows for stats to keep inspection fast on large files. HF API calls are made in parallel using `asyncio.gather`.

## Reference

Issue: #44
