### PR TITLE
ML-208 / Add observability and usage accounting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ LLM_MODEL=gpt-5.4
 # Optional request timeout for model calls.
 LLM_TIMEOUT_SECONDS=600
 
+# Rough usage-accounting rates used for session cost estimates.
+# These are intentionally configurable so you can match your provider pricing.
+LLM_PROMPT_COST_PER_1K_TOKENS_USD=0.0015
+LLM_COMPLETION_COST_PER_1K_TOKENS_USD=0.006
+
 # -----------------------------------------------------------------------------
 # Workspace and persistence
 # -----------------------------------------------------------------------------

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -6,10 +6,11 @@ import asyncio
 import json
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from time import perf_counter
 from typing import Any, Callable
 
-from app.agent.llm import LLMClient
+from app.agent.llm import LLMClient, Usage
 from app.config import AppSettings
 from app.storage.models import MessageRecord, PendingApprovalRecord, SessionRecord
 from app.storage.repository import SQLiteRepository
@@ -77,6 +78,48 @@ class TurnContext:
     messages: list[dict[str, Any]]
     event_sequence: int
     message_sequence: int
+
+
+@dataclass
+class TurnMetricsAccumulator:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    tool_calls: int = 0
+    tool_errors: int = 0
+    tool_retries: int = 0
+    tool_latency_ms: float = 0.0
+    error_count: int = 0
+    seen_fingerprints: set[str] = field(default_factory=set)
+
+    def record_usage(self, usage: Usage) -> None:
+        self.prompt_tokens += max(0, usage.prompt_tokens)
+        self.completion_tokens += max(0, usage.completion_tokens)
+        self.total_tokens += max(0, usage.total_tokens or usage.prompt_tokens + usage.completion_tokens)
+
+    def record_tool_call(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        self.tool_calls += 1
+        fingerprint = f"{tool_name}:{json.dumps(arguments, sort_keys=True, separators=(',', ':'))}"
+        if fingerprint in self.seen_fingerprints:
+            self.tool_retries += 1
+        else:
+            self.seen_fingerprints.add(fingerprint)
+
+    def record_tool_error(self) -> None:
+        self.tool_errors += 1
+        self.error_count += 1
+
+    def record_failure(self) -> None:
+        self.error_count += 1
+
+    def record_tool_latency(self, elapsed_ms: float) -> None:
+        self.tool_latency_ms += max(0.0, elapsed_ms)
+
+
+def _estimate_turn_cost_usd(settings: AppSettings, metrics: TurnMetricsAccumulator) -> float:
+    prompt_cost = metrics.prompt_tokens * settings.usage.prompt_cost_per_1k_tokens_usd / 1000.0
+    completion_cost = metrics.completion_tokens * settings.usage.completion_cost_per_1k_tokens_usd / 1000.0
+    return round(prompt_cost + completion_cost, 6)
 
 
 class AgentLoop:
@@ -242,10 +285,20 @@ class AgentLoop:
     ) -> dict[str, Any]:
         tool_specs = self.tools.openai_tools()
         iterations = 0
+        turn_started_at = _utc_now()
+        metrics = TurnMetricsAccumulator()
 
         while iterations < MAX_ITERATIONS:
             if self._interrupted:
                 await self.emit_event(ctx, EventType.INTERRUPTED, {})
+                await self._record_turn_metrics(
+                    session=session,
+                    turn_id=ctx.turn_id,
+                    metrics=metrics,
+                    status="interrupted",
+                    iterations=iterations,
+                    started_at=turn_started_at,
+                )
                 return {"status": "interrupted", "iterations": iterations}
 
             iterations += 1
@@ -257,12 +310,34 @@ class AgentLoop:
                     tool_choice="auto" if tool_specs else None,
                     stream=True,
                 )
+            except asyncio.CancelledError:
+                await self.emit_event(ctx, EventType.INTERRUPTED, {"message": "Turn interrupted."})
+                await self._record_turn_metrics(
+                    session=session,
+                    turn_id=ctx.turn_id,
+                    metrics=metrics,
+                    status="interrupted",
+                    iterations=iterations,
+                    started_at=turn_started_at,
+                )
+                raise
             except Exception as exc:
+                metrics.record_failure()
                 await self.emit_event(ctx, EventType.ERROR, {"error": str(exc)})
+                await self._record_turn_metrics(
+                    session=session,
+                    turn_id=ctx.turn_id,
+                    metrics=metrics,
+                    status="error",
+                    iterations=iterations,
+                    started_at=turn_started_at,
+                )
                 raise
 
             full_content = response.content
             tool_calls = response.tool_calls
