### PR TITLE
ML-108 / Add docs search and fetch tool

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -768,8 +768,8 @@ def create_agent_loop(
 
 
 def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
-    """Create and populate the tool registry with workspace, reporting, and dataset tools."""
-    from app.tools import datasets, reporting, workspace
+    """Create and populate the tool registry with workspace, reporting, dataset, and docs tools."""
+    from app.tools import datasets, docs, reporting, workspace
 
     registry = ToolRegistry()
     workspace_specs = workspace.get_tool_specs()
@@ -800,6 +800,15 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
             handler=_make_dataset_handler(settings),
+        )
+        registry.register(tool_spec)
+
+    for spec in docs.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_docs_handler(spec["name"], settings),
         )
         registry.register(tool_spec)
 
@@ -842,5 +851,20 @@ def _make_dataset_handler(settings: AppSettings) -> ToolHandler:
 
     async def _handler(args: dict[str, Any]) -> str:
         return await datasets.inspect_dataset_handler(args, settings)
+
+    return _handler
+
+
+def _make_docs_handler(name: str, settings: AppSettings) -> ToolHandler:
+    """Create a handler for docs tools (search_docs or fetch_doc_page)."""
+    from app.tools import docs
+
+    handlers = {
+        "search_docs": docs.search_docs_handler,
+        "fetch_doc_page": docs.fetch_doc_page_handler,
+    }
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await handlers[name](args, settings)
 
     return _handler

