### PR TITLE
ML-210 / Run release hardening and docs pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,17 @@ Most agent demos can talk about ML code. Fewer can work through an actual ML eng
 
 ## Product Shape
 
-The first version is intentionally narrow:
+The current release candidate is intentionally narrow:
 
 - Python backend and agent runtime
 - SQLite persistence
 - CLI for chat and repo workflows
 - FastAPI API with streaming events
+- React + Vite frontend shell for sessions, approvals, and tool traces
+- fixture-based eval runner with persisted scoring reports
+- Docker image for local deployment review
 - a small set of trustworthy tools
-- ML-specific helpers added only after the core loop is stable
+- ML-specific helpers for repository, dataset, docs, paper, and reporting workflows
 
 ## Architecture
 
@@ -137,36 +140,93 @@ Assistant responds
 - docs and paper helpers
 - eval runner
 - React + Vite frontend shell for chat, approvals, and tool traces
+- release packaging and documentation hardening
 
 ## Repo Boundaries
 
 This repository is only for the actual `ML Copilot` product.
 
-Planning notes and local reference material live outside this repo in the parent workspace, including:
-
-- project planning documents
-- Notion and issue workflow notes
-- `.codex-reference/ml-intern`
-
-That keeps the Git repository clean while still letting AI tooling use the surrounding workspace for context.
+Planning notes, local reference material, and personal workflow documents should stay outside this repository. That keeps the public Git history focused on product code, tests, docs, and release artifacts.
 
 ## Workflow Notes
 
 - [Issue and PR workflow guidance](docs/phase-2-issue-pr-workflow.md)
+- [Release readiness guide](docs/release-readiness.md)
+- [Eval runner guide](docs/phase-3-eval-runner.md)
 - Keep GitHub issue and PR titles aligned with the task ID and task name.
 - Keep issue labels, PR labels, and assignees in sync for each certified task.
 
-## Planned Stack
+## Setup
 
-- Python 3.12
-- FastAPI
-- Pydantic
-- SQLite
-- `httpx`
-- `uv`
-- `pytest`
-- `ruff`
-- React + TypeScript later, after backend contracts stabilize
+ML Copilot targets Python 3.12 and Node.js 22 for the bundled frontend.
+
+Install the backend in editable mode:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Install frontend dependencies:
+
+```bash
+cd frontend
+npm ci
+```
+
+Create a runtime environment file from the example:
+
+```bash
+cp .env.example .env
+```
+
+Set at least `LLM_API_KEY` and, when needed, adjust `LLM_BASE_URL`, `LLM_MODEL`, `ML_COPILOT_DB_PATH`, and the safety flags.
+
+## Run Locally
+
+Print the resolved backend configuration with secrets redacted:
+
+```bash
+python -m app.main --print-config
+```
+
+Run a CLI task:
+
+```bash
+python -m app.main run "Analyze this repository and summarize the ML components."
+```
+
+Start the API:
+
+```bash
+python -m uvicorn app.api:create_app --factory --host 127.0.0.1 --port 8000
+```
+
+Start the frontend in another terminal:
+
+```bash
+cd frontend
+npm run dev
+```
+
+The development frontend proxies `/api` to `http://127.0.0.1:8000`.
+
+## Validate
+
+Run the main local checks before opening a PR:
+
+```bash
+python -m pytest -q
+python -m ruff check app/ tests/
+python -m ruff format --check app/ tests/
+python -m mypy app/ --ignore-missing-imports --follow-imports=skip
+cd frontend && npm run build
+```
+
+Run a bundled eval fixture:
+
+```bash
+python -m app.main eval tests/fixtures/evals/ml-201-repo-analysis.json
+```
 
 ## Deployment Image
 
@@ -189,6 +249,18 @@ docker run --rm -p 8000:8000 \
 
 The image listens on port `8000`, stores the default SQLite database at `/data/ml-copilot.db`, and expects secrets such as `LLM_API_KEY` to be provided at runtime through environment variables or `--env-file`. The Docker build intentionally ignores local `.env` files, virtual environments, frontend build output, and `.ml-copilot` runtime data.
 
+## Safety Model
+
+ML Copilot is designed for inspectable local automation, not silent autonomous control:
+
+- tool calls are validated before execution
+- risky workspace actions can require explicit approval
+- destructive commands are disabled by default
+- secrets are redacted in user-facing configuration output
+- session history, tool calls, approvals, events, and usage metrics are persisted for review
+
+See [release readiness](docs/release-readiness.md) for the current limitations and release checklist.
+
 ## Success Criteria For MVP
 
 The MVP is successful when a user can:
@@ -203,4 +275,4 @@ The MVP is successful when a user can:
 
 ## Status
 
-Scaffolding the public repository and defining the architecture baseline.
+Phase 3 has backend, CLI, API, frontend, eval, observability, and Docker foundations in place for release review. Full autonomous research-and-training behavior remains future work.

--- a/docs/phase-2-issue-pr-workflow.md
+++ b/docs/phase-2-issue-pr-workflow.md
@@ -11,9 +11,10 @@
 ## GitHub Issue
 
 - Title: `ML-### / short task title`
-- Body sections: `Goal`, `Context`, `Scope`, `Acceptance Criteria`, `Notion`
+- Body sections: `Context`, `What needs to be done`, `Notes`
 - Assignee: the active owner doing the work
 - Labels: match the task type and keep them consistent with the PR
+- Do not include internal project-management metadata in the issue body
 
 ## Pull Request
 
@@ -22,6 +23,8 @@
 - Assignee: the active owner
 - Labels: match the issue labels exactly
 - Use a concise human tone, like a teammate handoff instead of a generated log
