### PR TITLE
ML-206 / Implement approval dialog

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -16,6 +16,7 @@ from app.storage.repository import SQLiteRepository
 
 from .runtime import ActiveTurnManager
 from .schemas import (
+    ApprovalDecisionRequest,
     ChatRequest,
     ChatResponse,
     CreateSessionRequest,
@@ -127,6 +128,60 @@ def create_app(
                 user_message=payload.message,
                 system_prompt=payload.system_prompt,
             )
+        except asyncio.CancelledError:
+            result = {"status": "interrupted"}
+        except Exception:
+            repo.update_session(session_id, status="error")
+            raise
+        finally:
+            active_turn_manager.unregister(session_id, current_task)
+            loop.remove_event_handler(event_stream_manager.publish)
+
+        updated_session = repo.update_session(session_id, status=_status_for_turn_result(result["status"]))
+        return ChatResponse(
+            session=_serialize_session_detail(repo, updated_session),
+            result=_serialize_turn_result(result),
+            messages=[_serialize_message(message) for message in repo.list_messages(session_id)],
+        )
+
+    @router.post("/approval/{session_id}/{approval_id}", response_model=ChatResponse)
+    async def resolve_approval(
+        session_id: str,
+        approval_id: str,
+        payload: ApprovalDecisionRequest,
+        request: Request,
+        repo: RepositoryDep,
+        loop: LoopDep,
+    ) -> ChatResponse:
+        session = _get_session_or_404(repo, session_id)
+        active_turn_manager = get_active_turn_manager(request)
+        if not active_turn_manager.register(session_id, loop):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Session already has an active turn",
+            )
+
+        repo.update_session(session_id, status="processing")
+        event_stream_manager = get_event_stream_manager(request)
+        loop.add_event_handler(event_stream_manager.publish)
+        current_task = asyncio.current_task()
+
+        try:
+            result = await loop.resume_pending_approval(
+                session=session,
+                approval_id=approval_id,
+                approved=payload.approved,
+                user_feedback=payload.user_feedback,
+                edited_arguments=payload.edited_arguments,
+                system_prompt=payload.system_prompt,
+            )
+        except KeyError as exc:
+            fallback_status = "waiting_approval" if repo.list_pending_approvals(session_id) else "idle"
+            repo.update_session(session_id, status=fallback_status)
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Pending approval not found",
+            ) from exc
         except asyncio.CancelledError:
             result = {"status": "interrupted"}
         except Exception:

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -18,6 +18,13 @@ class ChatRequest(BaseModel):
     system_prompt: str | None = None
 
 
+class ApprovalDecisionRequest(BaseModel):
+    approved: bool
+    user_feedback: str | None = None
+    edited_arguments: dict[str, Any] | None = None
+    system_prompt: str | None = None
+
+
 class PendingApprovalPayload(BaseModel):
     approval_id: str
     tool_call_id: str

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,10 +6,13 @@ import {
   fetchSession,
   fetchSessions,
   getApiBaseLabel,
+  resolveApproval,
   sendChatMessage,
 } from './api';