--- a/app/tools/docs.py
+++ b/app/tools/docs.py
@@ -1,0 +1,389 @@
+"""Documentation search and fetch tools for HuggingFace and ML libraries."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+from bs4 import BeautifulSoup
+from whoosh.analysis import StemmingAnalyzer
+from whoosh.fields import ID, TEXT, Schema
+from whoosh.filedb.filestore import RamStorage
+from whoosh.qparser import MultifieldParser, OrGroup
+
+from app.config import AppSettings
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_RESULTS = 20
+MAX_RESULTS_CAP = 50
+
+DOC_ENDPOINTS = [
+    "hub",
+    "transformers",
+    "diffusers",
+    "datasets",
+    "smolagents",
+    "huggingface_hub",
+    "peft",
+    "accelerate",
+    "trl",
+    "tokenizers",
+    "evaluate",
+    "sentence_transformers",
+    "bitsandbytes",
+    "tgi",
+    "safetensors",
+    "optimum",
+    "autotrain",
+    "timm",
+]
+
+# ---------------------------------------------------------------------------
+# Caches
+# ---------------------------------------------------------------------------
+
+_docs_cache: dict[str, list[dict[str, str]]] = {}
+_index_cache: dict[str, tuple[Any, MultifieldParser]] = {}
+_cache_lock = asyncio.Lock()
+
+# ---------------------------------------------------------------------------
+# HF Documentation — Fetching
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_endpoint_docs(endpoint: str) -> list[dict[str, str]]:
+    """Fetch all doc pages for an endpoint by parsing sidebar and fetching each page."""
+    url = f"https://huggingface.co/docs/{endpoint}"
+
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        sidebar = soup.find("nav", class_=lambda x: x and "flex-auto" in x)
+        if not sidebar:
+            raise ValueError(f"Could not find navigation sidebar for '{endpoint}'")
+
+        nav_items = []
+        for link in sidebar.find_all("a", href=True):
+            href = link["href"]
+            page_url = f"https://huggingface.co{href}" if href.startswith("/") else href
+            nav_items.append({"title": link.get_text(strip=True), "url": page_url})
+
+        if not nav_items:
+            raise ValueError(f"No navigation links found for '{endpoint}'")
+
+        async def fetch_page(item: dict[str, str]) -> dict[str, str]:
+            md_url = f"{item['url']}.md"
+            try:
+                r = await client.get(md_url)
+                r.raise_for_status()
+                content = r.text.strip()
+                glimpse = content[:200] + "..." if len(content) > 200 else content
+            except Exception as e:
+                content, glimpse = "", f"[Could not fetch: {str(e)[:50]}]"
+            return {
+                "title": item["title"],
+                "url": item["url"],
+                "md_url": md_url,
+                "glimpse": glimpse,
+                "content": content,
+                "section": endpoint,
+            }
+
+        return list(await asyncio.gather(*[fetch_page(item) for item in nav_items]))
+
+
+async def _get_docs(endpoint: str) -> list[dict[str, str]]:
+    """Get docs for endpoint with caching."""
+    async with _cache_lock:
+        if endpoint in _docs_cache:
+            return _docs_cache[endpoint]
+
+    docs = await _fetch_endpoint_docs(endpoint)
+    async with _cache_lock:
+        _docs_cache[endpoint] = docs
+    return docs
+
+
+# ---------------------------------------------------------------------------
+# HF Documentation — Search
+# ---------------------------------------------------------------------------
+
+
+async def _build_search_index(endpoint: str, docs: list[dict[str, str]]) -> tuple[Any, MultifieldParser]:
+    """Build or retrieve cached Whoosh search index."""
+    async with _cache_lock:
+        if endpoint in _index_cache:
+            return _index_cache[endpoint]
+
+    analyzer = StemmingAnalyzer()
+    schema = Schema(
+        title=TEXT(stored=True, analyzer=analyzer),
+        url=ID(stored=True, unique=True),
+        md_url=ID(stored=True),
+        section=ID(stored=True),
+        glimpse=TEXT(stored=True, analyzer=analyzer),
+        content=TEXT(stored=False, analyzer=analyzer),
+    )
+    storage = RamStorage()
+    index = storage.create_index(schema)
+    writer = index.writer()
+    for doc in docs:
+        writer.add_document(
+            title=doc.get("title", ""),
+            url=doc.get("url", ""),
+            md_url=doc.get("md_url", ""),
+            section=doc.get("section", endpoint),
+            glimpse=doc.get("glimpse", ""),
+            content=doc.get("content", ""),
+        )
+    writer.commit()
+
+    parser = MultifieldParser(
+        ["title", "content"],
+        schema=schema,
+        fieldboosts={"title": 2.0, "content": 1.0},
+        group=OrGroup,
+    )
+
+    async with _cache_lock:
+        _index_cache[endpoint] = (index, parser)
+    return index, parser
+
+
+async def _search_docs(
+    endpoint: str, docs: list[dict[str, str]], query: str, limit: int
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Search docs using Whoosh full-text search."""
+    index, parser = await _build_search_index(endpoint, docs)
+
+    try:
+        query_obj = parser.parse(query)
+    except Exception:
+        return [], "Query contained unsupported syntax; showing default ordering."
+
+    with index.searcher() as searcher:
+        results = searcher.search(query_obj, limit=limit)
+        matches = [
+            {
+                "title": hit["title"],
+                "url": hit["url"],
+                "md_url": hit.get("md_url", ""),
+                "section": hit.get("section", endpoint),
+                "glimpse": hit["glimpse"],
+                "score": round(hit.score, 2),
+            }
+            for hit in results
+        ]
+
+    if not matches:
+        return [], "No matches found; showing default ordering."
+    return matches, None
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_results(
+    endpoint: str,
+    items: list[dict[str, Any]],
+    total: int,
+    query: str | None = None,
+    note: str | None = None,
+) -> str:
+    """Format search results as readable Markdown."""
+    base_url = f"https://huggingface.co/docs/{endpoint}"
+    out = f"## Documentation: {base_url}\n\n"
+
+    if query:
+        out += f"**Query:** '{query}' → {len(items)} result(s) out of {total} pages"
+        if note:
+            out += f" ({note})"
+        out += "\n\n"
+    else:
+        out += f"**Pages:** {len(items)} shown (total: {total})"
+        if note:
+            out += f" ({note})"
+        out += "\n\n"
+
+    for i, item in enumerate(items, 1):
+        out += f"### {i}. {item['title']}\n"
+        out += f"- **URL:** {item['url']}\n"
+        if query and "score" in item:
+            out += f"- **Relevance:** {item['score']:.2f}\n"
+        out += f"- **Preview:** {item['glimpse']}\n\n"
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tool Handlers
+# ---------------------------------------------------------------------------
+
+
+async def search_docs_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Explore HF documentation structure with optional search query."""
+    endpoint = args.get("endpoint", "").strip().lstrip("/")
+    query = args.get("query", "").strip() or None
+    max_results = args.get("max_results")
+
+    if not endpoint:
+        return "Error: No endpoint provided. Use one of: " + ", ".join(DOC_ENDPOINTS)
+
+    if endpoint not in DOC_ENDPOINTS:
+        return f"Error: Unknown endpoint '{endpoint}'. Available: {', '.join(DOC_ENDPOINTS)}"
+
+    try:
+        if max_results is not None:
+            max_results = int(max_results)
+            if max_results <= 0:
+                return "Error: max_results must be greater than zero."
+    except (TypeError, ValueError):
+        return "Error: max_results must be an integer."
+
+    try:
+        docs = await _get_docs(endpoint)
+        total = len(docs)
+
+        limit = min(max_results or DEFAULT_MAX_RESULTS, MAX_RESULTS_CAP)
+        limit_note = None
+        if max_results and max_results > MAX_RESULTS_CAP:
+            limit_note = f"Capped at {MAX_RESULTS_CAP}."
+
+        if query:
+            results, fallback_msg = await _search_docs(endpoint, docs, query, limit)
+            if not results:
+                results = [
+                    {
+                        "title": d["title"],
+                        "url": d["url"],
+                        "glimpse": d["glimpse"],
+                        "section": d.get("section", endpoint),
+                    }
+                    for d in docs[:limit]
+                ]
+        else:
+            results = [
+                {
+                    "title": d["title"],
+                    "url": d["url"],
+                    "glimpse": d["glimpse"],
+                    "section": d.get("section", endpoint),
+                }
+                for d in docs[:limit]
+            ]
+            fallback_msg = None
+
+        notes = []
+        if query and fallback_msg:
+            notes.append(fallback_msg)
+        if limit_note:
+            notes.append(limit_note)
+        note = "; ".join(notes) if notes else None
+
+        return _format_results(endpoint, results, total, query, note)
+
+    except httpx.HTTPStatusError as e:
+        return f"Error: HTTP {e.response.status_code} fetching docs for '{endpoint}'."
+    except httpx.RequestError as e:
+        return f"Error: Network request failed — {e}"
+    except ValueError as e:
+        return f"Error: {e}"
+    except Exception as e:
+        return f"Error fetching docs: {e}"
+
+
+async def fetch_doc_page_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Fetch full Markdown content of a documentation page."""
+    url = args.get("url", "").strip()
+    if not url:
+        return "Error: No URL provided."
+
+    if not url.endswith(".md"):
+        url = f"{url}.md"
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+        return f"## Documentation: {url}\n\n{resp.text}"
+    except httpx.HTTPStatusError as e:
+        return f"Error: HTTP {e.response.status_code} fetching {url}"
+    except httpx.RequestError as e:
+        return f"Error: Network request failed — {e}"
+    except Exception as e:
+        return f"Error fetching page: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Tool Specifications
+# ---------------------------------------------------------------------------
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return OpenAI-compatible tool specifications for docs tools."""
+    return [
+        {
+            "name": "search_docs",
+            "description": (
+                "Browse and search HuggingFace documentation. Discovers available pages "
+                "with 200-char previews. Use with a query to find relevant docs, "
+                "or without to browse the full structure. "
+                "Pattern: search_docs (find pages) → fetch_doc_page (get full content)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "endpoint": {
+                        "type": "string",
+                        "enum": DOC_ENDPOINTS,
+                        "description": (
+                            "Documentation section to search. Key endpoints: "
+                            "transformers, diffusers, datasets, peft, trl, accelerate, "
+                            "huggingface_hub, smolagents, tokenizers, evaluate, optimum."
+                        ),
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "Keyword search to rank and filter pages. "
+                            "Supports stemming (e.g. 'training' matches 'train')."
+                        ),
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Max results to return (default: 20, max: 50).",
+                    },
+                },
+                "required": ["endpoint"],
+            },
+        },
+        {
+            "name": "fetch_doc_page",
+            "description": (
+                "Fetch full Markdown content of an HF documentation page. "
+                "Use after search_docs to get complete content of a relevant page. "
+                "The .md extension is added automatically."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": (
+                            "Full URL to the documentation page from search_docs results. "
+                            "Example: 'https://huggingface.co/docs/trl/dpo_trainer'"
+                        ),
+                    },
+                },
+                "required": ["url"],
+            },
+        },
+    ]

--- a/app/tools/docs.py
+++ b/app/tools/docs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -306,8 +307,11 @@ async def fetch_doc_page_handler(args: dict[str, Any], settings: AppSettings) ->
     if not url:
         return "Error: No URL provided."
 
-    if not url.endswith(".md"):
-        url = f"{url}.md"
+    normalized_url = _normalize_hf_docs_url(url)
+    if normalized_url is None:
+        return "Error: fetch_doc_page only accepts HuggingFace docs URLs under https://huggingface.co/docs/."
+
+    url = normalized_url
 
     try:
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
@@ -320,6 +324,20 @@ async def fetch_doc_page_handler(args: dict[str, Any], settings: AppSettings) ->
         return f"Error: Network request failed — {e}"
     except Exception as e:
         return f"Error fetching page: {e}"
+
+
+def _normalize_hf_docs_url(url: str) -> str | None:
+    """Return a normalized HuggingFace docs .md URL, or None if the URL is not allowed."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "huggingface.co":
+        return None
+    if not parsed.path.startswith("/docs/"):
+        return None
+
+    normalized = parsed._replace(query="", fragment="").geturl()
+    if not normalized.endswith(".md"):
+        normalized = f"{normalized}.md"
+    return normalized
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.121.0,<0.122.0",
     "httpx>=0.28.0,<0.29.0",
