### PR TITLE
ML-113 / Add native provider adapters behind LLM client interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,22 @@
 # Core model configuration
 # -----------------------------------------------------------------------------
 
-# Any OpenAI-compatible endpoint can be used here.
+# Provider family for the LLM client.
+# Examples:
+# - openai_compatible
+# - anthropic
+# - gemini
+# - xai
+LLM_PROVIDER=openai_compatible
+
+# Base URL for the configured endpoint. Native providers use their own default
+# if you leave this unset.
 # Examples:
 # - OpenAI: https://api.openai.com/v1
+# - Anthropic: https://api.anthropic.com/v1
+# - Gemini: https://generativelanguage.googleapis.com/v1beta
 # - OpenRouter: https://openrouter.ai/api/v1
+# - xAI: https://api.x.ai/v1
 # - Groq: https://api.groq.com/openai/v1
 # - DeepInfra: https://api.deepinfra.com/v1/openai
 # - Local vLLM / gateway: http://localhost:8000/v1

--- a/app/agent/llm.py
+++ b/app/agent/llm.py
@@ -556,7 +556,7 @@ class LLMClient:
             tools=tools,
             tool_choice=tool_choice,
             stream=stream,
-            model=model,
+            model=model or self.default_model,
             temperature=temperature,
             max_tokens=max_tokens,
         )

--- a/app/agent/llm.py
+++ b/app/agent/llm.py
@@ -1,4 +1,4 @@
-"""OpenAI-compatible LLM client and wire-format parsers."""
+"""Provider-aware LLM client and wire-format parsers."""
 
 from __future__ import annotations
 
@@ -54,6 +54,14 @@ class LLMResponse:
     raw: JsonDict | None = None
 
 
+@dataclass(frozen=True)
+class ProviderRequest:
+    path: str
+    body: JsonDict
+    headers: dict[str, str]
+    params: dict[str, str] | None = None
+
+
 class LLMError(RuntimeError):
     """Base error for LLM client failures."""
 
@@ -62,8 +70,437 @@ class LLMProtocolError(LLMError):
     """Raised when the remote response does not match the expected schema."""
 
 