+- Reference the GitHub issue in the `Reference` section
+- Do not include internal project-management metadata in the PR body
 
 ## Review
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,0 +1,123 @@
+# Release Readiness
+
+This guide captures the current release-hardening posture for `ML Copilot`.
+
+## Current Release Shape
+
+The release candidate includes:
+
+- Python 3.12 backend and CLI
+- FastAPI session API with SSE event streaming
+- SQLite persistence for sessions, messages, events, approvals, tool calls, eval runs, and usage metrics
+- approval-aware agent loop with OpenAI-compatible model calls
+- repository, workspace, dataset, docs, papers, and reporting tools
+- React + Vite frontend shell for chat, sessions, approvals, tool traces, and metrics
+- fixture-based eval runner with JSON and Markdown reports
+- Dockerfile that builds the frontend and serves it from the backend runtime
+
+## Runtime Configuration
+
+Use `.env.example` as the source of truth for supported environment variables.
+
+Required for real model calls:
+
+- `LLM_PROVIDER`
+- `LLM_BASE_URL`
+- `LLM_API_KEY`
+- `LLM_MODEL`
+
+Important runtime paths and safety flags:
+
+- `ML_COPILOT_WORKSPACE_ROOT`
+- `ML_COPILOT_DB_PATH`
+- `ML_COPILOT_REQUIRE_TOOL_APPROVAL`
+- `ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS`
+- `ML_COPILOT_REDACT_SECRETS`
+
+Confirm the resolved configuration without printing secrets:
+
+```bash
+python -m app.main --print-config
+```
+
+## Local Release Checks
+
+Run these before tagging or merging release-facing changes:
+
+```bash
+python -m pytest -q
+python -m ruff check app/ tests/
+python -m ruff format --check app/ tests/
+python -m mypy app/ --ignore-missing-imports --follow-imports=skip
+python -m pre_commit run --all-files
+```
+
+Build the frontend:
+
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
+Run at least one bundled eval fixture:
+
+```bash
+python -m app.main eval tests/fixtures/evals/ml-201-repo-analysis.json
+```
+
+If Docker is available, verify the deployment image:
+
+```bash
+docker build -t ml-copilot .
+docker run --rm -p 8000:8000 --env-file .env -v ml-copilot-data:/data ml-copilot
+```
+
+## Safety Expectations
+
+The current safety model is intentionally conservative:
+
+- destructive command execution is disabled by default
+- risky tool calls can pause for approval
+- approval decisions and edited arguments are persisted
+- tool call arguments and outputs are recorded for review
+- configuration output redacts secrets
+- local `.env`, `.ml-copilot`, virtualenvs, and frontend build artifacts are excluded from Docker build context
+
+Keep `ML_COPILOT_REQUIRE_TOOL_APPROVAL=true` for normal use. Only set `ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS=true` in a disposable workspace where destructive file or shell operations are expected.
+
+## Eval Guidance
+
+Eval fixtures live in `tests/fixtures/evals/` and are designed to exercise practical ML-engineering tasks such as repository analysis, training-script repair, dataset validation, eval-script updates, and model-card inference.
+
+Each eval run writes:
+
+- a reproducible workspace under `.ml-copilot/evals/workspaces/`
+- a JSON report under `.ml-copilot/evals/artifacts/`
+- a Markdown reviewer report under `.ml-copilot/evals/artifacts/`
+- a persisted `eval_runs` record in SQLite
+
+Use `docs/phase-3-eval-runner.md` for the fixture schema and scoring fields.
+
+## Known Limitations
+
+This release does not yet provide fully autonomous ML research, training, and deployment. In particular:
+
+- paper discovery and citation-graph planning are helper-level capabilities, not an end-to-end autonomous research planner
+- dataset selection is assisted by tools and prompts, not a guaranteed automatic benchmark chooser
+- training-loop diagnosis is not yet a closed-loop experiment optimizer
+- Docker packaging is local-deployment oriented and does not include hosted infrastructure manifests
+- the frontend is a focused operator shell, not a full product onboarding flow
+- SQLite persistence is appropriate for local and MVP use, not multi-tenant production service operation
+
+These limits should be treated as explicit product boundaries for Phase 3 and inputs into future Phase 4 work.
+
+## Release Handoff Checklist
+
+- Issue and PR titles match the task ID and task name
+- Issue labels and PR labels match exactly
+- PR is assigned to the active owner
+- CI checks pass
+- A code-review comment is posted on the PR
+- Actionable review findings are fixed on the same branch
+- Notion notes include the merged PR and closed issue after user certification

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,10 +2,12 @@
 
 React + Vite shell for the ML Copilot API.
 
+The frontend expects the backend API to serve session, chat, approval, event stream, and metrics endpoints under `/api`.
+
 ## Run
 
 ```bash
-npm install
+npm ci
 npm run dev
 ```
 
@@ -22,3 +24,5 @@ VITE_API_BASE_URL=http://127.0.0.1:8000
 ```bash
 npm run build
 ```
+
+The production Dockerfile copies `frontend/dist` into the backend image. When that directory contains `index.html`, the FastAPI app serves the built frontend from `/` while keeping API routes under `/api`.


### PR DESCRIPTION
## Summary
- expand the README with current release shape, setup, local run, validation, deployment, safety, and status guidance
- add a release-readiness guide covering runtime configuration, checks, safety expectations, eval guidance, known limitations, and handoff checklist
- align the issue/PR workflow doc with the current templates and update frontend docs for `npm ci` and bundled deployment behavior

## Testing
- `python -m pytest -q`
- `python -m pre_commit run --all-files`
- `npm run build`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`

## Notes
This is a docs and release-hardening pass. It intentionally describes fully autonomous research-and-training behavior as future work rather than current release behavior.

## Reference
Issue: #78