+            if response.usage is not None:
+                metrics.record_usage(response.usage)
 
             if full_content:
                 await self.emit_event(
@@ -301,12 +376,21 @@ class AgentLoop:
             if not tool_calls:
                 await self.emit_event(ctx, EventType.ASSISTANT_MESSAGE, {"content": full_content or ""})
                 await self.emit_event(ctx, EventType.TURN_COMPLETE, {"iterations": iterations})
+                await self._record_turn_metrics(
+                    session=session,
+                    turn_id=ctx.turn_id,
+                    metrics=metrics,
+                    status="complete",
+                    iterations=iterations,
+                    started_at=turn_started_at,
+                )
                 return {"status": "complete", "content": full_content, "iterations": iterations}
 
             pending_payloads: list[dict[str, Any]] = []
             approval_ids: list[str] = []
 
             for tool_call in tool_calls:
+                metrics.record_tool_call(tool_call.name, {"__raw_arguments__": tool_call.arguments})
                 await self.emit_event(
                     ctx,
                     EventType.TOOL_CALL,
@@ -321,6 +405,7 @@ class AgentLoop:
                     arguments = tool_call.arguments_as_json()
                 except Exception as exc:
                     error_message = f"Tool execution error: {exc}"
+                    metrics.record_tool_error()
                     self.repo.add_tool_call(
                         session_id=ctx.session_id,
                         turn_id=ctx.turn_id,
@@ -380,6 +465,7 @@ class AgentLoop:
                     tool_call_id=tool_call.id,
                     tool_name=tool_call.name,
                     arguments=arguments,
+                    metrics=metrics,
                 )
 
             if pending_payloads:
@@ -387,6 +473,14 @@ class AgentLoop:
                     ctx,
                     EventType.APPROVAL_REQUIRED,
                     {"tools": pending_payloads, "count": len(pending_payloads)},
+                )
+                await self._record_turn_metrics(
+                    session=session,
+                    turn_id=ctx.turn_id,
+                    metrics=metrics,
+                    status="approval_required",
+                    iterations=iterations,
+                    started_at=turn_started_at,
                 )
                 return {
                     "status": "approval_required",
@@ -396,6 +490,14 @@ class AgentLoop:
                 }
 
         await self.emit_event(ctx, EventType.TURN_COMPLETE, {"iterations": iterations, "max_reached": True})
+        await self._record_turn_metrics(
+            session=session,
+            turn_id=ctx.turn_id,
+            metrics=metrics,
+            status="max_iterations",
+            iterations=iterations,
+            started_at=turn_started_at,
+        )
         return {"status": "max_iterations", "iterations": iterations}
 
     async def _execute_tool_call(
@@ -405,6 +507,7 @@ class AgentLoop:
         tool_call_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        metrics: TurnMetricsAccumulator | None = None,
     ) -> None:
         now = _utc_now()
         existing = self.repo.get_tool_call(tool_call_id)
@@ -428,11 +531,15 @@ class AgentLoop:
                 error=None,
             )
 
+        start = perf_counter()
         try:
             tool_output = await self.tools.call(tool_name, arguments)
             success = True
             error = None
         except asyncio.CancelledError:
+            if metrics is not None:
+                metrics.record_tool_error()
+                metrics.record_tool_latency((perf_counter() - start) * 1000.0)
             tool_output = "Tool execution interrupted."
             self.repo.update_tool_call(
                 tool_call_id,
@@ -452,10 +559,14 @@ class AgentLoop:
             )
             raise
         except Exception as exc:
+            if metrics is not None:
+                metrics.record_tool_error()
             tool_output = f"Tool execution error: {exc}"
             success = False
             error = str(exc)
 