+def normalize_provider_name(value: str | None) -> str:
+    normalized = (value or "openai_compatible").strip().lower().replace("-", "_")
+    if normalized in {"openai", "openai_compatible", "compatible"}:
+        return "openai_compatible"
+    if normalized in {"anthropic", "claude"}:
+        return "anthropic"
+    if normalized in {"gemini", "google_gemini", "google"}:
+        return "gemini"
+    if normalized in {"xai", "grok"}:
+        return "xai"
+    if normalized == "minimax":
+        return "minimax"
+    if normalized == "kimi":
+        return "kimi"
+    if normalized in {"zai", "z_ai", "z"}:
+        return "zai"
+    raise ValueError(f"Unsupported LLM provider: {value!r}")
+
+
+class _ProviderAdapter:
+    supports_streaming = False
+
+    def build_request(
+        self,
+        *,
+        messages: list[JsonDict],
+        tools: list[JsonDict] | None,
+        tool_choice: str | JsonDict | None,
+        stream: bool,
+        model: str,
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> ProviderRequest:
+        raise NotImplementedError
+
+    def parse_response(self, payload: JsonDict) -> LLMResponse:
+        raise NotImplementedError
+
+
+class _OpenAICompatibleAdapter(_ProviderAdapter):
+    supports_streaming = True
+
+    def __init__(self, *, base_url: str, api_key: str | None, default_model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.default_model = default_model
+
+    def build_request(
+        self,
+        *,
+        messages: list[JsonDict],
+        tools: list[JsonDict] | None,
+        tool_choice: str | JsonDict | None,
+        stream: bool,
+        model: str,
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> ProviderRequest:
+        payload: JsonDict = {
+            "model": model or self.default_model,
+            "messages": messages,
+            "stream": stream,
+        }
+        if tools:
+            payload["tools"] = tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return ProviderRequest(path="/chat/completions", body=payload, headers=headers)
+
+    def parse_response(self, payload: JsonDict) -> LLMResponse:
+        return parse_chat_completion(payload)
+
+
+class _AnthropicAdapter(_ProviderAdapter):
+    def __init__(self, *, base_url: str, api_key: str | None, default_model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.default_model = default_model
+
+    def build_request(
+        self,
+        *,
+        messages: list[JsonDict],
+        tools: list[JsonDict] | None,
+        tool_choice: str | JsonDict | None,
+        stream: bool,
+        model: str,
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> ProviderRequest:
+        system_parts, anthropic_messages = _anthropic_messages(messages)
+        payload: JsonDict = {
+            "model": model or self.default_model,
+            "messages": anthropic_messages,
+            "max_tokens": max_tokens or 2048,
+        }
+        if system_parts:
+            payload["system"] = "\n\n".join(system_parts)
+        if tools:
+            payload["tools"] = [_anthropic_tool_spec(tool) for tool in tools]
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        if temperature is not None:
+            payload["temperature"] = temperature
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+        return ProviderRequest(path="/messages", body=payload, headers=headers)
+
+    def parse_response(self, payload: JsonDict) -> LLMResponse:
+        content_parts = payload.get("content") or []
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+
+        for item in content_parts:
+            part_type = item.get("type")
+            if part_type == "text":
+                text_parts.append(item.get("text") or "")
+            elif part_type == "tool_use":
+                arguments = item.get("input") or {}
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments, separators=(",", ":"))
+                tool_calls.append(
+                    ToolCall(
+                        id=item.get("id", ""),
+                        type="function",
+                        name=item.get("name", ""),
+                        arguments=arguments,
+                    )
+                )
+
+        usage_data = payload.get("usage") or {}
+        usage = None
+        if usage_data:
+            usage = Usage(
+                prompt_tokens=int(usage_data.get("input_tokens", 0) or 0),
+                completion_tokens=int(usage_data.get("output_tokens", 0) or 0),
+                total_tokens=int(usage_data.get("input_tokens", 0) or 0) + int(usage_data.get("output_tokens", 0) or 0),
+            )
+
+        for tool_call in tool_calls:
+            tool_call.arguments_as_json()
+
+        return LLMResponse(
+            model=payload.get("model", ""),
+            content="".join(text_parts),
+            tool_calls=tool_calls,
+            finish_reason=payload.get("stop_reason"),
+            usage=usage,
+            response_id=payload.get("id"),
+            raw=payload,
+        )
+
+
+class _GeminiAdapter(_ProviderAdapter):
+    def __init__(self, *, base_url: str, api_key: str | None, default_model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.default_model = default_model
+
+    def build_request(
+        self,
+        *,
+        messages: list[JsonDict],
+        tools: list[JsonDict] | None,
+        tool_choice: str | JsonDict | None,
+        stream: bool,
+        model: str,
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> ProviderRequest:
+        system_parts, contents = _gemini_contents(messages)
+        payload: JsonDict = {
+            "contents": contents,
+        }
+        if system_parts:
+            payload["systemInstruction"] = {"parts": [{"text": "\n\n".join(system_parts)}]}
+        if tools:
+            payload["tools"] = [{"functionDeclarations": [_gemini_function(tool) for tool in tools]}]
+        generation_config: JsonDict = {}
+        if temperature is not None:
+            generation_config["temperature"] = temperature
+        if max_tokens is not None:
+            generation_config["maxOutputTokens"] = max_tokens
+        elif stream:
+            generation_config["maxOutputTokens"] = 2048
+        if generation_config:
+            payload["generationConfig"] = generation_config
+        if tool_choice is not None:
+            payload["toolConfig"] = _gemini_tool_config(tool_choice)
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        params = {"key": self.api_key} if self.api_key else None
+        model_path = model or self.default_model
+        if not model_path.startswith("models/"):
+            model_path = f"models/{model_path}"
+        return ProviderRequest(
+            path=f"/{model_path}:generateContent",
+            body=payload,
+            headers=headers,
+            params=params,
+        )
+
+    def parse_response(self, payload: JsonDict) -> LLMResponse:
+        candidates = payload.get("candidates") or []
+        if not candidates:
+            raise LLMProtocolError("Gemini response did not include candidates.")
+
+        candidate = candidates[0]
+        content = candidate.get("content") or {}
+        parts = content.get("parts") or []
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+
+        for index, part in enumerate(parts):
+            if "text" in part:
+                text_parts.append(part.get("text") or "")
+                continue
+            function_call = part.get("functionCall") or part.get("function_call") or {}
+            if function_call:
+                arguments = (
+                    function_call.get("args") or function_call.get("arguments") or function_call.get("input") or {}
+                )
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments, separators=(",", ":"))
+                tool_calls.append(
+                    ToolCall(
+                        id=function_call.get("id") or f"gemini-tool-{index}",
+                        type="function",
+                        name=function_call.get("name", ""),
+                        arguments=arguments,
+                    )
+                )
+
+        usage_data = payload.get("usageMetadata") or {}
+        usage = None
+        if usage_data:
+            prompt_tokens = int(usage_data.get("promptTokenCount", 0) or 0)
+            completion_tokens = int(usage_data.get("candidatesTokenCount", 0) or 0)
+            total_tokens = int(usage_data.get("totalTokenCount", 0) or 0)
+            if not total_tokens:
+                total_tokens = prompt_tokens + completion_tokens
+            usage = Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+
+        for tool_call in tool_calls:
+            tool_call.arguments_as_json()
+
+        return LLMResponse(
+            model=payload.get("model", ""),
+            content="".join(text_parts),
+            tool_calls=tool_calls,
+            finish_reason=candidate.get("finishReason") or candidate.get("finish_reason"),
+            usage=usage,
+            response_id=payload.get("responseId") or payload.get("id"),
+            raw=payload,
+        )
+
+
+def build_provider_adapter(
+    *,
+    provider: str,
+    base_url: str,
+    api_key: str | None,
+    default_model: str,
+) -> _ProviderAdapter:
+    normalized = normalize_provider_name(provider)
+    if normalized == "anthropic":
+        return _AnthropicAdapter(base_url=base_url, api_key=api_key, default_model=default_model)
+    if normalized == "gemini":
+        return _GeminiAdapter(base_url=base_url, api_key=api_key, default_model=default_model)
+    return _OpenAICompatibleAdapter(base_url=base_url, api_key=api_key, default_model=default_model)
+
+
+def _anthropic_tool_spec(tool: JsonDict) -> JsonDict:
+    function = tool.get("function") or {}
+    return {
+        "name": function.get("name", ""),
+        "description": function.get("description", ""),
+        "input_schema": function.get("parameters")
+        or function.get("input_schema")
+        or {"type": "object", "properties": {}},
+    }
+
+
+def _anthropic_messages(messages: list[JsonDict]) -> tuple[list[str], list[JsonDict]]:
+    system_parts: list[str] = []
+    converted: list[JsonDict] = []
+
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content") or ""
+        if role == "system":
+            if content:
+                system_parts.append(str(content))
+            continue
+
+        if role == "assistant" and message.get("tool_calls"):
+            blocks: list[JsonDict] = []
+            if content:
+                blocks.append({"type": "text", "text": str(content)})
+            for tool_call in message.get("tool_calls") or []:
+                arguments = ((tool_call.get("function") or {}).get("arguments")) or "{}"
+                try:
+                    parsed_arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    parsed_arguments = {"__raw_arguments__": arguments}
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": tool_call.get("id", ""),
+                        "name": ((tool_call.get("function") or {}).get("name") or ""),
+                        "input": parsed_arguments,
+                    }
+                )
+            converted.append({"role": "assistant", "content": blocks})
+            continue
+
+        if role == "tool":
+            converted.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": message.get("tool_call_id", ""),
+                            "content": [{"type": "text", "text": str(content)}],
+                        }
+                    ],
+                }
+            )
+            continue
+
+        converted.append({"role": role, "content": str(content)})
+
+    return system_parts, converted
+
+
+def _gemini_tool_config(tool_choice: str | JsonDict) -> JsonDict:
+    if isinstance(tool_choice, str):
+        mode = "AUTO" if tool_choice == "auto" else tool_choice.upper()
+        return {"functionCallingConfig": {"mode": mode}}
+    return {"functionCallingConfig": tool_choice}
+
+
+def _gemini_function(tool: JsonDict) -> JsonDict:
+    function = tool.get("function") or {}
+    return {
+        "name": function.get("name", ""),
+        "description": function.get("description", ""),
+        "parameters": function.get("parameters") or {"type": "object", "properties": {}},
+    }
+
+
+def _gemini_contents(messages: list[JsonDict]) -> tuple[list[str], list[JsonDict]]:
+    system_parts: list[str] = []
+    contents: list[JsonDict] = []
+
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content") or ""
+        if role == "system":
+            if content:
+                system_parts.append(str(content))
+            continue
+
+        if role == "assistant" and message.get("tool_calls"):
+            parts: list[JsonDict] = []
+            if content:
+                parts.append({"text": str(content)})
+            for tool_call in message.get("tool_calls") or []:
+                arguments = ((tool_call.get("function") or {}).get("arguments")) or "{}"
+                try:
+                    parsed_arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    parsed_arguments = {"__raw_arguments__": arguments}
+                parts.append(
+                    {
+                        "functionCall": {
+                            "id": tool_call.get("id", ""),
+                            "name": ((tool_call.get("function") or {}).get("name") or ""),
+                            "args": parsed_arguments,
+                        }
+                    }
+                )
+            contents.append({"role": "model", "parts": parts})
+            continue
+
+        if role == "tool":
+            contents.append(
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "functionResponse": {
+                                "name": message.get("name", ""),
+                                "id": message.get("tool_call_id", ""),
+                                "response": {"output": str(content)},
+                            }
+                        }
+                    ],
+                }
+            )
+            continue
+
+        contents.append({"role": "user" if role == "user" else "model", "parts": [{"text": str(content)}]})
+
+    return system_parts, contents
+
+
 class LLMClient:
-    """Small provider-neutral client for OpenAI-compatible chat completions."""
+    """Provider-aware client that keeps one stable internal interface."""
 
     def __init__(
         self,
@@ -71,14 +508,22 @@ class LLMClient:
         base_url: str,
         api_key: str | None,
         default_model: str,
+        provider: str = "openai_compatible",
         timeout_seconds: int = 600,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.default_model = default_model
+        self.provider = normalize_provider_name(provider)
         self.timeout_seconds = timeout_seconds
         self._http_client = http_client
+        self._adapter = build_provider_adapter(
+            provider=self.provider,
+            base_url=self.base_url,
+            api_key=self.api_key,
+            default_model=self.default_model,
+        )
 
     @classmethod
     def from_settings(
@@ -91,6 +536,7 @@ class LLMClient:
             base_url=settings.llm.base_url,
             api_key=settings.llm.api_key,
             default_model=settings.llm.model,
+            provider=settings.llm.provider,
             timeout_seconds=settings.llm.timeout_seconds,
             http_client=http_client,
         )
@@ -105,7 +551,7 @@ class LLMClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
     ) -> LLMResponse:
-        payload = self._build_payload(
+        request = self._adapter.build_request(
             messages=messages,
             tools=tools,
             tool_choice=tool_choice,
@@ -115,64 +561,31 @@ class LLMClient:
             max_tokens=max_tokens,
         )
 
-        if stream:
-            return await self._chat_stream(payload)
-        return await self._chat_once(payload)
+        if stream and self._adapter.supports_streaming:
+            return await self._chat_stream(request)
+        return await self._chat_once(request)
 
-    def _build_payload(
-        self,
-        *,
-        messages: list[JsonDict],
-        tools: list[JsonDict] | None,
-        tool_choice: str | JsonDict | None,
-        stream: bool,
-        model: str | None,
-        temperature: float | None,
-        max_tokens: int | None,
-    ) -> JsonDict:
-        payload: JsonDict = {
-            "model": model or self.default_model,
-            "messages": messages,
-            "stream": stream,
-        }
-        if tools:
-            payload["tools"] = tools
-        if tool_choice is not None:
-            payload["tool_choice"] = tool_choice
-        if temperature is not None:
-            payload["temperature"] = temperature
-        if max_tokens is not None:
-            payload["max_tokens"] = max_tokens
-        return payload
-
-    def _headers(self) -> dict[str, str]:
-        headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-        return headers
-
-    async def _chat_once(self, payload: JsonDict) -> LLMResponse:
+    async def _chat_once(self, request: ProviderRequest) -> LLMResponse:
         async with self._client() as client:
             response = await client.post(
-                "/chat/completions",
-                json=payload,
-                headers=self._headers(),
+                request.path,
+                json=request.body,
+                params=request.params,
+                headers=request.headers,
             )
             response.raise_for_status()
             data = response.json()
-        return parse_chat_completion(data)
+        return self._adapter.parse_response(data)
 
-    async def _chat_stream(self, payload: JsonDict) -> LLMResponse:
+    async def _chat_stream(self, request: ProviderRequest) -> LLMResponse:
         state = _StreamState()
         async with self._client() as client:
             async with client.stream(
                 "POST",
-                "/chat/completions",
-                json=payload,
-                headers=self._headers(),
+                request.path,
+                json=request.body,
+                params=request.params,
+                headers=request.headers,
             ) as response:
                 response.raise_for_status()
                 async for line in response.aiter_lines():

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,7 @@ class AppPaths:
 
 @dataclass(frozen=True)
 class LLMSettings:
+    provider: str
     base_url: str
     api_key: str | None
     model: str
@@ -64,6 +65,7 @@ class AppSettings:
             version="0.1.0",
             paths=paths,
             llm=LLMSettings(
+                provider="openai_compatible",
                 base_url="https://api.openai.com/v1",
                 api_key=None,
                 model="gpt-5.4",
@@ -84,6 +86,7 @@ class AppSettings:
         env_file: Path | None = None,
     ) -> "AppSettings":
         merged_env = load_environment(environ=environ, env_file=env_file)
+        provider = normalize_llm_provider(merged_env.get("LLM_PROVIDER"))
         workspace_root = Path(merged_env.get("ML_COPILOT_WORKSPACE_ROOT", str(AppPaths.default().workspace_root)))
         paths = AppPaths.from_workspace_root(workspace_root)
 
@@ -101,7 +104,8 @@ class AppSettings:
             version="0.1.0",
             paths=paths,
             llm=LLMSettings(
-                base_url=merged_env.get("LLM_BASE_URL", "https://api.openai.com/v1"),
+                provider=provider,
+                base_url=merged_env.get("LLM_BASE_URL", default_llm_base_url(provider)),
                 api_key=blank_to_none(merged_env.get("LLM_API_KEY")),
                 model=merged_env.get("LLM_MODEL", "gpt-5.4"),
                 timeout_seconds=parse_int(
@@ -203,3 +207,32 @@ def strip_optional_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
         return value[1:-1]
     return value
+
+
+def normalize_llm_provider(value: str | None) -> str:
+    normalized = (value or "openai_compatible").strip().lower().replace("-", "_")
+    if normalized in {"openai", "openai_compatible", "compatible"}:
+        return "openai_compatible"
+    if normalized in {"anthropic", "claude"}:
+        return "anthropic"
+    if normalized in {"gemini", "google_gemini", "google"}:
+        return "gemini"
+    if normalized in {"xai", "grok"}:
+        return "xai"
+    if normalized == "minimax":
+        return "minimax"
+    if normalized == "kimi":
+        return "kimi"
+    if normalized in {"zai", "z_ai", "z"}:
+        return "zai"
+    raise ValueError(f"Unsupported LLM provider: {value!r}")
+
+
+def default_llm_base_url(provider: str) -> str:
+    if provider == "anthropic":
+        return "https://api.anthropic.com/v1"
+    if provider == "gemini":
+        return "https://generativelanguage.googleapis.com/v1beta"
+    if provider == "xai":
+        return "https://api.x.ai/v1"
+    return "https://api.openai.com/v1"

--- a/docs/phase-1-configuration.md
+++ b/docs/phase-1-configuration.md
@@ -10,6 +10,7 @@ This document captures the configuration slice for `ML Copilot`.
 
 The current configuration layer supports:
 
+- `LLM_PROVIDER`
 - `LLM_BASE_URL`
 - `LLM_API_KEY`
 - `LLM_MODEL`
@@ -46,10 +47,11 @@ development, tests, and CI.
 
 ## Provider Strategy
 
-For the MVP, `ML Copilot` should stay provider-agnostic through an
-OpenAI-compatible interface:
+For the MVP, `ML Copilot` should stay provider-agnostic through a stable
+internal client interface:
 
 - one internal request shape
+- one `provider`
 - one `base_url`
 - one `api_key`
 - one `model`
@@ -68,10 +70,10 @@ gateway or routing layer in front of them.
 
 For providers with native APIs that are not cleanly OpenAI-compatible, the next
 step should be an adapter layer rather than hardwiring provider logic all over
-the app. A later design can introduce a dedicated provider field such as:
+the app. That adapter layer now starts with a dedicated provider field:
 
 ```text
-LLM_PROVIDER=openai_compatible | anthropic | gemini
+LLM_PROVIDER=openai_compatible | anthropic | gemini | xai | minimax | kimi | zai
 ```
 
 Then the runtime can route through small provider clients behind one internal

--- a/docs/phase-1-llm-client.md
+++ b/docs/phase-1-llm-client.md
@@ -16,6 +16,7 @@ The current client is intentionally narrow and provider-neutral:
 - tool-call parsing for full responses and streamed deltas
 - timeout handling through the configured HTTP client
 - usage parsing when the provider returns token counts
+- provider routing through the internal `LLMClient` interface
 
 ## Why This Shape
 
@@ -25,7 +26,7 @@ That gives later work a single client surface for:
 - the agent runtime
 - tests with mocked transports
 - OpenAI-compatible providers and gateways
-- future native provider adapters
+- native provider adapters behind the same interface
 
 ## Deferred To Later Tasks
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,6 +20,7 @@ def test_settings_wrap_default_paths() -> None:
     assert settings.app_name == "ML Copilot"
     assert settings.version == "0.1.0"
     assert settings.paths.workspace_root.name == "ml-copilot"
+    assert settings.llm.provider == "openai_compatible"
     assert settings.llm.base_url == "https://api.openai.com/v1"
     assert settings.safety.require_tool_approval is True
 
@@ -28,6 +29,7 @@ def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
     settings = AppSettings.load(
         environ={
             "LLM_API_KEY": "secret-key",
+            "LLM_PROVIDER": "anthropic",
             "LLM_MODEL": "gpt-test",
             "ML_COPILOT_WORKSPACE_ROOT": str(tmp_path),
             "ML_COPILOT_REQUIRE_TOOL_APPROVAL": "false",
@@ -36,7 +38,8 @@ def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
         }
     )
 
-    assert settings.llm.base_url == "https://api.openai.com/v1"
+    assert settings.llm.provider == "anthropic"
+    assert settings.llm.base_url == "https://api.anthropic.com/v1"
     assert settings.llm.api_key == "secret-key"
     assert settings.llm.model == "gpt-test"
     assert settings.paths.workspace_root == tmp_path.resolve()

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -379,3 +379,118 @@ def test_client_streaming_chat_aggregates_sse_chunks() -> None:
         "content_delta",
         "tool_call_delta",
     ]
+
+
+def test_client_anthropic_adapter_uses_native_messages_shape() -> None:
+    recorded = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded["path"] = request.url.path
+        recorded["headers"] = {
+            "x-api-key": request.headers.get("x-api-key"),
+            "anthropic-version": request.headers.get("anthropic-version"),
+        }
+        recorded["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_123",
+                "model": "claude-test",
+                "stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "done"}],
+                "usage": {"input_tokens": 4, "output_tokens": 6},
+            },
+        )
+
+    client = LLMClient(
+        base_url="https://example.invalid/v1",
+        api_key="anthropic-key",
+        default_model="claude-test",
+        provider="anthropic",
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://example.invalid/v1",
+        ),
+    )
+
+    response = run(
+        client.chat(
+            messages=[{"role": "system", "content": "Be concise."}, {"role": "user", "content": "hello"}],
+            stream=True,
+        )
+    )
+
+    assert recorded["path"] == "/v1/messages"
+    assert recorded["headers"]["x-api-key"] == "anthropic-key"
+    assert recorded["headers"]["anthropic-version"] == "2023-06-01"
+    assert recorded["payload"]["system"] == "Be concise."
+    assert recorded["payload"]["messages"] == [{"role": "user", "content": "hello"}]
+    assert response.content == "done"
+    assert response.finish_reason == "end_turn"
+    assert response.usage is not None
+    assert response.usage.total_tokens == 10
+
+
+def test_client_gemini_adapter_parses_function_calls() -> None:
+    recorded = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded["path"] = request.url.path
+        recorded["params"] = dict(request.url.params)
+        recorded["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "id": "gemini_resp_123",
+                "model": "gemini-test",
+                "candidates": [
+                    {
+                        "finishReason": "STOP",
+                        "content": {
+                            "parts": [
+                                {"text": "working"},
+                                {
+                                    "functionCall": {
+                                        "id": "call_1",
+                                        "name": "read_file",
+                                        "args": {"path": "README.md"},
+                                    }
+                                },
+                            ]
+                        },
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 8,
+                    "candidatesTokenCount": 5,
+                    "totalTokenCount": 13,
+                },
+            },
+        )
+
+    client = LLMClient(
+        base_url="https://example.invalid/v1beta",
+        api_key="gemini-key",
+        default_model="gemini-test",
+        provider="gemini",
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://example.invalid/v1beta",
+        ),
+    )
+
+    response = run(
+        client.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+    )
+
+    assert recorded["path"] == "/v1beta/models/gemini-test:generateContent"
+    assert recorded["params"]["key"] == "gemini-key"
+    assert recorded["payload"]["contents"] == [{"role": "user", "parts": [{"text": "hello"}]}]
+    assert response.content == "working"
+    assert response.tool_calls[0].name == "read_file"
+    assert response.tool_calls[0].arguments == '{"path":"README.md"}'
+    assert response.usage is not None
+    assert response.usage.total_tokens == 13


### PR DESCRIPTION
## Summary
Add a provider-aware `LLMClient` seam with adapter routing for OpenAI-compatible providers plus native Anthropic and Gemini request/response handling.

## Testing
- `uv run pytest tests/ -q`
- `uv run ruff check app/ tests/`
- `uv run ruff format --check app/ tests/`

## Notes
- `LLM_PROVIDER` now selects the provider family in config.
- The default OpenAI-compatible path stays unchanged.
- The branch keeps the adapter boundary inside the existing `LLMClient` interface so the agent loop does not need provider-specific conditionals.

## Reference
- Issue: https://github.com/Sohail-Shaikh-07/ml-copilot/issues/56