### PR TITLE
ML-200 / Build eval runner

### DIFF
--- a/app/evals/__init__.py
+++ b/app/evals/__init__.py
@@ -1,1 +1,5 @@
 """Evaluation package for reproducible agent tasks."""
+
+from app.evals.runner import EvalFixture, EvalRunner, EvalRunResult, load_fixture
+
+__all__ = ["EvalFixture", "EvalRunner", "EvalRunResult", "load_fixture"]

--- a/app/evals/runner.py
+++ b/app/evals/runner.py
@@ -1,0 +1,387 @@
+"""Fixture-based evaluation runner for ML Copilot."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from app.agent.loop import create_agent_loop
+from app.config import AppPaths, AppSettings
+from app.storage.models import EvalRunRecord, SessionRecord, utc_now
+from app.storage.repository import SQLiteRepository
+
+AgentRunCallable = Callable[["EvalFixture", Path, AppSettings, SessionRecord], Awaitable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class EvalFile:
+    path: str
+    content: str
+
+
+@dataclass(frozen=True)
+class EvalCheck:
+    kind: str
+    value: str | None = None
+    path: str | None = None
+    weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class EvalFixture:
+    id: str
+    prompt: str
+    name: str | None = None
+    workspace_files: list[EvalFile] = field(default_factory=list)
+    checks: list[EvalCheck] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EvalCheckResult:
+    kind: str
+    passed: bool
+    weight: float
+    value: str | None = None
+    path: str | None = None
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class EvalRunResult:
+    record: EvalRunRecord
+    workspace_path: Path
+    artifact_dir: Path
+    report_path: Path
+    markdown_path: Path
+
+
+class EvalRunner:
+    """Run task fixtures in clean workspaces and persist eval reports."""
+
+    def __init__(
+        self,
+        settings: AppSettings,
+        *,
+        repository: SQLiteRepository | None = None,
+        agent_runner: AgentRunCallable | None = None,
+    ) -> None:
+        self.settings = settings
+        self.repository = repository or SQLiteRepository(settings.db_path)
+        self.repository.initialize()
+        self.agent_runner = agent_runner or run_agent_fixture
+
+    async def run_fixture(
+        self,
+        fixture: EvalFixture,
+        *,
+        output_dir: Path | None = None,
+    ) -> EvalRunResult:
+        eval_output_dir = (output_dir or self.settings.paths.workspace_root / ".ml-copilot" / "evals").resolve()
+        eval_output_dir.mkdir(parents=True, exist_ok=True)
+
+        session = self.repository.create_session(
+            model=self.settings.llm.model,
+            title=f"Eval: {fixture.id}",
+            metadata={"eval_fixture_id": fixture.id},
+        )
+        record = self.repository.create_eval_run(
+            task_id=fixture.id,
+            session_id=session.id,
+            report={"status": "running", "fixture_id": fixture.id},
+        )
+        workspace_path = eval_output_dir / "workspaces" / _safe_slug(fixture.id) / record.id
+        artifact_dir = eval_output_dir / "artifacts" / record.id
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        status = "error"
+        score = 0.0
+        error: str | None = None
+        agent_output: dict[str, Any] = {}
+        check_results: list[EvalCheckResult] = []
+
+        try:
+            workspace_path = self._prepare_workspace(fixture, eval_output_dir, record.id)
+            eval_settings = replace(
+                self.settings,
+                paths=AppPaths.from_workspace_root(workspace_path),
+                db_path=self.settings.db_path,
+            )
+            agent_output = await self.agent_runner(fixture, workspace_path, eval_settings, session)
+            final_content = str(agent_output.get("content") or "")
+            check_results = evaluate_checks(fixture.checks, final_content, workspace_path)
+            score = calculate_score(check_results)
+            status = "passed" if all(result.passed for result in check_results) else "failed"
+        except Exception as exc:
+            error = str(exc)
+
+        finished_at = utc_now()
+        report = build_report(
+            fixture=fixture,
+            eval_run_id=record.id,
+            session_id=session.id,
+            status=status,
+            score=score,
+            started_at=record.started_at,
+            finished_at=finished_at,
+            workspace_path=workspace_path,
+            artifact_dir=artifact_dir,
+            agent_output=agent_output,
+            check_results=check_results,
+            error=error,
+        )
+        report_path = artifact_dir / "report.json"
+        markdown_path = artifact_dir / "report.md"
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        markdown_path.write_text(format_markdown_report(report), encoding="utf-8")
+
+        updated_record = self.repository.update_eval_run(
+            record.id,
+            status=status,
+            score=score,
+            finished_at=finished_at,
+            report=report,
+        )
+        self.repository.update_session(session.id, status="idle")
+
+        return EvalRunResult(
+            record=updated_record,
+            workspace_path=workspace_path,
+            artifact_dir=artifact_dir,
+            report_path=report_path,
+            markdown_path=markdown_path,
+        )
+
+    def _prepare_workspace(self, fixture: EvalFixture, output_dir: Path, eval_run_id: str) -> Path:
+        workspace_path = output_dir / "workspaces" / _safe_slug(fixture.id) / eval_run_id
+        if workspace_path.exists():
+            shutil.rmtree(workspace_path)
+        workspace_path.mkdir(parents=True)
+
+        for file in fixture.workspace_files:
+            target = _resolve_workspace_file(workspace_path, file.path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(file.content, encoding="utf-8")
+
+        return workspace_path
+
+
+async def run_agent_fixture(
+    fixture: EvalFixture,
+    workspace_path: Path,
+    settings: AppSettings,
+    session: SessionRecord,
+) -> dict[str, Any]:
+    """Default fixture executor that runs one agent turn inside the fixture workspace."""
+    loop = create_agent_loop(settings)
+    result = await loop.run_turn(session=session, user_message=fixture.prompt)
+    return {
+        "content": result.get("content", ""),
+        "result": result,
+        "workspace_path": str(workspace_path),
+    }
+
+
+def load_fixture(path: Path) -> EvalFixture:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("Eval fixture must be a JSON object.")
+    return fixture_from_dict(raw)
+
+
+def fixture_from_dict(raw: dict[str, Any]) -> EvalFixture:
+    fixture_id = _required_str(raw, "id")
+    prompt = _required_str(raw, "prompt")
+    return EvalFixture(
+        id=fixture_id,
+        name=_optional_str(raw.get("name")),
+        prompt=prompt,
+        workspace_files=_parse_files(raw.get("workspace_files", raw.get("files", []))),
+        checks=_parse_checks(raw.get("checks", [])),
+        metadata=raw.get("metadata", {}) if isinstance(raw.get("metadata", {}), dict) else {},
+    )
+
+
+def evaluate_checks(checks: list[EvalCheck], final_content: str, workspace_path: Path) -> list[EvalCheckResult]:
+    if not checks:
+        return [EvalCheckResult(kind="no_checks", passed=True, weight=1.0, message="No checks configured.")]
+
+    results: list[EvalCheckResult] = []
+    for check in checks:
+        if check.kind == "contains":
+            passed = bool(check.value and check.value in final_content)
+            message = "Final response contains expected text." if passed else "Final response is missing expected text."
+        elif check.kind == "not_contains":
+            passed = bool(check.value is not None and check.value not in final_content)
+            message = "Final response omits forbidden text." if passed else "Final response contains forbidden text."
+        elif check.kind == "file_exists":
+            target = _resolve_workspace_file(workspace_path, _required_check_path(check))
+            passed = target.exists()
+            message = "Expected file exists." if passed else "Expected file is missing."
+        elif check.kind == "file_contains":
+            target = _resolve_workspace_file(workspace_path, _required_check_path(check))
+            content = target.read_text(encoding="utf-8") if target.exists() else ""
+            passed = bool(check.value and check.value in content)
+            message = "Expected file contains text." if passed else "Expected file is missing text."
+        else:
+            passed = False
+            message = f"Unsupported check type: {check.kind}"
+
+        results.append(
+            EvalCheckResult(
+                kind=check.kind,
+                passed=passed,
+                weight=check.weight,
+                value=check.value,
+                path=check.path,
+                message=message,
+            )
+        )
+    return results
+
+
+def calculate_score(results: list[EvalCheckResult]) -> float:
+    total_weight = sum(max(result.weight, 0.0) for result in results)
+    if total_weight == 0:
+        return 0.0
+    passed_weight = sum(max(result.weight, 0.0) for result in results if result.passed)
+    return round(passed_weight / total_weight, 4)
+
+
+def build_report(
+    *,
+    fixture: EvalFixture,
+    eval_run_id: str,
+    session_id: str,
+    status: str,
+    score: float,
+    started_at: str,
+    finished_at: str,
+    workspace_path: Path,
+    artifact_dir: Path,
+    agent_output: dict[str, Any],
+    check_results: list[EvalCheckResult],
+    error: str | None,
+) -> dict[str, Any]:
+    return {
+        "id": eval_run_id,
+        "fixture": {
+            "id": fixture.id,
+            "name": fixture.name,
+            "metadata": fixture.metadata,
+        },
+        "session_id": session_id,
+        "status": status,
+        "score": score,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "workspace_path": str(workspace_path),
+        "artifact_dir": str(artifact_dir),
+        "agent_output": agent_output,
+        "checks": [
+            {
+                "type": result.kind,
+                "passed": result.passed,
+                "weight": result.weight,
+                "value": result.value,
+                "path": result.path,
+                "message": result.message,
+            }
+            for result in check_results
+        ],
+        "error": error,
+    }
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    fixture = report["fixture"]
+    lines = [
+        f"# Eval Report: {fixture['id']}",
+        "",
+        f"- Status: `{report['status']}`",
+        f"- Score: `{report['score']}`",
+        f"- Session: `{report['session_id']}`",
+        f"- Workspace: `{report['workspace_path']}`",
+        f"- Artifacts: `{report['artifact_dir']}`",
+        "",
+        "## Checks",
+    ]
+    for check in report["checks"]:
+        mark = "PASS" if check["passed"] else "FAIL"
+        label = check["path"] or check["value"] or check["type"]
+        lines.append(f"- {mark} `{check['type']}` {label}: {check['message']}")
+    if report.get("error"):
+        lines.extend(["", "## Error", str(report["error"])])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _parse_files(raw_files: Any) -> list[EvalFile]:
+    if isinstance(raw_files, dict):
+        return [EvalFile(path=str(path), content=str(content)) for path, content in raw_files.items()]
+    if not isinstance(raw_files, list):
+        raise ValueError("workspace_files must be a list or object.")
+
+    files: list[EvalFile] = []
+    for item in raw_files:
+        if not isinstance(item, dict):
+            raise ValueError("Each workspace file must be an object.")
+        files.append(EvalFile(path=_required_str(item, "path"), content=str(item.get("content", ""))))
+    return files
+
+
+def _parse_checks(raw_checks: Any) -> list[EvalCheck]:
+    if not isinstance(raw_checks, list):
+        raise ValueError("checks must be a list.")
+
+    checks: list[EvalCheck] = []
+    for item in raw_checks:
+        if not isinstance(item, dict):
+            raise ValueError("Each eval check must be an object.")
+        weight = float(item.get("weight", 1.0))
+        checks.append(
+            EvalCheck(
+                kind=_required_str(item, "type"),
+                value=_optional_str(item.get("value")),
+                path=_optional_str(item.get("path")),
+                weight=weight,
+            )
+        )
+    return checks
+
+
+def _resolve_workspace_file(workspace_path: Path, relative_path: str) -> Path:
+    candidate = workspace_path / relative_path
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(workspace_path.resolve())
+    except ValueError as exc:
+        raise ValueError(f"Fixture path escapes workspace: {relative_path!r}") from exc
+    return resolved
+
+
+def _required_check_path(check: EvalCheck) -> str:
+    if not check.path:
+        raise ValueError(f"Check {check.kind!r} requires a path.")
+    return check.path
+
+
+def _required_str(raw: dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Fixture field {key!r} must be a non-empty string.")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _safe_slug(value: str) -> str:
+    slug = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in value.strip())
+    return slug.strip("-") or "fixture"

--- a/app/evals/runner.py
+++ b/app/evals/runner.py
@@ -280,7 +280,7 @@ def build_report(
         "finished_at": finished_at,
         "workspace_path": str(workspace_path),
         "artifact_dir": str(artifact_dir),
-        "agent_output": agent_output,
+        "agent_output": _json_safe(agent_output),
         "checks": [
             {
                 "type": result.kind,
@@ -385,3 +385,15 @@ def _optional_str(value: Any) -> str | None:
 def _safe_slug(value: str) -> str:
     slug = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in value.strip())
     return slug.strip("-") or "fixture"
+
+
+def _json_safe(value: Any) -> Any:
+    try:
+        json.dumps(value)
+    except TypeError:
+        if isinstance(value, dict):
+            return {str(key): _json_safe(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_json_safe(item) for item in value]
+        return str(value)
+    return value

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import json
 import logging
+from pathlib import Path
 
 from app.agent.loop import create_agent_loop
 from app.config import AppSettings
@@ -126,6 +127,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--feedback",
         type=str,
         help="Optional feedback to persist with the rejection",
+    )
+
+    eval_parser = subparsers.add_parser("eval", help="Run a fixture-based evaluation")
+    eval_parser.add_argument(
+        "fixture",
+        type=Path,
+        help="Path to an eval fixture JSON file",
+    )
+    eval_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for eval workspaces and artifacts (default: .ml-copilot/evals)",
+    )
+    eval_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the persisted eval report JSON instead of a short summary",
     )
 
     return parser
@@ -368,6 +386,27 @@ async def cmd_reject(args: argparse.Namespace, settings: AppSettings) -> int:
     return 0
 
 
+async def cmd_eval(args: argparse.Namespace, settings: AppSettings) -> int:
+    """Execute the 'eval' command."""
+    from app.evals import EvalRunner, load_fixture
+
+    fixture = load_fixture(args.fixture)
+    runner = EvalRunner(settings)
+    result = await runner.run_fixture(fixture, output_dir=args.output_dir)
+
+    if args.json:
+        print(result.record.report_json)
+    else:
+        print(f"Eval run: {result.record.id}")
+        print(f"Fixture: {result.record.task_id}")
+        print(f"Status: {result.record.status}")
+        print(f"Score: {result.record.score}")
+        print(f"Workspace: {result.workspace_path}")
+        print(f"Report: {result.markdown_path}")
+
+    return 0 if result.record.status == "passed" else 1
+
+
 def _get_sync_repo(settings: AppSettings):
     """Get a synchronous repository for simple operations."""
     from app.storage.repository import SQLiteRepository
@@ -410,6 +449,8 @@ def main() -> int:
             return asyncio.run(cmd_approve(args, settings))
         elif args.command == "reject":
             return asyncio.run(cmd_reject(args, settings))
+        elif args.command == "eval":
+            return asyncio.run(cmd_eval(args, settings))
         else:
             parser.print_help()
             return 0

--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -83,6 +83,18 @@ class PendingApprovalRecord:
 
 
 @dataclass(frozen=True)
+class EvalRunRecord:
+    id: str
+    task_id: str
+    session_id: str
+    status: str
+    score: float | None
+    started_at: str
+    finished_at: str | None
+    report_json: str
+
+
+@dataclass(frozen=True)
 class SessionHistory:
     session: SessionRecord
     messages: list[MessageRecord]

--- a/app/storage/repository.py
+++ b/app/storage/repository.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from app.db import connect_sqlite
 from app.storage.models import (
     ApprovalRecord,
+    EvalRunRecord,
     EventRecord,
     MessageRecord,
     PendingApprovalRecord,
@@ -761,6 +762,129 @@ class SQLiteRepository:
             rows = connection.execute(query, params).fetchall()
         return [_pending_approval_from_row(row) for row in rows]
 
+    def create_eval_run(
+        self,
+        *,
+        task_id: str,
+        session_id: str,
+        status: str = "running",
+        score: float | None = None,
+        report: dict | None = None,
+        eval_run_id: str | None = None,
+    ) -> EvalRunRecord:
+        record = EvalRunRecord(
+            id=eval_run_id or str(uuid.uuid4()),
+            task_id=task_id,
+            session_id=session_id,
+            status=status,
+            score=score,
+            started_at=utc_now(),
+            finished_at=None,
+            report_json=json.dumps(report or {}, sort_keys=True),
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO eval_runs (
+                    id,
+                    task_id,
+                    session_id,
+                    status,
+                    score,
+                    started_at,
+                    finished_at,
+                    report_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.id,
+                    record.task_id,
+                    record.session_id,
+                    record.status,
+                    record.score,
+                    record.started_at,
+                    record.finished_at,
+                    record.report_json,
+                ),
+            )
+            self._touch_session(connection, session_id)
+            connection.commit()
+        return record
+
+    def get_eval_run(self, eval_run_id: str) -> EvalRunRecord | None:
+        with connect_sqlite(self.database_path) as connection:
+            row = connection.execute(
+                """
+                SELECT id, task_id, session_id, status, score, started_at, finished_at, report_json
+                FROM eval_runs
+                WHERE id = ?
+                """,
+                (eval_run_id,),
+            ).fetchone()
+        return _eval_run_from_row(row) if row else None
+
+    def update_eval_run(
+        self,
+        eval_run_id: str,
+        *,
+        status: str | None = None,
+        score: float | None = None,
+        finished_at: str | None = None,
+        report: dict | None = None,
+    ) -> EvalRunRecord:
+        current = self.get_eval_run(eval_run_id)
+        if current is None:
+            raise KeyError(f"Unknown eval run: {eval_run_id}")
+
+        record = EvalRunRecord(
+            id=current.id,
+            task_id=current.task_id,
+            session_id=current.session_id,
+            status=status if status is not None else current.status,
+            score=score if score is not None else current.score,
+            started_at=current.started_at,
+            finished_at=finished_at if finished_at is not None else current.finished_at,
+            report_json=json.dumps(report, sort_keys=True) if report is not None else current.report_json,
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                UPDATE eval_runs
+                SET
+                    status = ?,
+                    score = ?,
+                    finished_at = ?,
+                    report_json = ?
+                WHERE id = ?
+                """,
+                (
+                    record.status,
+                    record.score,
+                    record.finished_at,
+                    record.report_json,
+                    record.id,
+                ),
+            )
+            self._touch_session(connection, record.session_id)
+            connection.commit()
+        return record
+
+    def list_eval_runs(self, task_id: str | None = None) -> list[EvalRunRecord]:
+        query = """
+            SELECT id, task_id, session_id, status, score, started_at, finished_at, report_json
+            FROM eval_runs
+        """
+        params: tuple[str, ...] = ()
+        if task_id is not None:
+            query += " WHERE task_id = ?"
+            params = (task_id,)
+        query += " ORDER BY started_at ASC, id ASC"
+
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(query, params).fetchall()
+        return [_eval_run_from_row(row) for row in rows]
+
     def get_session_history(self, session_id: str) -> SessionHistory:
         session = self.get_session(session_id)
         if session is None:
@@ -892,4 +1016,17 @@ def _pending_approval_from_row(row: sqlite3.Row) -> PendingApprovalRecord:
             success=None if row["tool_call_success"] is None else bool(row["tool_call_success"]),
             error=row["tool_call_error"],
         ),
+    )
+
+
+def _eval_run_from_row(row: sqlite3.Row) -> EvalRunRecord:
+    return EvalRunRecord(
+        id=row["id"],
+        task_id=row["task_id"],
+        session_id=row["session_id"],
+        status=row["status"],
+        score=row["score"],
+        started_at=row["started_at"],
+        finished_at=row["finished_at"],
+        report_json=row["report_json"],
     )

--- a/docs/phase-3-eval-runner.md
+++ b/docs/phase-3-eval-runner.md
@@ -1,0 +1,87 @@
+# Phase 3 Eval Runner
+
+This document captures the first evaluation-runner slice for `ML Copilot`.
+
+## Task
+
+`ML-200 / Build eval runner`
+
+## Scope
+
+The runner executes JSON task fixtures with:
+
+- a clean workspace rendered from fixture files
+- one agent turn against the fixture prompt
+- deterministic scoring checks
+- persisted `eval_runs` records
+- JSON and Markdown artifacts for each run
+
+## Fixture Shape
+
+```json
+{
+  "id": "repo-summary-basic",
+  "name": "Repo summary basic",
+  "prompt": "Summarize the repository and write summary.md.",
+  "workspace_files": [
+    {
+      "path": "README.md",
+      "content": "# Sample project\n"
+    }
+  ],
+  "checks": [
+    {
+      "type": "contains",
+      "value": "summary"
+    },
+    {
+      "type": "file_exists",
+      "path": "summary.md"
+    },
+    {
+      "type": "file_contains",
+      "path": "summary.md",
+      "value": "Sample project"
+    }
+  ]
+}
+```
+
+Supported check types:
+
+- `contains`: final agent response includes `value`
+- `not_contains`: final agent response omits `value`
+- `file_exists`: a workspace file exists at `path`
+- `file_contains`: a workspace file at `path` includes `value`
+
+## CLI
+
+Run an eval fixture:
+
+```bash
+python -m app.main eval path/to/fixture.json
+```
+
+Use a custom artifact directory:
+
+```bash
+python -m app.main eval path/to/fixture.json --output-dir .ml-copilot/evals
+```
+
+Print the persisted report JSON:
+
+```bash
+python -m app.main eval path/to/fixture.json --json
+```
+
+The command exits with `0` when all checks pass and `1` when the eval fails or errors.
+
+## Artifacts
+
+Each run writes:
+
+- `workspaces/<fixture-id>/<eval-run-id>/` for the reproducible fixture workspace
+- `artifacts/<eval-run-id>/report.json` for machine-readable results
+- `artifacts/<eval-run-id>/report.md` for reviewer-friendly results
+
+The same report payload is persisted in SQLite under `eval_runs.report_json`.