+        if metrics is not None:
+            metrics.record_tool_latency((perf_counter() - start) * 1000.0)
         self.repo.update_tool_call(
             tool_call_id,
             status="completed" if success else "failed",
@@ -471,6 +582,35 @@ class AgentLoop:
             tool_name=tool_name,
             output=tool_output,
             success=success,
+        )
+
+    async def _record_turn_metrics(
+        self,
+        *,
+        session: SessionRecord,
+        turn_id: str,
+        metrics: TurnMetricsAccumulator,
+        status: str,
+        iterations: int,
+        started_at: str,
+    ) -> None:
+        finished_at = _utc_now()
+        self.repo.add_turn_metrics(
+            session_id=session.id,
+            turn_id=turn_id,
+            status=status,
+            iterations=iterations,
+            prompt_tokens=metrics.prompt_tokens,
+            completion_tokens=metrics.completion_tokens,
+            total_tokens=metrics.total_tokens,
+            estimated_cost_usd=_estimate_turn_cost_usd(self.settings, metrics),
+            tool_calls=metrics.tool_calls,
+            tool_errors=metrics.tool_errors,
+            tool_retries=metrics.tool_retries,
+            tool_latency_ms=round(metrics.tool_latency_ms, 2),
+            error_count=metrics.error_count,
+            started_at=started_at,
+            finished_at=finished_at,
         )
 
     async def _record_tool_output(

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -390,7 +390,6 @@ class AgentLoop:
             approval_ids: list[str] = []
 
             for tool_call in tool_calls:
-                metrics.record_tool_call(tool_call.name, {"__raw_arguments__": tool_call.arguments})
                 await self.emit_event(
                     ctx,
                     EventType.TOOL_CALL,
@@ -405,6 +404,7 @@ class AgentLoop:
                     arguments = tool_call.arguments_as_json()
                 except Exception as exc:
                     error_message = f"Tool execution error: {exc}"
+                    metrics.record_tool_call(tool_call.name, {"__raw_arguments__": tool_call.arguments})
                     metrics.record_tool_error()
                     self.repo.add_tool_call(
                         session_id=ctx.session_id,
@@ -432,6 +432,7 @@ class AgentLoop:
                 requires_approval = (
                     self.settings.safety.require_tool_approval and tool_call.name in APPROVAL_REQUIRED_TOOLS
                 )
+                metrics.record_tool_call(tool_call.name, arguments)
                 if requires_approval:
                     self.repo.add_tool_call(
                         session_id=ctx.session_id,

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -11,7 +11,15 @@ from fastapi.responses import StreamingResponse
 
 from app.agent.loop import AgentLoop, create_agent_loop
 from app.config import AppSettings
-from app.storage.models import MessageRecord, PendingApprovalRecord, SessionRecord, ToolCallRecord
+from app.storage.models import (
+    MessageRecord,
+    PendingApprovalRecord,
+    SessionRecord,
+    ToolCallRecord,
+)
+from app.storage.models import (
+    SessionMetricsSummary as SessionMetricsRecord,
+)
 from app.storage.repository import SQLiteRepository
 
 from .runtime import ActiveTurnManager
@@ -24,6 +32,7 @@ from .schemas import (
     MessagePayload,
     PendingApprovalPayload,
     SessionDetail,
+    SessionMetricsSummary,
     SessionSummary,
     ToolCallPayload,
     TurnResultPayload,
@@ -279,6 +288,7 @@ def _get_session_or_404(repo: SQLiteRepository, session_id: str) -> SessionRecor
 
 
 def _serialize_session_summary(repo: SQLiteRepository, session: SessionRecord) -> SessionSummary:
+    metrics = _serialize_session_metrics(repo.get_session_metrics_summary(session.id))
     return SessionSummary(
         id=session.id,
         title=session.title,
@@ -290,6 +300,7 @@ def _serialize_session_summary(repo: SQLiteRepository, session: SessionRecord) -
         message_count=len(repo.list_messages(session.id)),
         event_count=len(repo.list_events(session.id)),
         pending_approval_count=len(repo.list_pending_approvals(session.id)),
+        metrics=metrics,
     )
 
 
@@ -299,6 +310,24 @@ def _serialize_session_detail(repo: SQLiteRepository, session: SessionRecord) ->
         **summary.model_dump(),
         pending_approvals=[_serialize_pending_approval(item) for item in repo.list_pending_approvals(session.id)],
         tool_calls=[_serialize_tool_call(tool_call) for tool_call in repo.list_tool_calls(session.id)],
+    )
+
+
+def _serialize_session_metrics(record: SessionMetricsRecord) -> SessionMetricsSummary:
+    return SessionMetricsSummary(
+        session_id=record.session_id,
+        turn_count=record.turn_count,
+        prompt_tokens=record.prompt_tokens,
+        completion_tokens=record.completion_tokens,
+        total_tokens=record.total_tokens,
+        estimated_cost_usd=record.estimated_cost_usd,
+        tool_calls=record.tool_calls,
+        tool_errors=record.tool_errors,
+        tool_retries=record.tool_retries,
+        tool_latency_ms=record.tool_latency_ms,
+        average_tool_latency_ms=record.average_tool_latency_ms,
+        error_count=record.error_count,
+        last_updated_at=record.last_updated_at,
     )
 
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -32,6 +32,22 @@ class PendingApprovalPayload(BaseModel):
     arguments: dict[str, Any]
 
 
+class SessionMetricsSummary(BaseModel):
+    session_id: str
+    turn_count: int
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    estimated_cost_usd: float
+    tool_calls: int
+    tool_errors: int
+    tool_retries: int
+    tool_latency_ms: float
+    average_tool_latency_ms: float
+    error_count: int
+    last_updated_at: str | None
+
+
 class ToolCallPayload(BaseModel):
     id: str
     session_id: str
@@ -72,6 +88,7 @@ class SessionSummary(BaseModel):
     message_count: int
     event_count: int
     pending_approval_count: int
+    metrics: SessionMetricsSummary
 
 
 class SessionDetail(SessionSummary):

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,12 @@ class SafetySettings:
 
 
 @dataclass(frozen=True)
+class UsageAccountingSettings:
+    prompt_cost_per_1k_tokens_usd: float
+    completion_cost_per_1k_tokens_usd: float
+
+
+@dataclass(frozen=True)
 class AppSettings:
     app_name: str
     version: str
@@ -57,6 +63,7 @@ class AppSettings:
     llm: LLMSettings
     db_path: Path
     safety: SafetySettings
+    usage: UsageAccountingSettings
 
     @classmethod
     def from_paths(cls, paths: AppPaths) -> "AppSettings":
@@ -76,6 +83,10 @@ class AppSettings:
                 require_tool_approval=True,
                 allow_destructive_commands=False,
                 redact_secrets=True,
+            ),
+            usage=UsageAccountingSettings(
+                prompt_cost_per_1k_tokens_usd=0.0015,
+                completion_cost_per_1k_tokens_usd=0.006,
             ),
         )
 
@@ -133,6 +144,20 @@ class AppSettings:
                     default=True,
                 ),
             ),
