### PR TITLE
ML-211 / Add MCP support follow-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,16 @@ ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS=false
 ML_COPILOT_REDACT_SECRETS=true
 
 # -----------------------------------------------------------------------------
+# Optional MCP-style tool discovery
+# -----------------------------------------------------------------------------
+
+# Disabled by default. When enabled, ML Copilot can load a local JSON manifest
+# of MCP-style tool descriptors and expose them as approval-gated placeholders.
+# Live MCP transport execution is intentionally not enabled in this release.
+ML_COPILOT_ENABLE_MCP=false
+# ML_COPILOT_MCP_MANIFEST_PATH=.ml-copilot/mcp-tools.json
+
+# -----------------------------------------------------------------------------
 # Optional custom env file location
 # -----------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The current release candidate is intentionally narrow:
 - Docker image for local deployment review
 - a small set of trustworthy tools
 - ML-specific helpers for repository, dataset, docs, paper, and reporting workflows
+- optional MCP-style tool discovery from a local manifest, disabled by default
 
 ## Architecture
 
@@ -153,6 +154,7 @@ Planning notes, local reference material, and personal workflow documents should
 - [Issue and PR workflow guidance](docs/phase-2-issue-pr-workflow.md)
 - [Release readiness guide](docs/release-readiness.md)
 - [Eval runner guide](docs/phase-3-eval-runner.md)
+- [MCP support guide](docs/phase-3-mcp-support.md)
 - Keep GitHub issue and PR titles aligned with the task ID and task name.
 - Keep issue labels, PR labels, and assignees in sync for each certified task.
 
@@ -257,6 +259,7 @@ ML Copilot is designed for inspectable local automation, not silent autonomous c
 - risky workspace actions can require explicit approval
 - destructive commands are disabled by default
 - secrets are redacted in user-facing configuration output
+- MCP-style tools are disabled by default and approval-gated when explicitly loaded
 - session history, tool calls, approvals, events, and usage metrics are persisted for review
 
 See [release readiness](docs/release-readiness.md) for the current limitations and release checklist.

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -429,9 +429,7 @@ class AgentLoop:
                     )
                     continue
 
-                requires_approval = self.settings.safety.require_tool_approval and self._tool_requires_approval(
-                    tool_call.name
-                )
+                requires_approval = self._tool_requires_approval(tool_call.name)
                 metrics.record_tool_call(tool_call.name, arguments)
                 if requires_approval:
                     self.repo.add_tool_call(
@@ -786,7 +784,7 @@ class AgentLoop:
 
     def _tool_requires_approval(self, tool_name: str) -> bool:
         if tool_name in APPROVAL_REQUIRED_TOOLS:
-            return True
+            return self.settings.safety.require_tool_approval
         try:
             return self.tools.get(tool_name).requires_approval
         except UnknownToolError:

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -429,8 +429,8 @@ class AgentLoop:
                     )
                     continue
 
-                requires_approval = (
-                    self.settings.safety.require_tool_approval and tool_call.name in APPROVAL_REQUIRED_TOOLS
+                requires_approval = self.settings.safety.require_tool_approval and self._tool_requires_approval(
+                    tool_call.name
                 )
                 metrics.record_tool_call(tool_call.name, arguments)
                 if requires_approval:
@@ -784,6 +784,14 @@ class AgentLoop:
                 return pending_approval
         raise KeyError(f"Unknown pending approval: {approval_id}")
 
+    def _tool_requires_approval(self, tool_name: str) -> bool:
+        if tool_name in APPROVAL_REQUIRED_TOOLS:
+            return True
+        try:
+            return self.tools.get(tool_name).requires_approval
+        except UnknownToolError:
+            return False
+
 
 def _utc_now() -> str:
     """Return current UTC time as an ISO string."""
@@ -910,7 +918,7 @@ def create_agent_loop(
 
 def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
     """Create and populate the tool registry with workspace, reporting, dataset, docs, paper, and repo tools."""
-    from app.tools import datasets, docs, papers, repo_analyzer, reporting, workspace
+    from app.tools import datasets, docs, mcp, papers, repo_analyzer, reporting, workspace
 
     registry = ToolRegistry()
     workspace_specs = workspace.get_tool_specs()
@@ -970,6 +978,12 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             handler=_make_repo_analyzer_handler(settings),
         )
         registry.register(tool_spec)
+
+    if settings.mcp.enabled:
+        try:
+            mcp.register_mcp_manifest_tools(registry, settings.mcp.manifest_path)
+        except mcp.MCPManifestError as exc:
+            logger.warning("MCP manifest discovery failed, continuing with local tools: %s", exc)
 
     return registry
 

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,12 @@ class UsageAccountingSettings:
 
 
 @dataclass(frozen=True)
+class MCPSettings:
+    enabled: bool
+    manifest_path: Path | None
+
+
+@dataclass(frozen=True)
 class AppSettings:
     app_name: str
     version: str
@@ -64,6 +70,7 @@ class AppSettings:
     db_path: Path
     safety: SafetySettings
     usage: UsageAccountingSettings
+    mcp: MCPSettings
 
     @classmethod
     def from_paths(cls, paths: AppPaths) -> "AppSettings":
@@ -88,6 +95,10 @@ class AppSettings:
                 prompt_cost_per_1k_tokens_usd=0.0015,
                 completion_cost_per_1k_tokens_usd=0.006,
             ),