--- a/tests/unit/test_eval_runner.py
+++ b/tests/unit/test_eval_runner.py
@@ -1,0 +1,154 @@
+"""Tests for fixture-based eval runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.config import AppPaths, AppSettings
+from app.evals.runner import EvalFixture, EvalRunner, fixture_from_dict, load_fixture
+from app.storage.models import SessionRecord
+from app.storage.repository import SQLiteRepository
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_eval_runner_writes_workspace_scores_and_artifacts(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    repository = SQLiteRepository(settings.db_path)
+    fixture = fixture_from_dict(
+        {
+            "id": "fixture-pass",
+            "name": "Passing fixture",
+            "prompt": "Create a summary",
+            "workspace_files": [{"path": "input.txt", "content": "seed data"}],
+            "checks": [
+                {"type": "contains", "value": "done"},
+                {"type": "file_exists", "path": "summary.md"},
+                {"type": "file_contains", "path": "summary.md", "value": "artifact"},
+            ],
+        }
+    )
+
+    async def fake_agent(
+        _fixture: EvalFixture,
+        workspace_path: Path,
+        _settings: AppSettings,
+        session: SessionRecord,
+    ) -> dict[str, object]:
+        (workspace_path / "summary.md").write_text("artifact created\n", encoding="utf-8")
+        return {"content": "done", "session_id": session.id}
+
+    result = await EvalRunner(settings, repository=repository, agent_runner=fake_agent).run_fixture(
+        fixture,
+        output_dir=tmp_path / "eval-output",
+    )
+
+    assert result.record.status == "passed"
+    assert result.record.score == 1.0
+    assert (result.workspace_path / "input.txt").read_text(encoding="utf-8") == "seed data"
+    assert result.report_path.exists()
+    assert result.markdown_path.exists()
+
+    report = json.loads(result.record.report_json)
+    assert report["fixture"]["id"] == "fixture-pass"
+    assert report["status"] == "passed"
+    assert all(check["passed"] for check in report["checks"])
+    assert repository.list_eval_runs("fixture-pass") == [result.record]
+
+
+@pytest.mark.asyncio
+async def test_eval_runner_records_failed_checks(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    fixture = fixture_from_dict(
+        {
+            "id": "fixture-fail",
+            "prompt": "Create a summary",
+            "checks": [
+                {"type": "contains", "value": "expected", "weight": 2},
+                {"type": "not_contains", "value": "forbidden", "weight": 1},
+            ],
+        }
+    )
+
+    async def fake_agent(
+        _fixture: EvalFixture,
+        _workspace_path: Path,
+        _settings: AppSettings,
+        _session: SessionRecord,
+    ) -> dict[str, object]:
+        return {"content": "missing expected and forbidden"}
+
+    result = await EvalRunner(settings, agent_runner=fake_agent).run_fixture(
+        fixture,
+        output_dir=tmp_path / "eval-output",
+    )
+
+    report = json.loads(result.record.report_json)
+
+    assert result.record.status == "failed"
+    assert result.record.score == pytest.approx(2 / 3, abs=0.0001)
+    assert [check["passed"] for check in report["checks"]] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_eval_runner_records_agent_errors(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    fixture = fixture_from_dict({"id": "fixture-error", "prompt": "fail", "checks": []})
+
+    async def failing_agent(
+        _fixture: EvalFixture,
+        _workspace_path: Path,
+        _settings: AppSettings,
+        _session: SessionRecord,
+    ) -> dict[str, object]:
+        raise RuntimeError("boom")
+
+    result = await EvalRunner(settings, agent_runner=failing_agent).run_fixture(
+        fixture,
+        output_dir=tmp_path / "eval-output",
+    )
+    report = json.loads(result.record.report_json)
+
+    assert result.record.status == "error"
+    assert result.record.score == 0.0
+    assert report["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_runner_records_workspace_escape_as_error(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "id": "fixture-escape",
+                "prompt": "unsafe",
+                "workspace_files": [{"path": "../outside.txt", "content": "bad"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    settings = _settings(tmp_path)
+    fixture = load_fixture(fixture_path)
+
+    async def fake_agent(
+        _fixture: EvalFixture,
+        _workspace_path: Path,
+        _settings: AppSettings,
+        _session: SessionRecord,
+    ) -> dict[str, object]:
+        return {"content": "should not run"}
+
+    result = await EvalRunner(settings, agent_runner=fake_agent).run_fixture(
+        fixture,
+        output_dir=tmp_path / "eval-output",
+    )
+    report = json.loads(result.record.report_json)
+
+    assert result.record.status == "error"
+    assert "escapes workspace" in report["error"]

--- a/tests/unit/test_eval_runner.py
+++ b/tests/unit/test_eval_runner.py
@@ -121,6 +121,29 @@ async def test_eval_runner_records_agent_errors(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_eval_runner_sanitizes_agent_output_for_reports(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    fixture = fixture_from_dict({"id": "fixture-json-safe", "prompt": "ok", "checks": []})
+
+    async def fake_agent(
+        _fixture: EvalFixture,
+        workspace_path: Path,
+        _settings: AppSettings,
+        _session: SessionRecord,
+    ) -> dict[str, object]:
+        return {"content": "ok", "path": workspace_path}
+
+    result = await EvalRunner(settings, agent_runner=fake_agent).run_fixture(
+        fixture,
+        output_dir=tmp_path / "eval-output",
+    )
+    report = json.loads(result.record.report_json)
+
+    assert result.record.status == "passed"
+    assert report["agent_output"]["path"] == str(result.workspace_path)
+
+
+@pytest.mark.asyncio
 async def test_runner_records_workspace_escape_as_error(tmp_path: Path) -> None:
     fixture_path = tmp_path / "fixture.json"
     fixture_path.write_text(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,6 +8,16 @@ def test_build_parser_uses_project_name() -> None:
     assert parser.prog == "ml-copilot"
 
 
+def test_build_parser_accepts_eval_command() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["eval", "fixtures/basic.json", "--json"])
+
+    assert args.command == "eval"
+    assert str(args.fixture) == "fixtures\\basic.json" or str(args.fixture) == "fixtures/basic.json"
+    assert args.json is True
+
+
 def test_format_layout_includes_expected_directories() -> None:
     output = format_layout(AppSettings.from_paths(AppPaths.default()))
 

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -197,6 +197,38 @@ def test_tool_call_and_approval_lifecycle(tmp_path: Path) -> None:
     assert repository.list_pending_approvals("session-1") == []
 
 
+def test_eval_run_lifecycle(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    repository.create_session(
+        session_id="session-1",
+        title="Eval",
+        model="gpt-5.4",
+    )
+
+    created = repository.create_eval_run(
+        eval_run_id="eval-1",
+        task_id="fixture-1",
+        session_id="session-1",
+        report={"status": "running"},
+    )
+    updated = repository.update_eval_run(
+        "eval-1",
+        status="passed",
+        score=1.0,
+        finished_at="2026-06-15T00:00:00+00:00",
+        report={"status": "passed", "score": 1.0},
+    )
+
+    assert created.status == "running"
+    assert updated.status == "passed"
+    assert updated.score == 1.0
+    assert updated.report_json == '{"score": 1.0, "status": "passed"}'
+    assert repository.get_eval_run("eval-1") == updated
+    assert repository.list_eval_runs("fixture-1") == [updated]
+    assert repository.list_eval_runs("missing") == []
+
+
 def test_next_sequences_advance_with_history(tmp_path: Path) -> None:
     repository = SQLiteRepository(tmp_path / "ml-copilot.db")
     repository.initialize()


### PR DESCRIPTION
## Summary
- Adds a fixture-based eval runner with clean per-run workspaces, scoring checks, and JSON/Markdown artifacts.
- Persists eval run lifecycle data through the existing SQLite `eval_runs` table.
- Adds a CLI entrypoint for running eval fixtures locally.

## Task
Notion: `ML-200 / Build eval runner`

## Testing
- `uv run pytest tests/unit/test_eval_runner.py tests/unit/test_repository.py tests/unit/test_main.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check app/ tests/`
- `uv run ruff format --check app/ tests/`
- `uv run mypy app/ --ignore-missing-imports --follow-imports=skip`
- `uv run python -m app.main eval --help`

## Notes
- The default eval command runs the configured agent, so tests inject a fake agent runner to keep CI deterministic.
- Eval failures return a non-zero CLI exit code while still writing report artifacts for debugging.

## Reference
Closes #58