+            usage=UsageAccountingSettings(
+                prompt_cost_per_1k_tokens_usd=parse_float(
+                    "LLM_PROMPT_COST_PER_1K_TOKENS_USD",
+                    merged_env.get("LLM_PROMPT_COST_PER_1K_TOKENS_USD"),
+                    default=0.0015,
+                    minimum=0.0,
+                ),
+                completion_cost_per_1k_tokens_usd=parse_float(
+                    "LLM_COMPLETION_COST_PER_1K_TOKENS_USD",
+                    merged_env.get("LLM_COMPLETION_COST_PER_1K_TOKENS_USD"),
+                    default=0.006,
+                    minimum=0.0,
+                ),
+            ),
         )
 
 
@@ -160,6 +185,16 @@ def parse_int(name: str, value: str | None, *, default: int, minimum: int | None
         return default
 
     parsed = int(value)
+    if minimum is not None and parsed < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {parsed}.")
+    return parsed
+
+
+def parse_float(name: str, value: str | None, *, default: float, minimum: float | None = None) -> float:
+    if value is None:
+        return default
+
+    parsed = float(value)
     if minimum is not None and parsed < minimum:
         raise ValueError(f"{name} must be >= {minimum}, got {parsed}.")
     return parsed

--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -64,6 +64,44 @@ class ToolCallRecord:
 
 
 @dataclass(frozen=True)
+class TurnMetricsRecord:
+    id: str
+    session_id: str
+    turn_id: str
+    status: str
+    iterations: int
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    estimated_cost_usd: float
+    tool_calls: int
+    tool_errors: int
+    tool_retries: int
+    tool_latency_ms: float
+    error_count: int
+    started_at: str
+    finished_at: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class SessionMetricsSummary:
+    session_id: str
+    turn_count: int
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    estimated_cost_usd: float
+    tool_calls: int
+    tool_errors: int
+    tool_retries: int
+    tool_latency_ms: float
+    average_tool_latency_ms: float
+    error_count: int
+    last_updated_at: str | None
+
+
+@dataclass(frozen=True)
 class ApprovalRecord:
     id: str
     session_id: str

--- a/app/storage/repository.py
+++ b/app/storage/repository.py
@@ -15,8 +15,10 @@ from app.storage.models import (
     MessageRecord,
     PendingApprovalRecord,
     SessionHistory,
+    SessionMetricsSummary,
     SessionRecord,
     ToolCallRecord,
+    TurnMetricsRecord,
     utc_now,
 )
 
@@ -101,6 +103,29 @@ SCHEMA_STATEMENTS = (
         started_at TEXT NOT NULL,
         finished_at TEXT,
         report_json TEXT NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS turn_metrics (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        iterations INTEGER NOT NULL,
+        prompt_tokens INTEGER NOT NULL,
+        completion_tokens INTEGER NOT NULL,
+        total_tokens INTEGER NOT NULL,
+        estimated_cost_usd REAL NOT NULL,
+        tool_calls INTEGER NOT NULL,
+        tool_errors INTEGER NOT NULL,
+        tool_retries INTEGER NOT NULL,
+        tool_latency_ms REAL NOT NULL,
+        error_count INTEGER NOT NULL,
+        started_at TEXT NOT NULL,
+        finished_at TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (session_id, turn_id),
         FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
     )
     """,
@@ -885,6 +910,183 @@ class SQLiteRepository:
             rows = connection.execute(query, params).fetchall()
         return [_eval_run_from_row(row) for row in rows]
 
+    def add_turn_metrics(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        status: str,
+        iterations: int,
+        prompt_tokens: int,
+        completion_tokens: int,
+        total_tokens: int,
+        estimated_cost_usd: float,
+        tool_calls: int,
+        tool_errors: int,
+        tool_retries: int,
+        tool_latency_ms: float,
+        error_count: int,
+        started_at: str,
+        finished_at: str,
+        metric_id: str | None = None,
+    ) -> TurnMetricsRecord:
+        record = TurnMetricsRecord(
+            id=metric_id or str(uuid.uuid4()),
+            session_id=session_id,
+            turn_id=turn_id,
+            status=status,
+            iterations=iterations,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            estimated_cost_usd=estimated_cost_usd,
+            tool_calls=tool_calls,
+            tool_errors=tool_errors,
+            tool_retries=tool_retries,
+            tool_latency_ms=tool_latency_ms,
+            error_count=error_count,
+            started_at=started_at,
+            finished_at=finished_at,
+            created_at=utc_now(),
+        )
+        with connect_sqlite(self.database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO turn_metrics (
+                    id,
+                    session_id,
+                    turn_id,
+                    status,
+                    iterations,
+                    prompt_tokens,
+                    completion_tokens,
+                    total_tokens,
+                    estimated_cost_usd,
+                    tool_calls,
+                    tool_errors,
+                    tool_retries,
+                    tool_latency_ms,
+                    error_count,
+                    started_at,
+                    finished_at,
+                    created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(session_id, turn_id) DO UPDATE SET
+                    status = excluded.status,
+                    iterations = excluded.iterations,
+                    prompt_tokens = excluded.prompt_tokens,
+                    completion_tokens = excluded.completion_tokens,
+                    total_tokens = excluded.total_tokens,
+                    estimated_cost_usd = excluded.estimated_cost_usd,
+                    tool_calls = excluded.tool_calls,
+                    tool_errors = excluded.tool_errors,
+                    tool_retries = excluded.tool_retries,
+                    tool_latency_ms = excluded.tool_latency_ms,
+                    error_count = excluded.error_count,
+                    started_at = excluded.started_at,
+                    finished_at = excluded.finished_at
+                """,
+                (
+                    record.id,
+                    record.session_id,
+                    record.turn_id,
+                    record.status,
+                    record.iterations,
+                    record.prompt_tokens,
+                    record.completion_tokens,
+                    record.total_tokens,
+                    record.estimated_cost_usd,
+                    record.tool_calls,
+                    record.tool_errors,
+                    record.tool_retries,
+                    record.tool_latency_ms,
+                    record.error_count,
+                    record.started_at,
+                    record.finished_at,
+                    record.created_at,
+                ),
+            )
+            self._touch_session(connection, session_id)
+            connection.commit()
+        return record
+
+    def list_turn_metrics(self, session_id: str) -> list[TurnMetricsRecord]:
+        with connect_sqlite(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT
+                    id,
+                    session_id,
+                    turn_id,
+                    status,
+                    iterations,
+                    prompt_tokens,
+                    completion_tokens,
+                    total_tokens,
+                    estimated_cost_usd,
+                    tool_calls,
+                    tool_errors,
+                    tool_retries,
+                    tool_latency_ms,
+                    error_count,
+                    started_at,
+                    finished_at,
+                    created_at
+                FROM turn_metrics
+                WHERE session_id = ?
+                ORDER BY created_at ASC, turn_id ASC
+                """,
+                (session_id,),
+            ).fetchall()
+        return [_turn_metrics_from_row(row) for row in rows]
+
+    def get_session_metrics_summary(self, session_id: str) -> SessionMetricsSummary:
+        metrics = self.list_turn_metrics(session_id)
+        if not metrics:
+            return SessionMetricsSummary(
+                session_id=session_id,
+                turn_count=0,
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                estimated_cost_usd=0.0,
+                tool_calls=0,
+                tool_errors=0,
+                tool_retries=0,
+                tool_latency_ms=0.0,
+                average_tool_latency_ms=0.0,
+                error_count=0,
+                last_updated_at=None,
+            )
+
+        prompt_tokens = sum(metric.prompt_tokens for metric in metrics)
+        completion_tokens = sum(metric.completion_tokens for metric in metrics)
+        total_tokens = sum(metric.total_tokens for metric in metrics)
+        estimated_cost_usd = round(sum(metric.estimated_cost_usd for metric in metrics), 6)
+        tool_calls = sum(metric.tool_calls for metric in metrics)
+        tool_errors = sum(metric.tool_errors for metric in metrics)
+        tool_retries = sum(metric.tool_retries for metric in metrics)
+        tool_latency_ms = round(sum(metric.tool_latency_ms for metric in metrics), 2)
+        error_count = sum(metric.error_count for metric in metrics)
+        last_updated_at = max(metric.finished_at for metric in metrics)
+
+        return SessionMetricsSummary(
+            session_id=session_id,
+            turn_count=len(metrics),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            estimated_cost_usd=estimated_cost_usd,
+            tool_calls=tool_calls,
+            tool_errors=tool_errors,
+            tool_retries=tool_retries,
+            tool_latency_ms=tool_latency_ms,
+            average_tool_latency_ms=round(tool_latency_ms / tool_calls, 2) if tool_calls else 0.0,
+            error_count=error_count,
+            last_updated_at=last_updated_at,
+        )
+
     def get_session_history(self, session_id: str) -> SessionHistory:
         session = self.get_session(session_id)
         if session is None:
@@ -1029,4 +1231,26 @@ def _eval_run_from_row(row: sqlite3.Row) -> EvalRunRecord:
         started_at=row["started_at"],
         finished_at=row["finished_at"],
         report_json=row["report_json"],
+    )
+
+
+def _turn_metrics_from_row(row: sqlite3.Row) -> TurnMetricsRecord:
+    return TurnMetricsRecord(
+        id=row["id"],
+        session_id=row["session_id"],
+        turn_id=row["turn_id"],
+        status=row["status"],
+        iterations=row["iterations"],
+        prompt_tokens=row["prompt_tokens"],
+        completion_tokens=row["completion_tokens"],
+        total_tokens=row["total_tokens"],
+        estimated_cost_usd=row["estimated_cost_usd"],
+        tool_calls=row["tool_calls"],
+        tool_errors=row["tool_errors"],
+        tool_retries=row["tool_retries"],
+        tool_latency_ms=row["tool_latency_ms"],
+        error_count=row["error_count"],
+        started_at=row["started_at"],
+        finished_at=row["finished_at"],
+        created_at=row["created_at"],
     )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,21 @@ function titleForSession(session: SessionSummary | SessionDetail) {
   return session.title?.trim() || 'Untitled session';
 }
 
+function formatCompact(value: number) {
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 4 }).format(value);
+}
+
+function formatLatency(value: number) {
+  if (value < 1000) {
+    return `${Math.round(value)}ms`;
+  }
+  return `${(value / 1000).toFixed(2)}s`;
+}
+
 function roleLabel(role: string) {
   if (role === 'assistant') return 'Assistant';
   if (role === 'user') return 'User';
@@ -296,6 +311,12 @@ function App() {
     ? [
         { label: 'Messages', value: activeSession.message_count },
         { label: 'Events', value: activeSession.event_count },
+        { label: 'Turns', value: activeSession.metrics.turn_count },
+        { label: 'Tokens', value: formatCompact(activeSession.metrics.total_tokens) },
+        { label: 'Est. cost', value: formatCurrency(activeSession.metrics.estimated_cost_usd) },
+        { label: 'Tool latency', value: formatLatency(activeSession.metrics.tool_latency_ms) },
+        { label: 'Tool errors', value: activeSession.metrics.tool_errors },
+        { label: 'Retries', value: activeSession.metrics.tool_retries },
         { label: 'Approvals', value: activeSession.pending_approval_count },
       ]
     : [];
@@ -448,7 +469,12 @@ function App() {
               onResolve={handleResolveApproval}
             />
 
-            <ToolTracePanel liveEvents={liveEvents} pendingApprovals={pendingApprovals} toolCalls={toolCalls} />
+            <ToolTracePanel
+              liveEvents={liveEvents}
+              metrics={activeSession?.metrics ?? null}
+              pendingApprovals={pendingApprovals}
+              toolCalls={toolCalls}
+            />
           </div>
         </aside>
       </main>

--- a/frontend/src/components/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar.tsx
@@ -41,6 +41,14 @@ function formatPreview(message: MessagePayload) {
   return `${trimmed.slice(0, 93)}...`;
 }
 
+function formatCompact(value: number) {
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 4 }).format(value);
+}
+
 function roleLabel(role: string) {
   if (role === 'assistant') return 'Assistant';
   if (role === 'user') return 'User';
@@ -153,6 +161,9 @@ export default function SessionSidebar({
               <div className="session-card-meta">
                 <span>{currentSession.message_count} messages</span>
                 <span>{currentSession.event_count} events</span>
+                <span>{currentSession.metrics.turn_count} turns</span>
+                <span>{formatCompact(currentSession.metrics.total_tokens)} tokens</span>
+                <span>{formatCurrency(currentSession.metrics.estimated_cost_usd)}</span>
                 <span>Updated {formatTimestamp(currentSession.updated_at)}</span>
               </div>
             </div>

--- a/frontend/src/components/ToolTracePanel.tsx
+++ b/frontend/src/components/ToolTracePanel.tsx
@@ -1,8 +1,14 @@
-import type { PendingApprovalPayload, SessionEventPayload, ToolCallPayload } from '../types';
+import type {
+  PendingApprovalPayload,
+  SessionEventPayload,
+  SessionMetricsSummary,
+  ToolCallPayload,
+} from '../types';
 
 interface ToolTracePanelProps {
   liveEvents: SessionEventPayload[];
   pendingApprovals: PendingApprovalPayload[];
+  metrics: SessionMetricsSummary | null;
   toolCalls: ToolCallPayload[];
 }
 
@@ -77,6 +83,14 @@ function toneForStatus(status: string) {
   return 'neutral';
 }
 
+function formatCompact(value: number) {
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 4 }).format(value);
+}
+
 function groupToolCalls(toolCalls: ToolCallPayload[]) {
   const sorted = [...toolCalls].sort((a, b) => {
     const aTime = a.started_at ?? a.finished_at ?? '';
@@ -102,7 +116,7 @@ function groupToolCalls(toolCalls: ToolCallPayload[]) {
   return groups;
 }
 
-export default function ToolTracePanel({ liveEvents, pendingApprovals, toolCalls }: ToolTracePanelProps) {
+export default function ToolTracePanel({ liveEvents, pendingApprovals, metrics, toolCalls }: ToolTracePanelProps) {
   const grouped = groupToolCalls(toolCalls);
   const recentEvents = liveEvents.slice(-6);
 
@@ -115,6 +129,11 @@ export default function ToolTracePanel({ liveEvents, pendingApprovals, toolCalls
             <h3>
               {toolCalls.length} calls across {grouped.length} turns
             </h3>
+            <p className="muted">
+              {metrics
+                ? `${formatCompact(metrics.total_tokens)} tokens · ${formatCurrency(metrics.estimated_cost_usd)} est. spend`
+                : 'Usage metrics will appear after the first completed turn.'}
+            </p>
           </div>
           <span className="status-chip neutral">{recentEvents.length} live events</span>
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,6 +15,23 @@ export interface SessionSummary {
   message_count: number;
   event_count: number;
   pending_approval_count: number;
+  metrics: SessionMetricsSummary;
+}
+
+export interface SessionMetricsSummary {
+  session_id: string;
+  turn_count: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  estimated_cost_usd: number;
+  tool_calls: number;
+  tool_errors: number;
+  tool_retries: number;
+  tool_latency_ms: number;
+  average_tool_latency_ms: number;
+  error_count: number;
+  last_updated_at: string | null;
 }
 
 export interface PendingApprovalPayload {

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from app.agent.llm import LLMResponse, ToolCall
+from app.agent.llm import LLMResponse, ToolCall, Usage
 from app.agent.loop import AgentLoop, _create_tool_registry
 from app.config import AppPaths, AppSettings
 from app.storage.repository import SQLiteRepository
@@ -59,6 +59,39 @@ def test_tool_registry_includes_paper_details(tmp_path: Path) -> None:
 
     assert registry.get("paper_details").name == "paper_details"
     assert registry.get("analyze_ml_repo").name == "analyze_ml_repo"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_records_session_metrics(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    session = repository.create_session(session_id="session-1", title="Metrics", model="gpt-5.4")
+    llm = DummyLLM(
+        responses=[
+            LLMResponse(
+                model="gpt-5.4",
+                content="Metrics captured.",
+                finish_reason="stop",
+                usage=Usage(prompt_tokens=100, completion_tokens=40, total_tokens=140),
+            )
+        ]
+    )
+    loop = AgentLoop(
+        llm_client=llm,
+        tool_registry=_registry("unused", []),
+        repository=repository,
+        settings=_settings(tmp_path),
+    )
+
+    result = await loop.run_turn(session, "Measure this turn")
+    metrics = repository.get_session_metrics_summary(session.id)
+
+    assert result["status"] == "complete"
+    assert metrics.turn_count == 1
+    assert metrics.prompt_tokens == 100
+    assert metrics.completion_tokens == 40
+    assert metrics.total_tokens == 140
+    assert metrics.tool_calls == 0
+    assert metrics.estimated_cost_usd == 0.00039
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -9,18 +9,19 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from app.agent.llm import LLMResponse, ToolCall
+from app.agent.llm import LLMResponse, ToolCall, Usage
 from app.api import create_app
 from app.config import AppSettings
 from app.storage.repository import SQLiteRepository
 
 
 class FakeLLMClient:
-    def __init__(self, content: str = "Working on it.") -> None:
+    def __init__(self, content: str = "Working on it.", usage: Usage | None = None) -> None:
         self._content = content
+        self._usage = usage
 
     async def chat(self, **kwargs) -> LLMResponse:
-        return LLMResponse(model="gpt-test", content=self._content)
+        return LLMResponse(model="gpt-test", content=self._content, usage=self._usage)
 
 
 class BlockingLLMClient:
@@ -97,7 +98,10 @@ def test_chat_route_persists_messages_and_session_state(tmp_path: Path) -> None:
         return create_agent_loop(
             app_settings,
             repository=repository,
-            llm_client=FakeLLMClient(content="Repository summary ready."),
+            llm_client=FakeLLMClient(
+                content="Repository summary ready.",
+                usage=Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500),
+            ),
         )
 
     app = create_app(settings, loop_factory=loop_factory)
@@ -118,6 +122,9 @@ def test_chat_route_persists_messages_and_session_state(tmp_path: Path) -> None:
     assert body["result"]["status"] == "complete"
     assert body["result"]["content"] == "Repository summary ready."
     assert body["session"]["status"] == "idle"
+    assert body["session"]["metrics"]["turn_count"] == 1
+    assert body["session"]["metrics"]["total_tokens"] == 1500
+    assert body["session"]["metrics"]["estimated_cost_usd"] == 0.0045
     assert [message["role"] for message in body["messages"]] == ["user", "assistant"]
 
     assert messages.status_code == 200
@@ -129,6 +136,7 @@ def test_chat_route_persists_messages_and_session_state(tmp_path: Path) -> None:
     assert session.status_code == 200
     assert session.json()["message_count"] == 2
     assert session.json()["event_count"] >= 3
+    assert session.json()["metrics"]["tool_calls"] == 0
 
 
 def test_missing_session_returns_404(tmp_path: Path) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -23,6 +23,8 @@ def test_settings_wrap_default_paths() -> None:
     assert settings.llm.provider == "openai_compatible"
     assert settings.llm.base_url == "https://api.openai.com/v1"
     assert settings.safety.require_tool_approval is True
+    assert settings.usage.prompt_cost_per_1k_tokens_usd == 0.0015
+    assert settings.usage.completion_cost_per_1k_tokens_usd == 0.006
 
 
 def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
@@ -35,6 +37,8 @@ def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
             "ML_COPILOT_REQUIRE_TOOL_APPROVAL": "false",
             "ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS": "true",
             "ML_COPILOT_REDACT_SECRETS": "false",
+            "LLM_PROMPT_COST_PER_1K_TOKENS_USD": "0.01",
+            "LLM_COMPLETION_COST_PER_1K_TOKENS_USD": "0.02",
         }
     )
 
@@ -47,6 +51,8 @@ def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
     assert settings.safety.require_tool_approval is False
     assert settings.safety.allow_destructive_commands is True
     assert settings.safety.redact_secrets is False
+    assert settings.usage.prompt_cost_per_1k_tokens_usd == 0.01
+    assert settings.usage.completion_cost_per_1k_tokens_usd == 0.02
 
 
 def test_environment_prefers_process_env_over_env_file(tmp_path: Path) -> None:

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -17,6 +17,7 @@ def test_initialize_creates_expected_tables(tmp_path: Path) -> None:
         "tool_calls",
         "approvals",
         "eval_runs",
+        "turn_metrics",
     }.issubset(table_names)
 
 
@@ -227,6 +228,67 @@ def test_eval_run_lifecycle(tmp_path: Path) -> None:
     assert repository.get_eval_run("eval-1") == updated
     assert repository.list_eval_runs("fixture-1") == [updated]
     assert repository.list_eval_runs("missing") == []
+
+
+def test_turn_metrics_summary_aggregates_turn_data(tmp_path: Path) -> None:
+    repository = SQLiteRepository(tmp_path / "ml-copilot.db")
+    repository.initialize()
+    repository.create_session(
+        session_id="session-1",
+        title="Metrics",
+        model="gpt-5.4",
+    )
+    repository.add_turn_metrics(
+        session_id="session-1",
+        turn_id="turn-1",
+        status="complete",
+        iterations=2,
+        prompt_tokens=100,
+        completion_tokens=40,
+        total_tokens=140,
+        estimated_cost_usd=0.42,
+        tool_calls=3,
+        tool_errors=1,
+        tool_retries=1,
+        tool_latency_ms=250.5,
+        error_count=1,
+        started_at="2026-06-15T00:00:00+00:00",
+        finished_at="2026-06-15T00:00:03+00:00",
+        metric_id="metric-1",
+    )
+    repository.add_turn_metrics(
+        session_id="session-1",
+        turn_id="turn-2",
+        status="approval_required",
+        iterations=1,
+        prompt_tokens=60,
+        completion_tokens=12,
+        total_tokens=72,
+        estimated_cost_usd=0.18,
+        tool_calls=1,
+        tool_errors=0,
+        tool_retries=0,
+        tool_latency_ms=75.0,
+        error_count=0,
+        started_at="2026-06-15T00:01:00+00:00",
+        finished_at="2026-06-15T00:01:02+00:00",
+        metric_id="metric-2",
+    )
+
+    metrics = repository.get_session_metrics_summary("session-1")
+
+    assert metrics.turn_count == 2
+    assert metrics.prompt_tokens == 160
+    assert metrics.completion_tokens == 52
+    assert metrics.total_tokens == 212
+    assert metrics.estimated_cost_usd == 0.6
+    assert metrics.tool_calls == 4
+    assert metrics.tool_errors == 1
+    assert metrics.tool_retries == 1
+    assert metrics.tool_latency_ms == 325.5
+    assert metrics.average_tool_latency_ms == 81.38
+    assert metrics.error_count == 1
+    assert metrics.last_updated_at == "2026-06-15T00:01:02+00:00"
 
 
 def test_next_sequences_advance_with_history(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Summary
- add turn-level usage accounting backed by SQLite session metrics
- expose aggregated metrics in the session API so the frontend can show tokens, estimated spend, tool latency, errors, and retries
- surface the new observability data in the session sidebar, trace panel, and tests

## Testing
- `pytest -q`
- `npm run build`
- `pre-commit run --all-files`

## Notes
The cost figure is an estimated spend based on configurable prompt and completion token rates. It is intentionally lightweight and can be tuned through environment variables.

## Reference
Issue: #74