+            mcp=MCPSettings(
+                enabled=False,
+                manifest_path=None,
+            ),
         )
 
     @classmethod
@@ -109,6 +120,11 @@ class AppSettings:
         )
         if not db_path.is_absolute():
             db_path = paths.workspace_root / db_path
+
+        mcp_manifest_path = blank_to_none(merged_env.get("ML_COPILOT_MCP_MANIFEST_PATH"))
+        resolved_mcp_manifest_path = Path(mcp_manifest_path) if mcp_manifest_path else None
+        if resolved_mcp_manifest_path is not None and not resolved_mcp_manifest_path.is_absolute():
+            resolved_mcp_manifest_path = paths.workspace_root / resolved_mcp_manifest_path
 
         return cls(
             app_name="ML Copilot",
@@ -157,6 +173,14 @@ class AppSettings:
                     default=0.006,
                     minimum=0.0,
                 ),
+            ),
+            mcp=MCPSettings(
+                enabled=parse_bool(
+                    "ML_COPILOT_ENABLE_MCP",
+                    merged_env.get("ML_COPILOT_ENABLE_MCP"),
+                    default=False,
+                ),
+                manifest_path=resolved_mcp_manifest_path.resolve() if resolved_mcp_manifest_path else None,
             ),
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -177,6 +177,8 @@ def format_config(settings: AppSettings) -> str:
             f"safety.require_tool_approval={settings.safety.require_tool_approval}",
             f"safety.allow_destructive_commands={settings.safety.allow_destructive_commands}",
             f"safety.redact_secrets={settings.safety.redact_secrets}",
+            f"mcp.enabled={settings.mcp.enabled}",
+            f"mcp.manifest_path={settings.mcp.manifest_path or '<unset>'}",
         ]
     )
 