+    "whoosh>=2.7.4,<3.0.0",
+    "beautifulsoup4>=4.12.0,<5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -175,6 +175,11 @@ class TestFetchDocPageHandler:
             call_url = mock_client.get.call_args[0][0]
         assert call_url.endswith(".md")
 
+    @pytest.mark.asyncio
+    async def test_rejects_non_hf_docs_urls(self, tmp_path: Path) -> None:
+        result = await fetch_doc_page_handler({"url": "https://example.com/docs/trl/sft"}, _settings(tmp_path))
+        assert "HuggingFace docs URLs" in result
+
 
 class TestGetToolSpecs:
     def test_returns_two_tools(self) -> None:

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,0 +1,199 @@
+"""Tests for app.tools.docs module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.config import AppPaths, AppSettings
+from app.tools.docs import (
+    DOC_ENDPOINTS,
+    _format_results,
+    _search_docs,
+    fetch_doc_page_handler,
+    get_tool_specs,
+    search_docs_handler,
+)
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+class TestFormatResults:
+    def test_no_query(self) -> None:
+        items = [{"title": "Overview", "url": "https://hf.co/docs/trl", "glimpse": "TRL intro..."}]
+        result = _format_results("trl", items, total=10)
+        assert "Documentation" in result
+        assert "Overview" in result
+        assert "1 shown" in result
+
+    def test_with_query(self) -> None:
+        items = [{"title": "DPO Trainer", "url": "https://hf.co/docs/trl/dpo", "glimpse": "DPO...", "score": 3.5}]
+        result = _format_results("trl", items, total=50, query="dpo")
+        assert "dpo" in result
+        assert "3.50" in result
+        assert "1 result" in result
+
+
+class TestSearchDocs:
+    @pytest.mark.asyncio
+    async def test_search_indexed_docs(self) -> None:
+        docs = [
+            {
+                "title": "LoRA Training",
+                "url": "https://hf.co/docs/peft/lora",
+                "md_url": "",
+                "glimpse": "LoRA guide",
+                "content": "Low-rank adaptation training tutorial for PEFT",
+                "section": "peft",
+            },
+            {
+                "title": "Installation",
+                "url": "https://hf.co/docs/peft/install",
+                "md_url": "",
+                "glimpse": "Install peft",
+                "content": "pip install peft",
+                "section": "peft",
+            },
+        ]
+        results, msg = await _search_docs("peft", docs, "lora training", limit=5)
+        assert len(results) >= 1
+        assert results[0]["title"] == "LoRA Training"
+        assert msg is None
+
+    @pytest.mark.asyncio
+    async def test_no_matches(self) -> None:
+        docs = [
+            {"title": "Install", "url": "u", "md_url": "", "glimpse": "g", "content": "pip install", "section": "x"},
+        ]
+        results, msg = await _search_docs("x", docs, "xyznonexistent", limit=5)
+        assert results == []
+        assert msg is not None
+
+
+class TestSearchDocsHandler:
+    @pytest.mark.asyncio
+    async def test_missing_endpoint(self, tmp_path: Path) -> None:
+        result = await search_docs_handler({}, _settings(tmp_path))
+        assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_endpoint(self, tmp_path: Path) -> None:
+        result = await search_docs_handler({"endpoint": "nonexistent"}, _settings(tmp_path))
+        assert "Unknown endpoint" in result
+
+    @pytest.mark.asyncio
+    async def test_valid_endpoint_mocked(self, tmp_path: Path) -> None:
+        mock_docs = [
+            {
+                "title": "Quickstart",
+                "url": "https://hf.co/docs/trl/quickstart",
+                "md_url": "",
+                "glimpse": "Get started with TRL",
+                "content": "TRL quickstart guide",
+                "section": "trl",
+            },
+        ]
+        with patch("app.tools.docs._get_docs", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_docs
+            result = await search_docs_handler({"endpoint": "trl"}, _settings(tmp_path))
+        assert "Quickstart" in result
+        assert "Documentation" in result
+
+    @pytest.mark.asyncio
+    async def test_with_query_mocked(self, tmp_path: Path) -> None:
+        mock_docs = [
+            {
+                "title": "DPO",
+                "url": "u1",
+                "md_url": "",
+                "glimpse": "DPO trainer",
+                "content": "Direct preference optimization trainer",
+                "section": "trl",
+            },
+            {
+                "title": "SFT",
+                "url": "u2",
+                "md_url": "",
+                "glimpse": "SFT trainer",
+                "content": "Supervised fine-tuning",
+                "section": "trl",
+            },
+        ]
+        with patch("app.tools.docs._get_docs", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_docs
+            result = await search_docs_handler({"endpoint": "trl", "query": "dpo"}, _settings(tmp_path))
+        assert "DPO" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_results(self, tmp_path: Path) -> None:
+        result = await search_docs_handler({"endpoint": "trl", "max_results": -1}, _settings(tmp_path))
+        assert "Error" in result
+
+
+class TestFetchDocPageHandler:
+    @pytest.mark.asyncio
+    async def test_missing_url(self, tmp_path: Path) -> None:
+        result = await fetch_doc_page_handler({}, _settings(tmp_path))
+        assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_fetch(self, tmp_path: Path) -> None:
+        mock_resp = MagicMock()
+        mock_resp.text = "# DPO Trainer\n\nContent here."
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            result = await fetch_doc_page_handler(
+                {"url": "https://huggingface.co/docs/trl/dpo_trainer"}, _settings(tmp_path)
+            )
+        assert "DPO Trainer" in result
+
+    @pytest.mark.asyncio
+    async def test_appends_md_extension(self, tmp_path: Path) -> None:
+        mock_resp = MagicMock()
+        mock_resp.text = "content"
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            await fetch_doc_page_handler({"url": "https://huggingface.co/docs/trl/sft"}, _settings(tmp_path))
+            call_url = mock_client.get.call_args[0][0]
+        assert call_url.endswith(".md")
+
+
+class TestGetToolSpecs:
+    def test_returns_two_tools(self) -> None:
+        specs = get_tool_specs()
+        assert len(specs) == 2
+        names = {s["name"] for s in specs}
+        assert "search_docs" in names
+        assert "fetch_doc_page" in names
+
+    def test_endpoints_enum(self) -> None:
+        specs = get_tool_specs()
+        search_spec = next(s for s in specs if s["name"] == "search_docs")
+        assert "enum" in search_spec["parameters"]["properties"]["endpoint"]
+        assert "transformers" in search_spec["parameters"]["properties"]["endpoint"]["enum"]
+
+
+class TestDocEndpoints:
+    def test_key_endpoints_present(self) -> None:
+        assert "transformers" in DOC_ENDPOINTS
+        assert "datasets" in DOC_ENDPOINTS
+        assert "peft" in DOC_ENDPOINTS
+        assert "trl" in DOC_ENDPOINTS


### PR DESCRIPTION
## Summary

- Add `app/tools/docs.py` with `search_docs` and `fetch_doc_page` tools using Whoosh full-text search and BeautifulSoup sidebar parsing — same architecture as `ml-intern/agent/tools/docs_tools.py`
- `search_docs` crawls HF doc sidebar, fetches each page as Markdown, builds an in-memory Whoosh index with stemming and title-boosted ranking, then returns top matches with 200-char previews
- `fetch_doc_page` fetches full Markdown content of any HF documentation URL (auto-appends `.md`)
- Support 18 HF documentation endpoints: transformers, datasets, peft, trl, accelerate, huggingface_hub, diffusers, smolagents, etc.
- Register both tools in the agent loop (read-only, no approval needed)
- Add `whoosh>=2.7.4` and `beautifulsoup4>=4.12.0` to project dependencies
- Add 15 unit tests covering Whoosh indexing, result formatting, handler validation, fetch behavior, and tool spec structure

## Testing

- `python -m pytest tests/ -q` — 120 passed
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `python -m bandit -q -r app/`

## Notes

Docs are cached in memory after first fetch — subsequent searches for the same endpoint are instant. The Whoosh index lives in RAM (no disk I/O) via `RamStorage`. Pattern for the agent: `search_docs` to discover relevant pages → `fetch_doc_page` to get full content.

## Reference

Issue: #46
