### PR TITLE
ML-201 / Add first five eval fixtures

### DIFF
--- a/docs/phase-3-eval-runner.md
+++ b/docs/phase-3-eval-runner.md
@@ -85,3 +85,13 @@ Each run writes:
 - `artifacts/<eval-run-id>/report.md` for reviewer-friendly results
 
 The same report payload is persisted in SQLite under `eval_runs.report_json`.
+
+## Bundled Fixtures
+
+The first seeded eval fixtures live under `tests/fixtures/evals/`:
+
+- `ml-201-training-script-fix.json`
+- `ml-201-dataset-validation.json`
+- `ml-201-eval-script.json`
+- `ml-201-model-card-inference.json`
+- `ml-201-repo-analysis.json`

--- a/tests/fixtures/evals/ml-201-dataset-validation.json
+++ b/tests/fixtures/evals/ml-201-dataset-validation.json
@@ -1,0 +1,35 @@
+{
+  "id": "ml-201-dataset-validation",
+  "name": "Dataset validation",
+  "prompt": "Inspect data/train.csv, validate row count and missing values, then write dataset_report.md with a concise summary.",
+  "workspace_files": [
+    {
+      "path": "data/train.csv",
+      "content": "feature_a,feature_b,label\n1,2,yes\n3,,no\n5,6,yes\n"
+    },
+    {
+      "path": "validate_dataset.py",
+      "content": "from pathlib import Path\n\n\ndef main() -> None:\n    data_path = Path('data/train.csv')\n    print(f'Validating {data_path}')\n\n\nif __name__ == '__main__':\n    main()\n"
+    }
+  ],
+  "checks": [
+    {
+      "type": "file_exists",
+      "path": "dataset_report.md"
+    },
+    {
+      "type": "file_contains",
+      "path": "dataset_report.md",
+      "value": "rows"
+    },
+    {
+      "type": "file_contains",
+      "path": "dataset_report.md",
+      "value": "missing"
+    }
+  ],
+  "metadata": {
+    "category": "dataset-validation",
+    "phase": "Phase 3"
+  }
+}

--- a/tests/fixtures/evals/ml-201-eval-script.json
+++ b/tests/fixtures/evals/ml-201-eval-script.json
@@ -1,0 +1,39 @@
+{
+  "id": "ml-201-eval-script",
+  "name": "Eval script",
+  "prompt": "Implement evaluate.py to compute accuracy from predictions.json and references.json, then write eval_report.json.",
+  "workspace_files": [
+    {
+      "path": "predictions.json",
+      "content": "[\"yes\", \"no\", \"yes\"]\n"
+    },
+    {
+      "path": "references.json",
+      "content": "[\"yes\", \"yes\", \"yes\"]\n"
+    },
+    {
+      "path": "evaluate.py",
+      "content": "import json\nfrom pathlib import Path\n\n\ndef main() -> None:\n    predictions = json.loads(Path('predictions.json').read_text(encoding='utf-8'))\n    references = json.loads(Path('references.json').read_text(encoding='utf-8'))\n    print(len(predictions), len(references))\n\n\nif __name__ == '__main__':\n    main()\n"
+    }
+  ],
+  "checks": [
+    {
+      "type": "file_contains",
+      "path": "evaluate.py",
+      "value": "accuracy"
+    },
+    {
+      "type": "file_exists",
+      "path": "eval_report.json"
+    },
+    {
+      "type": "file_contains",
+      "path": "eval_report.json",
+      "value": "accuracy"
+    }
+  ],
+  "metadata": {
+    "category": "eval-script",
+    "phase": "Phase 3"
+  }
+}

--- a/tests/fixtures/evals/ml-201-model-card-inference.json
+++ b/tests/fixtures/evals/ml-201-model-card-inference.json
@@ -1,0 +1,32 @@
+{
+  "id": "ml-201-model-card-inference",
+  "name": "Model card inference",
+  "prompt": "Add an inference section to model_card.md describing how to call the model and include a short safety note.",
+  "workspace_files": [
+    {
+      "path": "model_card.md",
+      "content": "# Model Card\n\n## Overview\nA small text classifier.\n\n## Training\nTrained on a toy dataset.\n"
+    }
+  ],
+  "checks": [
+    {
+      "type": "file_contains",
+      "path": "model_card.md",
+      "value": "## Inference"
+    },
+    {
+      "type": "file_contains",
+      "path": "model_card.md",
+      "value": "Safety"
+    },
+    {
+      "type": "file_contains",
+      "path": "model_card.md",
+      "value": "model"
+    }
+  ],
+  "metadata": {
+    "category": "model-card-inference",
+    "phase": "Phase 3"
+  }
+}