--- a/app/tools/mcp.py
+++ b/app/tools/mcp.py
@@ -1,0 +1,147 @@
+"""Optional MCP-style tool discovery support.
+
+This module intentionally avoids opening live MCP transports. It loads a
+reviewable manifest of discovered tools, registers them behind approval, and
+keeps execution stubbed until a future transport layer is added.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.tools.registry import ToolRegistry, ToolSpec
+
+JsonDict = dict[str, Any]
+
+SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+BLOCKED_MCP_TOOL_NAMES = {
+    "apply_patch",
+    "run_command",
+    "write_file",
+    "hf_jobs",
+    "hf_doc_search",
+    "hf_doc_fetch",
+    "hf_whoami",
+}
+
+
+@dataclass(frozen=True)
+class MCPToolDescriptor:
+    server_name: str
+    tool_name: str
+    registered_name: str
+    description: str
+    input_schema: JsonDict
+
+
+class MCPManifestError(ValueError):
+    """Raised when an MCP discovery manifest has an invalid shape."""
+
+
+def load_mcp_manifest_tools(path: Path) -> list[MCPToolDescriptor]:
+    """Load namespaced MCP tool descriptors from a JSON manifest."""
+    if not path.exists():
+        raise MCPManifestError(f"MCP manifest does not exist: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MCPManifestError(f"MCP manifest is not valid JSON: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise MCPManifestError("MCP manifest must be a JSON object.")
+
+    descriptors: list[MCPToolDescriptor] = []
+    for server_name, tools in _iter_manifest_servers(payload):
+        if not _is_safe_name(server_name):
+            continue
+        for tool_payload in tools:
+            descriptor = _parse_tool_descriptor(server_name, tool_payload)
+            if descriptor is not None:
+                descriptors.append(descriptor)
+    return descriptors
+
+
+def register_mcp_manifest_tools(registry: ToolRegistry, manifest_path: Path | None) -> list[ToolSpec]:
+    """Register discovered MCP tools as approval-gated placeholders."""
+    if manifest_path is None:
+        return []
+
+    registered: list[ToolSpec] = []
+    for descriptor in load_mcp_manifest_tools(manifest_path):
+        if registry.has(descriptor.registered_name):
+            continue
+
+        async def _handler(_: JsonDict, item: MCPToolDescriptor = descriptor) -> str:
+            return (
+                f"MCP tool {item.server_name}/{item.tool_name} is discovered but not executable yet. "
+                "A live MCP transport must be configured in a future release before this tool can run."
+            )
+
+        registered.append(
+            registry.register(
+                ToolSpec(
+                    name=descriptor.registered_name,
+                    description=descriptor.description,
+                    input_schema=descriptor.input_schema,
+                    handler=_handler,
+                    source="mcp",
+                    requires_approval=True,
+                )
+            )
+        )
+    return registered
+
+
+def _iter_manifest_servers(payload: JsonDict) -> list[tuple[str, list[JsonDict]]]:
+    servers = payload.get("servers")
+    if isinstance(servers, list):
+        return [
+            (str(server.get("name", "")), server["tools"])
+            for server in servers
+            if isinstance(server, dict) and isinstance(server.get("tools"), list)
+        ]
+
+    mcp_servers = payload.get("mcpServers")
+    if isinstance(mcp_servers, dict):
+        discovered: list[tuple[str, list[JsonDict]]] = []
+        for server_name, server_payload in mcp_servers.items():
+            if isinstance(server_payload, dict) and isinstance(server_payload.get("tools"), list):
+                discovered.append((str(server_name), server_payload["tools"]))
+        return discovered
+
+    return []
+
+
+def _parse_tool_descriptor(server_name: str, payload: Any) -> MCPToolDescriptor | None:
+    if not isinstance(payload, dict):
+        return None
+
+    tool_name = str(payload.get("name", "")).strip()
+    if not _is_safe_name(tool_name) or tool_name in BLOCKED_MCP_TOOL_NAMES:
+        return None
+
+    registered_name = f"mcp__{server_name}__{tool_name}"
+    if not _is_safe_name(registered_name):
+        return None
+
+    description = str(payload.get("description") or f"MCP tool {server_name}/{tool_name}.").strip()
+    input_schema = payload.get("input_schema", payload.get("inputSchema", {"type": "object", "properties": {}}))
+    if not isinstance(input_schema, dict):
+        input_schema = {"type": "object", "properties": {}}
+
+    return MCPToolDescriptor(
+        server_name=server_name,
+        tool_name=tool_name,
+        registered_name=registered_name,
+        description=description,
+        input_schema=input_schema,
+    )
+
+
+def _is_safe_name(name: str) -> bool:
+    return bool(SAFE_NAME_RE.fullmatch(name))

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -30,6 +30,8 @@ class ToolSpec:
     description: str
     input_schema: JsonDict
     handler: ToolHandler = field(repr=False)
+    source: str = "builtin"
+    requires_approval: bool = False
 
     def to_openai_tool(self) -> JsonDict:
         return {
@@ -54,6 +56,9 @@ class ToolRegistry:
         self._tools[tool.name] = tool
         return tool
 
+    def has(self, name: str) -> bool:
+        return name in self._tools
+
     def get(self, name: str) -> ToolSpec:
         tool = self._tools.get(name)
         if tool is None:
@@ -62,6 +67,9 @@ class ToolRegistry:
 
     def list_tools(self) -> builtins.list[ToolSpec]:
         return builtins.list(self._tools.values())
+
+    def list_by_source(self, source: str) -> builtins.list[ToolSpec]:
+        return [tool for tool in self._tools.values() if tool.source == source]
 
     def list(self):
         return self.list_tools()

--- a/docs/phase-3-mcp-support.md
+++ b/docs/phase-3-mcp-support.md
@@ -1,0 +1,64 @@
+# Phase 3 MCP Support Follow-Up
+
+`ML-211` adds an incremental MCP support contract for `ML Copilot`.
+
+## Scope
+
+This release does not open live MCP transports. Instead, it adds:
+
+- configuration flags for optional MCP-style discovery
+- a local JSON manifest format for discovered tool descriptors
+- namespaced registration as `mcp__<server>__<tool>`
+- approval-gated placeholder execution for discovered tools
+- tests around manifest parsing, registration, filtering, and safety behavior
+
+This keeps the core local tool system stable while creating a clear seam for future live MCP clients.
+
+## Manifest
+
+Set these environment variables:
+
+```bash
+ML_COPILOT_ENABLE_MCP=true
+ML_COPILOT_MCP_MANIFEST_PATH=.ml-copilot/mcp-tools.json
+```
+
+Example manifest:
+
+```json
+{
+  "servers": [
+    {
+      "name": "research",
+      "tools": [
+        {
+          "name": "search_papers",
+          "description": "Search paper metadata.",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "query": {"type": "string"}
+            },
+            "required": ["query"]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+The loader also accepts an `mcpServers` object with per-server `tools` arrays.
+
+## Safety
+
+MCP-style tools are disabled by default. When loaded, they:
+
+- are skipped if server or tool names are unsafe
+- are skipped if they use blocked built-in or high-risk tool names
+- are registered under a namespaced name
+- are marked with source `mcp`
+- require approval before execution
+- return a safe placeholder until a live transport is implemented
+
+This mirrors the product safety model: external capabilities should be discoverable and reviewable before they become executable.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -33,6 +33,8 @@ Important runtime paths and safety flags:
 - `ML_COPILOT_REQUIRE_TOOL_APPROVAL`
 - `ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS`
 - `ML_COPILOT_REDACT_SECRETS`
+- `ML_COPILOT_ENABLE_MCP`
+- `ML_COPILOT_MCP_MANIFEST_PATH`
 
 Confirm the resolved configuration without printing secrets:
 
@@ -82,9 +84,41 @@ The current safety model is intentionally conservative:
 - approval decisions and edited arguments are persisted
 - tool call arguments and outputs are recorded for review
 - configuration output redacts secrets
+- MCP-style tools are disabled by default and are approval-gated when loaded from a manifest
 - local `.env`, `.ml-copilot`, virtualenvs, and frontend build artifacts are excluded from Docker build context
 
 Keep `ML_COPILOT_REQUIRE_TOOL_APPROVAL=true` for normal use. Only set `ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS=true` in a disposable workspace where destructive file or shell operations are expected.
+
+## Optional MCP Discovery
+
+MCP support is currently a discovery contract, not live remote execution. Set `ML_COPILOT_ENABLE_MCP=true` and point `ML_COPILOT_MCP_MANIFEST_PATH` at a local JSON manifest to expose MCP-style tool descriptors to the agent. Discovered tools are namespaced as `mcp__<server>__<tool>`, marked with source `mcp`, and require approval before execution.
+
+Supported manifest shape:
+
+```json
+{
+  "servers": [
+    {
+      "name": "research",
+      "tools": [
+        {
+          "name": "search_papers",
+          "description": "Search paper metadata.",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "query": {"type": "string"}
+            },
+            "required": ["query"]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+In this release, MCP tool execution returns a safe placeholder message. A future transport layer can replace that handler without changing the registry shape.
 
 ## Eval Guidance
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,8 @@ def test_settings_wrap_default_paths() -> None:
     assert settings.safety.require_tool_approval is True
     assert settings.usage.prompt_cost_per_1k_tokens_usd == 0.0015
     assert settings.usage.completion_cost_per_1k_tokens_usd == 0.006
+    assert settings.mcp.enabled is False
+    assert settings.mcp.manifest_path is None
 
 
 def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
@@ -37,6 +39,8 @@ def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
             "ML_COPILOT_REQUIRE_TOOL_APPROVAL": "false",
             "ML_COPILOT_ALLOW_DESTRUCTIVE_COMMANDS": "true",
             "ML_COPILOT_REDACT_SECRETS": "false",
+            "ML_COPILOT_ENABLE_MCP": "true",
+            "ML_COPILOT_MCP_MANIFEST_PATH": "mcp-tools.json",
             "LLM_PROMPT_COST_PER_1K_TOKENS_USD": "0.01",
             "LLM_COMPLETION_COST_PER_1K_TOKENS_USD": "0.02",
         }
@@ -53,6 +57,8 @@ def test_load_uses_env_values_and_defaults(tmp_path: Path) -> None:
     assert settings.safety.redact_secrets is False
     assert settings.usage.prompt_cost_per_1k_tokens_usd == 0.01
     assert settings.usage.completion_cost_per_1k_tokens_usd == 0.02
+    assert settings.mcp.enabled is True
+    assert settings.mcp.manifest_path == (tmp_path / "mcp-tools.json").resolve()
 
 
 def test_environment_prefers_process_env_over_env_file(tmp_path: Path) -> None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -61,3 +61,4 @@ def test_main_prints_config(monkeypatch, capsys, tmp_path) -> None:
     assert exit_code == 0
     assert "ML Copilot configuration" in captured.out
     assert "llm.model=gpt-config" in captured.out
+    assert "mcp.enabled=False" in captured.out

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -113,3 +113,21 @@ def test_agent_registry_keeps_local_tools_when_mcp_manifest_is_missing(tmp_path:
 
     assert registry.has("list_files")
     assert registry.list_by_source("mcp") == []
+
+
+def test_mcp_tools_require_approval_even_when_global_approval_is_disabled(tmp_path: Path) -> None:
+    manifest = write_manifest(
+        tmp_path / "mcp-tools.json",
+        {"servers": [{"name": "research", "tools": [{"name": "search", "description": "Search."}]}]},
+    )
+    settings = AppSettings.load(
+        environ={
+            "ML_COPILOT_WORKSPACE_ROOT": str(tmp_path),
+            "ML_COPILOT_REQUIRE_TOOL_APPROVAL": "false",
+            "ML_COPILOT_ENABLE_MCP": "true",
+            "ML_COPILOT_MCP_MANIFEST_PATH": str(manifest),
+        }
+    )
+    registry = _create_tool_registry(settings)
+
+    assert registry.get("mcp__research__search").requires_approval is True

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,0 +1,115 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from app.agent.loop import _create_tool_registry
+from app.config import AppSettings
+from app.tools.mcp import MCPManifestError, load_mcp_manifest_tools, register_mcp_manifest_tools
+from app.tools.registry import ToolRegistry
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def write_manifest(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_load_mcp_manifest_tools_namespaces_and_filters_tools(tmp_path: Path) -> None:
+    manifest = write_manifest(
+        tmp_path / "mcp-tools.json",
+        {
+            "servers": [
+                {
+                    "name": "research",
+                    "tools": [
+                        {
+                            "name": "search_papers",
+                            "description": "Search paper metadata.",
+                            "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                        },
+                        {"name": "run_command", "description": "Blocked builtin name."},
+                        {"name": "bad name", "description": "Unsafe name."},
+                    ],
+                },
+                {"name": "bad server", "tools": [{"name": "safe_tool"}]},
+            ]
+        },
+    )
+
+    tools = load_mcp_manifest_tools(manifest)
+
+    assert [tool.registered_name for tool in tools] == ["mcp__research__search_papers"]
+    assert tools[0].description == "Search paper metadata."
+    assert tools[0].input_schema["properties"]["query"]["type"] == "string"
+
+
+def test_register_mcp_manifest_tools_adds_approval_gated_placeholders(tmp_path: Path) -> None:
+    manifest = write_manifest(
+        tmp_path / "mcp-tools.json",
+        {
+            "mcpServers": {
+                "docs": {
+                    "tools": [
+                        {
+                            "name": "lookup",
+                            "description": "Lookup docs.",
+                            "inputSchema": {"type": "object"},
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    registry = ToolRegistry()
+
+    registered = register_mcp_manifest_tools(registry, manifest)
+
+    assert len(registered) == 1
+    tool = registry.get("mcp__docs__lookup")
+    assert tool.source == "mcp"
+    assert tool.requires_approval is True
+    assert "not executable yet" in run(registry.call("mcp__docs__lookup", {"query": "x"}))
+
+
+def test_missing_mcp_manifest_raises_helpful_error(tmp_path: Path) -> None:
+    with pytest.raises(MCPManifestError, match="does not exist"):
+        load_mcp_manifest_tools(tmp_path / "missing.json")
+
+
+def test_agent_registry_loads_mcp_tools_only_when_enabled(tmp_path: Path) -> None:
+    manifest = write_manifest(
+        tmp_path / "mcp-tools.json",
+        {"servers": [{"name": "research", "tools": [{"name": "search", "description": "Search."}]}]},
+    )
+
+    disabled = AppSettings.load(environ={"ML_COPILOT_WORKSPACE_ROOT": str(tmp_path)})
+    enabled = AppSettings.load(
+        environ={
+            "ML_COPILOT_WORKSPACE_ROOT": str(tmp_path),
+            "ML_COPILOT_ENABLE_MCP": "true",
+            "ML_COPILOT_MCP_MANIFEST_PATH": str(manifest),
+        }
+    )
+
+    assert _create_tool_registry(disabled).list_by_source("mcp") == []
+    assert [tool.name for tool in _create_tool_registry(enabled).list_by_source("mcp")] == ["mcp__research__search"]
+
+
+def test_agent_registry_keeps_local_tools_when_mcp_manifest_is_missing(tmp_path: Path) -> None:
+    settings = AppSettings.load(
+        environ={
+            "ML_COPILOT_WORKSPACE_ROOT": str(tmp_path),
+            "ML_COPILOT_ENABLE_MCP": "true",
+            "ML_COPILOT_MCP_MANIFEST_PATH": str(tmp_path / "missing.json"),
+        }
+    )
+
+    registry = _create_tool_registry(settings)
+
+    assert registry.has("list_files")
+    assert registry.list_by_source("mcp") == []

--- a/tests/unit/test_tools_registry.py
+++ b/tests/unit/test_tools_registry.py
@@ -55,8 +55,12 @@ def test_registry_registers_lists_and_calls_tools() -> None:
     registry.register(spec)
 
     assert registry.get("list_files") == spec
+    assert registry.has("list_files") is True
+    assert registry.has("missing_tool") is False
     assert registry.list_tools() == [spec]
     assert registry.list() == [spec]
+    assert registry.list_by_source("builtin") == [spec]
+    assert registry.list_by_source("mcp") == []
     assert registry.openai_tools() == [spec.to_openai_tool()]
     assert run(registry.call("list_files", {"path": "."})) == "listing:."
 


### PR DESCRIPTION
## Summary
- add optional MCP-style tool discovery from a local JSON manifest, disabled by default
- register discovered tools under `mcp__<server>__<tool>` with source metadata, approval requirements, blocked-name filtering, and safe placeholder execution
- expose MCP config in settings and `--print-config`, and document the manifest contract and current limitations
- add tests for MCP config parsing, manifest loading, registry integration, graceful fallback, and approval-gated placeholders

## Testing
- `python -m pytest tests/unit/test_mcp_tools.py tests/unit/test_tools_registry.py tests/unit/test_config.py tests/unit/test_main.py -q`
- `python -m ruff check app tests --output-format=github`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `python -m pytest -q`
- `python -m pre_commit run --all-files`
- `npm run build`
- `python -m app.main --print-config`

## Notes
This is an incremental support slice. It adds MCP-style discovery and registry metadata without enabling live remote MCP execution yet, so local tools remain stable and MCP capabilities stay opt-in and approval-gated.

## Reference
Issue: #80