### PR TITLE
ML-109 / Add paper metadata reader

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -769,7 +769,7 @@ def create_agent_loop(
 
 def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
     """Create and populate the tool registry with workspace, reporting, dataset, and docs tools."""
-    from app.tools import datasets, docs, reporting, workspace
+    from app.tools import datasets, docs, papers, reporting, workspace
 
     registry = ToolRegistry()
     workspace_specs = workspace.get_tool_specs()
@@ -812,6 +812,15 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
         )
         registry.register(tool_spec)
 
+    for spec in papers.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_papers_handler(settings),
+        )
+        registry.register(tool_spec)
+
     return registry
 
 
@@ -851,6 +860,16 @@ def _make_dataset_handler(settings: AppSettings) -> ToolHandler:
 
     async def _handler(args: dict[str, Any]) -> str:
         return await datasets.inspect_dataset_handler(args, settings)
+
+    return _handler
+
+
+def _make_papers_handler(settings: AppSettings) -> ToolHandler:
+    """Create a handler for the paper_details tool."""
+    from app.tools import papers
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await papers.paper_details_handler(args, settings)
 
     return _handler
 

--- a/app/tools/papers.py
+++ b/app/tools/papers.py
@@ -1,0 +1,132 @@
+"""Paper metadata reader for Hugging Face papers."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from app.config import AppSettings
+
+HF_API = "https://huggingface.co/api"
+
+MAX_AUTHOR_COUNT = 10
+MAX_SUMMARY_LEN = 500
+
+
+def _normalize_arxiv_id(value: str) -> str:
+    """Normalize raw IDs and paper URLs to an arXiv identifier."""
+    candidate = value.strip()
+    if not candidate:
+        return ""
+
+    if "://" in candidate:
+        parsed = urlparse(candidate)
+        candidate = parsed.path.rstrip("/").split("/")[-1]
+
+    for prefix in ("arxiv:", "ArXiv:"):
+        if candidate.startswith(prefix):
+            candidate = candidate[len(prefix) :]
+
+    return candidate.strip().rstrip("/")
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
+
+
+def _format_paper_details(paper: dict[str, Any]) -> str:
+    """Format Hugging Face paper metadata as readable Markdown."""
+    arxiv_id = paper.get("id", "")
+    title = paper.get("title", "Unknown")
+    upvotes = paper.get("upvotes", 0)
+    summary = paper.get("summary") or ""
+    ai_summary = paper.get("ai_summary") or ""
+    keywords = paper.get("ai_keywords") or []
+    github = paper.get("githubRepo") or ""
+    stars = paper.get("githubStars") or 0
+    authors = paper.get("authors") or []
+
+    lines = [f"# {title}"]
+    lines.append(f"**arxiv_id:** {arxiv_id} | **upvotes:** {upvotes}")
+    lines.append(f"https://huggingface.co/papers/{arxiv_id}")
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}")
+
+    if authors:
+        names = [author.get("name", "") for author in authors[:MAX_AUTHOR_COUNT]]
+        author_str = ", ".join(name for name in names if name)
+        if len(authors) > MAX_AUTHOR_COUNT:
+            author_str += f" (+{len(authors) - MAX_AUTHOR_COUNT} more)"
+        if author_str:
+            lines.append(f"**Authors:** {author_str}")
+
+    if keywords:
+        lines.append(f"**Keywords:** {', '.join(keywords)}")
+    if github:
+        lines.append(f"**GitHub:** {github} ({stars} stars)")
+    if ai_summary:
+        lines.append(f"\n## AI Summary\n{ai_summary}")
+    if summary:
+        lines.append(f"\n## Abstract\n{_truncate(summary, MAX_SUMMARY_LEN)}")
+
+    lines.append(
+        "\n**Next:** Use this metadata before citation graph or paper reading tasks."
+    )
+    return "\n".join(lines)
+
+
+async def _fetch_paper(arxiv_id: str) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(f"{HF_API}/papers/{arxiv_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def paper_details_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Fetch and format Hugging Face paper metadata."""
+    raw_arxiv_id = args.get("arxiv_id", "")
+    arxiv_id = _normalize_arxiv_id(raw_arxiv_id)
+    if not arxiv_id:
+        return "Error: No arxiv_id provided. Pass an arXiv ID or paper URL."
+
+    try:
+        paper = await _fetch_paper(arxiv_id)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return f"Error: Paper {arxiv_id} was not found on Hugging Face."
+        return f"Error fetching paper {arxiv_id}: HTTP {exc.response.status_code}"
+    except httpx.RequestError as exc:
+        return f"Error fetching paper {arxiv_id}: {exc}"
+    except Exception as exc:
+        return f"Error fetching paper {arxiv_id}: {exc}"
+
+    return _format_paper_details(paper)
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return the paper metadata tool specification."""
+    return [
+        {
+            "name": "paper_details",
+            "description": (
+                "Fetch Hugging Face paper metadata for an arXiv ID. "
+                "Returns title, authors, keywords, abstract or summary, and useful links."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "arxiv_id": {
+                        "type": "string",
+                        "description": (
+                            "ArXiv paper ID or paper URL, for example '2305.18290' or "
+                            "'https://huggingface.co/papers/2305.18290'."
+                        ),
+                    },
+                },
+                "required": ["arxiv_id"],
+            },
+        }
+    ]

--- a/app/tools/papers.py
+++ b/app/tools/papers.py
@@ -15,9 +15,12 @@ MAX_AUTHOR_COUNT = 10
 MAX_SUMMARY_LEN = 500
 
 
-def _normalize_arxiv_id(value: str) -> str:
+def _normalize_arxiv_id(value: Any) -> str:
     """Normalize raw IDs and paper URLs to an arXiv identifier."""
-    candidate = value.strip()
+    if value is None:
+        return ""
+
+    candidate = str(value).strip()
     if not candidate:
         return ""
 

--- a/app/tools/papers.py
+++ b/app/tools/papers.py
@@ -75,9 +75,7 @@ def _format_paper_details(paper: dict[str, Any]) -> str:
     if summary:
         lines.append(f"\n## Abstract\n{_truncate(summary, MAX_SUMMARY_LEN)}")
 
-    lines.append(
-        "\n**Next:** Use this metadata before citation graph or paper reading tasks."
-    )
+    lines.append("\n**Next:** Use this metadata before citation graph or paper reading tasks.")
     return "\n".join(lines)
 
 

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from app.agent.llm import LLMResponse, ToolCall
-from app.agent.loop import AgentLoop
+from app.agent.loop import AgentLoop, _create_tool_registry
 from app.config import AppPaths, AppSettings
 from app.storage.repository import SQLiteRepository
 from app.tools.registry import ToolRegistry, ToolSpec
@@ -52,6 +52,12 @@ def _registry(tool_output: str, tool_calls: list[dict[str, object]]) -> ToolRegi
         )
     )
     return registry
+
+
+def test_tool_registry_includes_paper_details(tmp_path: Path) -> None:
+    registry = _create_tool_registry(_settings(tmp_path))
+
+    assert registry.get("paper_details").name == "paper_details"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_papers.py
+++ b/tests/unit/test_papers.py
@@ -1,0 +1,111 @@
+"""Tests for app.tools.papers module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.config import AppPaths, AppSettings
+from app.tools.papers import (
+    _format_paper_details,
+    _normalize_arxiv_id,
+    get_tool_specs,
+    paper_details_handler,
+)
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+def test_normalize_arxiv_id_from_urls() -> None:
+    assert _normalize_arxiv_id("https://huggingface.co/papers/2305.18290") == "2305.18290"
+    assert _normalize_arxiv_id("https://arxiv.org/abs/2305.18290") == "2305.18290"
+
+
+def test_format_paper_details() -> None:
+    paper = {
+        "id": "2305.18290",
+        "title": "A Sample Paper",
+        "upvotes": 42,
+        "summary": "Abstract text that explains the paper.",
+        "ai_summary": "Shorter AI summary.",
+        "ai_keywords": ["ml", "agents"],
+        "githubRepo": "org/repo",
+        "githubStars": 99,
+        "authors": [{"name": "Ada"}, {"name": "Bob"}],
+    }
+
+    result = _format_paper_details(paper)
+
+    assert "A Sample Paper" in result
+    assert "2305.18290" in result
+    assert "Ada, Bob" in result
+    assert "ml, agents" in result
+    assert "org/repo" in result
+    assert "AI Summary" in result
+    assert "Abstract" in result
+
+
+@pytest.mark.asyncio
+async def test_paper_details_handler_success(tmp_path: Path) -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "id": "2305.18290",
+        "title": "A Sample Paper",
+        "upvotes": 10,
+        "summary": "Paper abstract.",
+        "authors": [{"name": "Ada"}],
+    }
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await paper_details_handler(
+            {"arxiv_id": "https://huggingface.co/papers/2305.18290"},
+            _settings(tmp_path),
+        )
+
+    assert "A Sample Paper" in result
+    assert "Ada" in result
+    assert "huggingface.co/papers/2305.18290" in result
+
+
+@pytest.mark.asyncio
+async def test_paper_details_handler_missing_id(tmp_path: Path) -> None:
+    result = await paper_details_handler({}, _settings(tmp_path))
+
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_paper_details_handler_not_found(tmp_path: Path) -> None:
+    request = httpx.Request("GET", "https://huggingface.co/api/papers/2305.18290")
+    response = httpx.Response(404, request=request)
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await paper_details_handler({"arxiv_id": "2305.18290"}, _settings(tmp_path))
+
+    assert "not found" in result.lower()
+
+
+def test_get_tool_specs() -> None:
+    specs = get_tool_specs()
+
+    assert len(specs) == 1
+    assert specs[0]["name"] == "paper_details"
+    assert "arxiv_id" in specs[0]["parameters"]["properties"]

--- a/tests/unit/test_papers.py
+++ b/tests/unit/test_papers.py
@@ -24,6 +24,7 @@ def _settings(tmp_path: Path) -> AppSettings:
 def test_normalize_arxiv_id_from_urls() -> None:
     assert _normalize_arxiv_id("https://huggingface.co/papers/2305.18290") == "2305.18290"
     assert _normalize_arxiv_id("https://arxiv.org/abs/2305.18290") == "2305.18290"
+    assert _normalize_arxiv_id(None) == ""
 
 
 def test_format_paper_details() -> None:


### PR DESCRIPTION
## Summary
- add a Hugging Face paper metadata reader for arXiv IDs and paper URLs
- format paper metadata with title, authors, keywords, summary, and helpful links
- register the new `paper_details` tool in the agent registry and cover it with unit tests

## Testing
- `ruff check app tests`
- `pytest -q`

## Notes
This is the first paper-oriented helper in the ML tool stack and stays intentionally small for ML-109.

## Reference
Fixes #48