--- a/tests/fixtures/evals/ml-201-repo-analysis.json
+++ b/tests/fixtures/evals/ml-201-repo-analysis.json
@@ -1,0 +1,39 @@
+{
+  "id": "ml-201-repo-analysis",
+  "name": "Repo analysis",
+  "prompt": "Inspect the repository layout and write analysis.md summarizing the architecture, entrypoints, and next risks.",
+  "workspace_files": [
+    {
+      "path": "README.md",
+      "content": "# Sample repo\n\nThis repo has a small app, tools, and tests layout.\n"
+    },
+    {
+      "path": "app/main.py",
+      "content": "def main() -> None:\n    print('hello')\n"
+    },
+    {
+      "path": "app/tools.py",
+      "content": "def tool() -> str:\n    return 'tool'\n"
+    }
+  ],
+  "checks": [
+    {
+      "type": "file_exists",
+      "path": "analysis.md"
+    },
+    {
+      "type": "file_contains",
+      "path": "analysis.md",
+      "value": "architecture"
+    },
+    {
+      "type": "file_contains",
+      "path": "analysis.md",
+      "value": "entrypoint"
+    }
+  ],
+  "metadata": {
+    "category": "repo-analysis",
+    "phase": "Phase 3"
+  }
+}

--- a/tests/fixtures/evals/ml-201-training-script-fix.json
+++ b/tests/fixtures/evals/ml-201-training-script-fix.json
@@ -16,7 +16,12 @@
     {
       "type": "file_contains",
       "path": "train.py",
-      "value": "argparse"
+      "value": "--epochs"
+    },
+    {
+      "type": "file_contains",
+      "path": "train.py",
+      "value": "--output"
     },
     {
       "type": "file_exists",

--- a/tests/fixtures/evals/ml-201-training-script-fix.json
+++ b/tests/fixtures/evals/ml-201-training-script-fix.json
@@ -1,0 +1,35 @@
+{
+  "id": "ml-201-training-script-fix",
+  "name": "Training script fix",
+  "prompt": "Fix train.py so it parses --epochs and --output, then writes a training_report.md file summarizing the run.",
+  "workspace_files": [
+    {
+      "path": "train.py",
+      "content": "import sys\n\n\ndef main():\n    epochs = int(sys.argv[1])\n    output = sys.argv[2]\n    print(f'Training for {epochs} epochs')\n    print(f'Writing results to {output}')\n\n\nif __name__ == '__main__':\n    main()\n"
+    },
+    {
+      "path": "README.md",
+      "content": "# Training task\n\nThe script should accept `--epochs` and `--output`.\n"
+    }
+  ],
+  "checks": [
+    {
+      "type": "file_contains",
+      "path": "train.py",
+      "value": "argparse"
+    },
+    {
+      "type": "file_exists",
+      "path": "training_report.md"
+    },
+    {
+      "type": "file_contains",
+      "path": "training_report.md",
+      "value": "epochs"
+    }
+  ],
+  "metadata": {
+    "category": "training-script-fix",
+    "phase": "Phase 3"
+  }
+}

--- a/tests/unit/test_eval_fixtures.py
+++ b/tests/unit/test_eval_fixtures.py
@@ -1,0 +1,34 @@
+"""Tests for bundled eval fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.evals.runner import load_fixture
+
+
+def test_bundled_eval_fixtures_load_and_are_unique() -> None:
+    fixture_dir = Path(__file__).resolve().parents[1] / "fixtures" / "evals"
+    fixture_paths = sorted(fixture_dir.glob("*.json"))
+
+    assert len(fixture_paths) == 5
+
+    fixtures = [load_fixture(path) for path in fixture_paths]
+    fixture_ids = [fixture.id for fixture in fixtures]
+
+    assert fixture_ids == [
+        "ml-201-dataset-validation",
+        "ml-201-eval-script",
+        "ml-201-model-card-inference",
+        "ml-201-repo-analysis",
+        "ml-201-training-script-fix",
+    ]
+    assert all(fixture.prompt for fixture in fixtures)
+    assert all(fixture.checks for fixture in fixtures)
+
+
+def test_eval_fixture_filenames_match_ids() -> None:
+    fixture_dir = Path(__file__).resolve().parents[1] / "fixtures" / "evals"
+    for path in fixture_dir.glob("*.json"):
+        fixture = load_fixture(path)
+        assert fixture.id in path.stem


### PR DESCRIPTION
## Summary
- Adds five bundled eval fixtures for training script fixes, dataset validation, eval scripting, model-card inference, and repo analysis.
- Adds a validator test so the fixtures stay loadable and unique.
- Documents the bundled fixture set alongside the eval runner.

## Task
Notion: `ML-201 / Add first five eval fixtures`

## Testing
- `uv run pytest tests/unit/test_eval_fixtures.py tests/unit/test_eval_runner.py tests/unit/test_repository.py tests/unit/test_main.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check app/ tests/`
- `uv run ruff format --check app/ tests/`
- `uv run mypy app/ --ignore-missing-imports --follow-imports=skip`

## Notes
- The fixture set is intentionally small and reproducible so future eval runs can reuse it without extra setup.
- The model-card fixture checks for a dedicated inference section and a safety note to keep the task concrete.

## Reference
Closes #60