+import ApprovalDialog from './components/ApprovalDialog';
 import ToolTracePanel from './components/ToolTracePanel';
 import type {
+  ApprovalDecisionRequest,
   MessagePayload,
   PendingApprovalPayload,
   SessionDetail,
@@ -76,6 +79,7 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [sending, setSending] = useState(false);
+  const [resolvingApproval, setResolvingApproval] = useState(false);
   const [draftTitle, setDraftTitle] = useState('');
   const [draftModel, setDraftModel] = useState('');
   const [draftPrompt, setDraftPrompt] = useState('');
@@ -238,7 +242,7 @@ function App() {
       );
 
       if (response.result.status === 'approval_required') {
-        setNotice('The agent is waiting for approval. Approval controls are planned for the next dedicated task.');
+        setNotice('The agent is waiting for approval. Review the pending action in the approval dialog.');
       } else if (response.result.status === 'interrupted') {
         setNotice('The turn was interrupted.');
       }
@@ -248,6 +252,44 @@ function App() {
       setStreamState('error');
     } finally {
       setSending(false);
+      void refreshSession(selectedSessionId);
+      void refreshSessions();
+    }
+  }
+
+  async function handleResolveApproval(approvalId: string, payload: ApprovalDecisionRequest) {
+    if (!selectedSessionId || resolvingApproval) {
+      return;
+    }
+
+    setResolvingApproval(true);
+    setError(null);
+    setNotice(null);
+    setLiveEvents([]);
+    setLiveAssistantText('');
+    connectEventStream(selectedSessionId, { replay: false });
+
+    try {
+      const response = await resolveApproval(selectedSessionId, approvalId, payload);
+      setActiveSession(response.session);
+      setMessages(response.messages);
+      setSessions((current) =>
+        current.map((session) => (session.id === response.session.id ? response.session : session)),
+      );
+
+      if (response.result.status === 'approval_required') {
+        setNotice('One approval was resolved. Another pending approval still needs review.');
+      } else if (response.result.status === 'interrupted') {
+        setNotice('The approval continuation was interrupted.');
+      } else {
+        setNotice('Approval decision applied.');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to resolve approval.');
+      closeEventStream();
+      setStreamState('error');
+    } finally {
+      setResolvingApproval(false);
       void refreshSession(selectedSessionId);
       void refreshSessions();
     }
@@ -452,19 +494,11 @@ function App() {
               </p>
             </section>
 
-            <section className="info-card">
-              <h3>Pending approvals</h3>
-              {pendingApprovals.length === 0 ? (
-                <p className="muted">None right now.</p>
-              ) : (
-                pendingApprovals.map((approval) => (
-                  <div key={approval.approval_id} className="mini-row">
-                    <strong>{approval.tool_name}</strong>
-                    <span>{shortId(approval.approval_id)}</span>
-                  </div>
-                ))
-              )}
-            </section>
+            <ApprovalDialog
+              pendingApprovals={pendingApprovals}
+              resolving={resolvingApproval}
+              onResolve={handleResolveApproval}
+            />
 
             <ToolTracePanel liveEvents={liveEvents} pendingApprovals={pendingApprovals} toolCalls={toolCalls} />
           </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalDecisionRequest,
   ChatRequest,
   ChatResponse,
   CreateSessionRequest,
@@ -55,6 +56,13 @@ export function createSession(payload: CreateSessionRequest) {
 
 export function sendChatMessage(sessionId: string, payload: ChatRequest) {
   return request<ChatResponse>(`/api/chat/${sessionId}`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function resolveApproval(sessionId: string, approvalId: string, payload: ApprovalDecisionRequest) {
+  return request<ChatResponse>(`/api/approval/${sessionId}/${approvalId}`, {
     method: 'POST',
     body: JSON.stringify(payload),
   });

--- a/frontend/src/components/ApprovalDialog.tsx
+++ b/frontend/src/components/ApprovalDialog.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react';
+import type { ApprovalDecisionRequest, PendingApprovalPayload } from '../types';
+
+interface ApprovalDialogProps {
+  pendingApprovals: PendingApprovalPayload[];
+  resolving: boolean;
+  onResolve: (approvalId: string, payload: ApprovalDecisionRequest) => Promise<void>;
+}
+
+function shortId(value: string) {
+  return value.slice(0, 8);
+}
+
+function formatJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+export default function ApprovalDialog({ pendingApprovals, resolving, onResolve }: ApprovalDialogProps) {
+  const [selectedApprovalId, setSelectedApprovalId] = useState<string | null>(null);
+  const [argumentText, setArgumentText] = useState('');
+  const [feedback, setFeedback] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const selectedApproval =
+    pendingApprovals.find((approval) => approval.approval_id === selectedApprovalId) ?? pendingApprovals[0] ?? null;
+  const originalArgumentText = selectedApproval ? formatJson(selectedApproval.arguments) : '';
+  const hasArgumentEdits = argumentText.trim() !== originalArgumentText.trim();
+
+  useEffect(() => {
+    const next = pendingApprovals[0] ?? null;
+    setSelectedApprovalId((current) =>
+      current && pendingApprovals.some((approval) => approval.approval_id === current)
+        ? current
+        : next?.approval_id ?? null,
+    );
+  }, [pendingApprovals]);
+
+  useEffect(() => {
+    if (!selectedApproval) {
+      setArgumentText('');
+      setFeedback('');
+      setLocalError(null);
+      return;
+    }
+
+    setArgumentText(formatJson(selectedApproval.arguments));
+    setFeedback('');
+    setLocalError(null);
+  }, [selectedApproval?.approval_id]);
+
+  async function submitDecision(approved: boolean, includeEditedArguments: boolean) {
+    if (!selectedApproval) return;
+
+    setLocalError(null);
+    let editedArguments: Record<string, unknown> | null = null;
+
+    if (includeEditedArguments) {
+      try {
+        const parsed = JSON.parse(argumentText) as unknown;
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          setLocalError('Edited arguments must be a JSON object.');
+          return;
+        }
+        editedArguments = parsed as Record<string, unknown>;
+      } catch {
+        setLocalError('Edited arguments are not valid JSON.');
+        return;
+      }
+    }
+
+    await onResolve(selectedApproval.approval_id, {
+      approved,
+      user_feedback: feedback.trim() || null,
+      edited_arguments: editedArguments,
+    });
+  }
+
+  if (!selectedApproval) {
+    return (
+      <section className="approval-dialog approval-empty">
+        <div>
+          <p className="panel-label">Approval dialog</p>
+          <h3>No pending approvals</h3>
+        </div>
+        <p className="muted">When the agent needs permission to run a command or patch, the review dialog appears here.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="approval-dialog">
+      <div className="approval-dialog-header">
+        <div>
+          <p className="panel-label">Approval dialog</p>
+          <h3>{selectedApproval.tool_name}</h3>
+        </div>
+        <span className="status-chip warning">{shortId(selectedApproval.approval_id)}</span>
+      </div>
+
+      {pendingApprovals.length > 1 ? (
+        <div className="approval-tabs" aria-label="Pending approvals">
+          {pendingApprovals.map((approval) => (
+            <button
+              key={approval.approval_id}
+              type="button"
+              className={approval.approval_id === selectedApproval.approval_id ? 'active' : ''}
+              onClick={() => setSelectedApprovalId(approval.approval_id)}
+            >
+              {approval.tool_name} / {shortId(approval.approval_id)}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="approval-payload">
+        <div className="approval-section-label">
+          <strong>Exact payload</strong>
+          <span>{selectedApproval.tool_call_id}</span>
+        </div>
+        <pre>{originalArgumentText}</pre>
+      </div>
+
+      <label className="approval-edit-field">
+        Edited arguments
+        <textarea
+          rows={8}
+          value={argumentText}
+          onChange={(event) => setArgumentText(event.target.value)}
+          spellCheck={false}
+          disabled={resolving}
+        />
+      </label>
+
+      <label className="approval-feedback-field">
+        Feedback
+        <textarea
+          rows={3}
+          placeholder="Explain the approval, rejection, or requested change."
+          value={feedback}
+          onChange={(event) => setFeedback(event.target.value)}
+          disabled={resolving}
+        />
+      </label>
+
+      {localError ? <p className="approval-error">{localError}</p> : null}
+
+      <div className="approval-actions">
+        <button className="ghost-button danger-action" type="button" disabled={resolving} onClick={() => void submitDecision(false, false)}>
+          Reject
+        </button>
+        <button className="ghost-button" type="button" disabled={resolving || !feedback.trim()} onClick={() => void submitDecision(false, false)}>
+          Send feedback
+        </button>
+        <button className="ghost-button" type="button" disabled={resolving || !hasArgumentEdits} onClick={() => void submitDecision(true, true)}>
+          Approve edited
+        </button>
+        <button className="primary-button" type="button" disabled={resolving} onClick={() => void submitDecision(true, false)}>
+          Approve
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -158,6 +158,11 @@ button {
   border-color: rgba(251, 113, 133, 0.35);
 }
 
+.status-chip.warning {
+  color: #fde68a;
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
 .status-chip.neutral {
   color: #bfdbfe;
   border-color: rgba(56, 189, 248, 0.28);
@@ -436,6 +441,135 @@ button {
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
+}
+
+.approval-dialog {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  border-radius: 20px;
+  background:
+    linear-gradient(135deg, rgba(245, 158, 11, 0.1), transparent 42%),
+    rgba(8, 15, 28, 0.9);
+}
+
+.approval-empty {
+  border-color: var(--border);
+  background: rgba(8, 15, 28, 0.88);
+}
+
+.approval-dialog-header,
+.approval-section-label,
+.approval-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.approval-dialog h3 {
+  margin: 4px 0 0;
+  letter-spacing: -0.03em;
+}
+
+.approval-tabs {
+  display: grid;
+  gap: 8px;
+}
+
+.approval-tabs button {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 14px;
+  padding: 10px 12px;
+  background: rgba(3, 7, 18, 0.54);
+  color: var(--muted);
+  text-align: left;
+}
+
+.approval-tabs button.active {
+  border-color: rgba(245, 158, 11, 0.42);
+  color: var(--text);
+}
+
+.approval-section-label {
+  align-items: center;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.approval-section-label span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.approval-payload pre,
+.approval-edit-field textarea,
+.approval-feedback-field textarea {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.68);
+  color: var(--text);
+  font-family: "JetBrains Mono", "Cascadia Code", monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.approval-payload pre {
+  max-height: 170px;
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.approval-edit-field,
+.approval-feedback-field {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.approval-edit-field textarea,
+.approval-feedback-field textarea {
+  resize: vertical;
+  padding: 12px;
+  outline: none;
+}
+
+.approval-edit-field textarea:focus,
+.approval-feedback-field textarea:focus {
+  border-color: rgba(245, 158, 11, 0.42);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+}
+
+.approval-feedback-field textarea {
+  font-family: inherit;
+}
+
+.approval-error {
+  margin: 0;
+  color: #fecdd3;
+  font-size: 0.82rem;
+}
+
+.approval-actions {
+  flex-wrap: wrap;
+}
+
+.approval-actions button {
+  flex: 1 1 120px;
+}
+
+.danger-action {
+  color: #fecdd3;
+  border-color: rgba(251, 113, 133, 0.28);
 }
 
 .tool-trace-panel {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -63,6 +63,13 @@ export interface ChatRequest {
   system_prompt?: string | null;
 }
 
+export interface ApprovalDecisionRequest {
+  approved: boolean;
+  user_feedback?: string | null;
+  edited_arguments?: Record<string, unknown> | null;
+  system_prompt?: string | null;
+}
+
 export interface TurnResultPayload {
   status: string;
   content: string | null;

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -371,6 +371,84 @@ def test_approval_flow_replays_terminal_events_after_reconnect(
     )
 
 
+def test_approval_route_resumes_loop_with_edited_arguments(tmp_path: Path, monkeypatch) -> None:
+    settings = _settings(tmp_path)
+    repository = SQLiteRepository(settings.db_path)
+    repository.initialize()
+    llm = ApprovalFlowLLMClient(final_content="Edited command finished.")
+
+    async def run_command_handler(args: dict[str, object], _settings: AppSettings) -> str:
+        return f"command executed: {args['command']}"
+
+    monkeypatch.setattr("app.tools.workspace.run_command_handler", run_command_handler)
+
+    def repository_factory(_: AppSettings) -> SQLiteRepository:
+        return repository
+
+    def loop_factory(app_settings: AppSettings, repo: SQLiteRepository):
+        from app.agent.loop import create_agent_loop
+
+        return create_agent_loop(
+            app_settings,
+            repository=repo,
+            llm_client=llm,
+        )
+
+    app = create_app(
+        settings,
+        repository_factory=repository_factory,
+        loop_factory=loop_factory,
+    )
+    client = TestClient(app)
+
+    created = client.post("/api/session", json={"title": "Approval API"})
+    session_id = created.json()["id"]
+    chat_response = client.post(
+        f"/api/chat/{session_id}",
+        json={"message": "Please run the command"},
+    )
+    approval_id = chat_response.json()["result"]["approval_ids"][0]
+
+    response = client.post(
+        f"/api/approval/{session_id}/{approval_id}",
+        json={
+            "approved": True,
+            "user_feedback": "use the focused test target",
+            "edited_arguments": {"command": "pytest tests/unit/test_api.py -q"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["status"] == "complete"
+    assert body["result"]["resolved_approval_id"] is None
+    assert body["session"]["status"] == "idle"
+    assert body["session"]["pending_approval_count"] == 0
+    assert body["messages"][2]["content"] == "command executed: pytest tests/unit/test_api.py -q"
+
+    approval = repository.get_approval(approval_id)
+    assert approval is not None
+    assert approval.status == "approved"
+    assert approval.user_feedback == "use the focused test target"
+    assert approval.edited_payload_json == '{"command": "pytest tests/unit/test_api.py -q"}'
+
+
+def test_approval_route_returns_404_for_unknown_pending_approval(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+
+    created = client.post("/api/session", json={"title": "Missing Approval"})
+    session_id = created.json()["id"]
+
+    response = client.post(
+        f"/api/approval/{session_id}/missing-approval",
+        json={"approved": False, "user_feedback": "not this one"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Pending approval not found"}
+
+
 def test_interrupt_route_reports_idle_session(tmp_path: Path) -> None:
     app = create_app(_settings(tmp_path))
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- add an HTTP approval decision route that resumes pending tool approvals from the web UI
- add a frontend approval dialog that shows the exact pending payload, supports feedback, and allows edited JSON arguments
- keep session state, transcript, live events, and tool traces refreshed after approval decisions

## Testing
- `pytest tests/unit/test_api.py -q`
- `pytest -q`
- `npm run build`
- `npm audit --omit=dev`
- `pre-commit run --all-files`

## Notes
The dialog intentionally keeps approval review in the inspector panel so the conversation view remains focused on chat while pending tool actions are reviewed next to trace details.

## Reference
Issue: #70
