### PR TITLE
ML-300 / Add Hugging Face auth and per-user token plumbing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,11 @@ LLM_BASE_URL=https://api.openai.com/v1
 # Provider API key for the configured endpoint.
 LLM_API_KEY=replace-me
 
+# Optional Hugging Face token used when a session does not provide its own.
+# HF-backed datasets, docs, and paper lookups will prefer a per-session token
+# when one is attached to the request.
+# HF_TOKEN=hf_xxx
+
 # Model name for the configured endpoint.
 # Examples:
 # - gpt-5.4

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Create a runtime environment file from the example:
 cp .env.example .env
 ```
 
-Set at least `LLM_API_KEY` and, when needed, adjust `LLM_BASE_URL`, `LLM_MODEL`, `ML_COPILOT_DB_PATH`, and the safety flags.
+Set at least `LLM_API_KEY` and, when needed, adjust `LLM_BASE_URL`, `LLM_MODEL`, `ML_COPILOT_DB_PATH`, and the safety flags. If you will use Hugging Face-backed tools without a per-session token, set `HF_TOKEN` as a local fallback.
 
 ## Run Locally
 

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -14,6 +14,7 @@ from app.agent.llm import LLMClient, Usage
 from app.config import AppSettings
 from app.storage.models import MessageRecord, PendingApprovalRecord, SessionRecord
 from app.storage.repository import SQLiteRepository
+from app.tools.context import ToolExecutionContext, use_tool_execution_context
 from app.tools.registry import ToolHandler, ToolRegistry, ToolSpec, UnknownToolError
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,7 @@ class TurnContext:
     messages: list[dict[str, Any]]
     event_sequence: int
     message_sequence: int
+    hf_token: str | None = None
 
 
 @dataclass
@@ -184,9 +186,10 @@ class AgentLoop:
         session: SessionRecord,
         user_message: str,
         system_prompt: str | None = None,
+        hf_token: str | None = None,
     ) -> dict[str, Any]:
         """Run a complete turn for a new user message."""
-        ctx = self._build_turn_context(session, system_prompt)
+        ctx = self._build_turn_context(session, system_prompt, hf_token=hf_token)
         await self.emit_event(ctx, EventType.READY, {"message": "Agent ready"})
 
         pending_approvals = self.repo.list_pending_approvals(session.id)
@@ -214,9 +217,10 @@ class AgentLoop:
         user_feedback: str | None = None,
         edited_arguments: dict[str, Any] | None = None,
         system_prompt: str | None = None,
+        hf_token: str | None = None,
     ) -> dict[str, Any]:
         """Apply an approval decision and continue the agent loop."""
-        ctx = self._build_turn_context(session, system_prompt)
+        ctx = self._build_turn_context(session, system_prompt, hf_token=hf_token)
         await self.emit_event(ctx, EventType.READY, {"message": "Approval decision received"})
         await self.emit_event(ctx, EventType.PROCESSING, {})
 
@@ -267,6 +271,8 @@ class AgentLoop:
         self,
         session: SessionRecord,
         system_prompt: str | None,
+        *,
+        hf_token: str | None = None,
     ) -> TurnContext:
         prompt = system_prompt or _default_system_prompt()
         history = [_message_to_llm_dict(record) for record in self.repo.list_messages(session.id)]
@@ -276,6 +282,7 @@ class AgentLoop:
             messages=[{"role": "system", "content": prompt}, *history],
             event_sequence=self.repo.next_event_sequence(session.id),
             message_sequence=self.repo.next_message_sequence(session.id),
+            hf_token=hf_token,
         )
 
     async def _run_loop(
@@ -532,7 +539,13 @@ class AgentLoop:
 
         start = perf_counter()
         try:
-            tool_output = await self.tools.call(tool_name, arguments)
+            with use_tool_execution_context(
+                ToolExecutionContext(
+                    session_id=ctx.session_id,
+                    hf_token=ctx.hf_token,
+                )
+            ):
+                tool_output = await self.tools.call(tool_name, arguments)
             success = True
             error = None
         except asyncio.CancelledError:

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -11,6 +11,7 @@ from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.agent.loop import AgentLoop, create_agent_loop
+from app.auth import resolve_hf_request_token
 from app.config import AppSettings
 from app.storage.models import (
     MessageRecord,
@@ -23,7 +24,7 @@ from app.storage.models import (
 )
 from app.storage.repository import SQLiteRepository
 
-from .runtime import ActiveTurnManager
+from .runtime import ActiveTurnManager, SessionAuthManager
 from .schemas import (
     ApprovalDecisionRequest,
     ChatRequest,
@@ -58,20 +59,26 @@ def create_app(
     app.state.loop_factory = loop_factory or _default_loop_factory
     app.state.event_stream_manager = SessionEventStreamManager()
     app.state.active_turn_manager = ActiveTurnManager()
+    app.state.session_auth_manager = SessionAuthManager()
 
     router = APIRouter(prefix="/api", tags=["sessions"])
 
     @router.post("/session", response_model=SessionSummary, status_code=status.HTTP_201_CREATED)
     async def create_session(
         payload: CreateSessionRequest,
+        request: Request,
         repo: RepositoryDep,
         current_settings: SettingsDep,
     ) -> SessionSummary:
+        session_token = _resolve_session_token(request)
+        metadata = _sanitize_metadata(payload.metadata)
         record = repo.create_session(
             model=payload.model or current_settings.llm.model,
             title=payload.title,
-            metadata=payload.metadata,
+            metadata=metadata,
         )
+        if session_token:
+            get_session_auth_manager(request).set_token(record.id, session_token)
         return _serialize_session_summary(repo, record)
 
     @router.get("/sessions", response_model=list[SessionSummary])
@@ -120,6 +127,10 @@ def create_app(
     ) -> ChatResponse:
         session = _get_session_or_404(repo, session_id)
         active_turn_manager = get_active_turn_manager(request)
+        session_token = _resolve_session_token(request)
+        if session_token:
+            get_session_auth_manager(request).set_token(session_id, session_token)
+        hf_token = _token_for_session(request, session_id)
         if not active_turn_manager.register(session_id, loop):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -137,6 +148,7 @@ def create_app(
                 session=session,
                 user_message=payload.message,
                 system_prompt=payload.system_prompt,
+                hf_token=hf_token,
             )
         except asyncio.CancelledError:
             result = {"status": "interrupted"}
@@ -165,6 +177,10 @@ def create_app(
     ) -> ChatResponse:
         session = _get_session_or_404(repo, session_id)
         active_turn_manager = get_active_turn_manager(request)
+        session_token = _resolve_session_token(request)
+        if session_token:
+            get_session_auth_manager(request).set_token(session_id, session_token)
+        hf_token = _token_for_session(request, session_id)
         if not active_turn_manager.register(session_id, loop):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -184,6 +200,7 @@ def create_app(
                 user_feedback=payload.user_feedback,
                 edited_arguments=payload.edited_arguments,
                 system_prompt=payload.system_prompt,
+                hf_token=hf_token,
             )
         except KeyError as exc:
             fallback_status = "waiting_approval" if repo.list_pending_approvals(session_id) else "idle"
@@ -250,6 +267,10 @@ def get_active_turn_manager(request: Request) -> ActiveTurnManager:
     return request.app.state.active_turn_manager
 
 
+def get_session_auth_manager(request: Request) -> SessionAuthManager:
+    return request.app.state.session_auth_manager
+
+
 def get_repository(
     request: Request,
     settings: Annotated[AppSettings, Depends(get_settings)],
@@ -275,6 +296,38 @@ def _default_repository_factory(settings: AppSettings) -> SQLiteRepository:
 
 def _default_loop_factory(settings: AppSettings, repository: SQLiteRepository) -> AgentLoop:
     return create_agent_loop(settings, repository=repository)
+
+
+def _resolve_session_token(request: Request) -> str | None:
+    """Resolve an explicit HF token from the incoming request."""
+    return resolve_hf_request_token(request, include_env_fallback=False)
+
+
+def _token_for_session(request: Request, session_id: str) -> str | None:
+    """Resolve the token to use for a session, falling back to env/cache."""
+    auth_manager = get_session_auth_manager(request)
+    return auth_manager.get_token(session_id) or resolve_hf_request_token(request)
+
+
+def _sanitize_metadata(value: dict[str, Any]) -> dict[str, Any]:
+    def _sanitize(item: Any) -> Any:
+        if isinstance(item, dict):
+            return {key: _sanitize(child) for key, child in item.items() if not _is_sensitive_metadata_key(str(key))}
+        if isinstance(item, list):
+            return [_sanitize(child) for child in item]
+        return item
+
+    return _sanitize(value)
+
+
+def _is_sensitive_metadata_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    return (
+        "token" in normalized
+        or "authorization" in normalized
+        or "bearer" in normalized
+        or normalized in {"secret", "apikey", "api_key"}
+    )
 
 
 def _mount_frontend_if_available(app: FastAPI, settings: AppSettings) -> None:

--- a/app/api/runtime.py
+++ b/app/api/runtime.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.agent.loop import AgentLoop
+from app.auth import clean_hf_token
 
 
 @dataclass(frozen=True)
@@ -66,3 +67,27 @@ class ActiveTurnManager:
         active_turn.loop.interrupt()
         active_turn.event_loop.call_soon_threadsafe(active_turn.task.cancel)
         return True
+
+
+class SessionAuthManager:
+    """In-memory per-session Hugging Face token store."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._tokens: dict[str, str] = {}
+
+    def set_token(self, session_id: str, token: str | None) -> None:
+        cleaned = clean_hf_token(token)
+        with self._lock:
+            if cleaned is None:
+                self._tokens.pop(session_id, None)
+            else:
+                self._tokens[session_id] = cleaned
+
+    def get_token(self, session_id: str) -> str | None:
+        with self._lock:
+            return self._tokens.get(session_id)
+
+    def clear(self, session_id: str) -> None:
+        with self._lock:
+            self._tokens.pop(session_id, None)

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,71 @@
+"""Shared Hugging Face token helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def clean_hf_token(token: str | None) -> str | None:
+    """Normalize token strings and drop empty values."""
+    if token is None:
+        return None
+    cleaned = token.replace("\r", "").replace("\n", "").strip()
+    return cleaned or None
+
+
+def bearer_token_from_header(auth_header: str | None) -> str | None:
+    """Extract a bearer token from an Authorization header."""
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return None
+    return clean_hf_token(auth_header[7:])
+
+
+def get_cached_hf_token() -> str | None:
+    """Return the token from huggingface_hub's own cache lookup."""
+    try:
+        from huggingface_hub import get_token
+
+        return clean_hf_token(get_token())
+    except Exception:
+        return None
+
+
+def resolve_hf_token(
+    *candidates: str | None,
+    include_cached: bool = True,
+) -> str | None:
+    """Return the first usable token from explicit candidates."""
+    for token in candidates:
+        cleaned = clean_hf_token(token)
+        if cleaned:
+            return cleaned
+    if include_cached:
+        return get_cached_hf_token()
+    return None
+
+
+def resolve_hf_request_token(
+    request: Any,
+    *,
+    include_env_fallback: bool = True,
+) -> str | None:
+    """Resolve the HF token attached to a request, if any."""
+    token = bearer_token_from_header(request.headers.get("Authorization", ""))
+    if token:
+        return token
+
+    token = clean_hf_token(request.headers.get("X-HF-Token"))
+    if token:
+        return token
+
+    token = clean_hf_token(request.cookies.get("hf_access_token"))
+    if token:
+        return token
+
+    if include_env_fallback:
+        return resolve_hf_token(
+            os.environ.get("HF_TOKEN"),
+            os.environ.get("HUGGING_FACE_HUB_TOKEN"),
+        )
+    return None

--- a/app/tools/context.py
+++ b/app/tools/context.py
@@ -1,0 +1,47 @@
+"""Tool execution context for request-scoped Hugging Face state."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Iterator
+
+from app.auth import resolve_hf_token
+
+
+@dataclass(frozen=True)
+class ToolExecutionContext:
+    """Request-scoped execution metadata for tools."""
+
+    session_id: str | None = None
+    hf_token: str | None = None
+
+
+_CURRENT_TOOL_CONTEXT: ContextVar[ToolExecutionContext | None] = ContextVar(
+    "current_tool_execution_context",
+    default=None,
+)
+
+
+def get_current_tool_context() -> ToolExecutionContext | None:
+    return _CURRENT_TOOL_CONTEXT.get()
+
+
+@contextmanager
+def use_tool_execution_context(context: ToolExecutionContext) -> Iterator[None]:
+    token = _CURRENT_TOOL_CONTEXT.set(context)
+    try:
+        yield
+    finally:
+        _CURRENT_TOOL_CONTEXT.reset(token)
+
+
+def current_hf_token() -> str | None:
+    context = get_current_tool_context()
+    return resolve_hf_token(
+        context.hf_token if context else None,
+        os.environ.get("HF_TOKEN"),
+        os.environ.get("HUGGING_FACE_HUB_TOKEN"),
+    )

--- a/app/tools/datasets.py
+++ b/app/tools/datasets.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 
 from app.config import AppSettings
+from app.tools.context import current_hf_token
 from app.tools.workspace import _safe_path
 
 HF_DATASETS_SERVER = "https://datasets-server.huggingface.co"
@@ -300,7 +301,7 @@ async def _inspect_hf(source: str, args: dict[str, Any]) -> str:
     config = args.get("config")
     split = args.get("split")
     sample_rows = min(args.get("sample_rows", 3), MAX_SAMPLE_ROWS)
-    token = args.get("token")
+    token = current_hf_token()
 
     headers: dict[str, str] = {}
     if token:

--- a/app/tools/docs.py
+++ b/app/tools/docs.py
@@ -14,6 +14,7 @@ from whoosh.filedb.filestore import RamStorage
 from whoosh.qparser import MultifieldParser, OrGroup
 
 from app.config import AppSettings
+from app.tools.context import current_hf_token
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -59,8 +60,12 @@ _cache_lock = asyncio.Lock()
 async def _fetch_endpoint_docs(endpoint: str) -> list[dict[str, str]]:
     """Fetch all doc pages for an endpoint by parsing sidebar and fetching each page."""
     url = f"https://huggingface.co/docs/{endpoint}"
+    headers: dict[str, str] = {}
+    token = current_hf_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
 
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True, headers=headers) as client:
         resp = await client.get(url)
         resp.raise_for_status()
 
@@ -314,7 +319,11 @@ async def fetch_doc_page_handler(args: dict[str, Any], settings: AppSettings) ->
     url = normalized_url
 
     try:
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        headers: dict[str, str] = {}
+        token = current_hf_token()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True, headers=headers) as client:
             resp = await client.get(url)
             resp.raise_for_status()
         return f"## Documentation: {url}\n\n{resp.text}"

--- a/app/tools/papers.py
+++ b/app/tools/papers.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 import httpx
 
 from app.config import AppSettings
+from app.tools.context import current_hf_token
 
 HF_API = "https://huggingface.co/api"
 
@@ -80,7 +81,12 @@ def _format_paper_details(paper: dict[str, Any]) -> str:
 
 
 async def _fetch_paper(arxiv_id: str) -> dict[str, Any]:
-    async with httpx.AsyncClient(timeout=15) as client:
+    headers: dict[str, str] = {}
+    token = current_hf_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    async with httpx.AsyncClient(timeout=15, headers=headers) as client:
         resp = await client.get(f"{HF_API}/papers/{arxiv_id}")
         resp.raise_for_status()
         return resp.json()

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -35,6 +35,7 @@ Important runtime paths and safety flags:
 - `ML_COPILOT_REDACT_SECRETS`
 - `ML_COPILOT_ENABLE_MCP`
 - `ML_COPILOT_MCP_MANIFEST_PATH`
+- `HF_TOKEN` (optional fallback for HF-backed reads and writes)
 
 Confirm the resolved configuration without printing secrets:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -94,6 +94,7 @@ function App() {
   const [resolvingApproval, setResolvingApproval] = useState(false);
   const [draftTitle, setDraftTitle] = useState('');
   const [draftModel, setDraftModel] = useState('');
+  const [draftHfToken, setDraftHfToken] = useState('');
   const [draftPrompt, setDraftPrompt] = useState('');
 
   useEffect(() => {
@@ -216,7 +217,7 @@ function App() {
         title: draftTitle.trim() || null,
         model: draftModel.trim() || null,
         metadata: seedMetadata,
-      });
+      }, draftHfToken.trim() || null);
       setSessions((current) => [created, ...current.filter((session) => session.id !== created.id)]);
       setSelectedSessionId(created.id);
       setDraftTitle('');
@@ -245,7 +246,11 @@ function App() {
     connectEventStream(selectedSessionId, { replay: false });
 
     try {
-      const response = await sendChatMessage(selectedSessionId, { message: prompt });
+      const response = await sendChatMessage(
+        selectedSessionId,
+        { message: prompt },
+        draftHfToken.trim() || null,
+      );
       setActiveSession(response.session);
       setMessages(response.messages);
       setLiveAssistantText('');
@@ -282,7 +287,12 @@ function App() {
     connectEventStream(selectedSessionId, { replay: false });
 
     try {
-      const response = await resolveApproval(selectedSessionId, approvalId, payload);
+      const response = await resolveApproval(
+        selectedSessionId,
+        approvalId,
+        payload,
+        draftHfToken.trim() || null,
+      );
       setActiveSession(response.session);
       setMessages(response.messages);
       setSessions((current) =>
@@ -351,6 +361,7 @@ function App() {
             activeSession={activeSession}
             creating={creating}
             draftModel={draftModel}
+            draftHfToken={draftHfToken}
             draftTitle={draftTitle}
             messages={messages}
             onCreateSession={handleCreateSession}
@@ -359,6 +370,7 @@ function App() {
             selectedSessionId={selectedSessionId}
             sessions={sessions}
             setDraftModel={setDraftModel}
+            setDraftHfToken={setDraftHfToken}
             setDraftTitle={setDraftTitle}
           />
         </aside>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,13 +11,19 @@ import type {
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? '';
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+async function request<T>(path: string, init?: RequestInit, hfToken?: string | null): Promise<T> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(init?.headers ? (init.headers as Record<string, string>) : {}),
+  };
+  if (hfToken) {
+    headers.Authorization = `Bearer ${hfToken}`;
+  }
+
   const response = await fetch(`${API_BASE_URL}${path}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-    },
     ...init,
+    credentials: 'include',
+    headers,
   });
 
   if (!response.ok) {
@@ -47,25 +53,30 @@ export function fetchMessages(sessionId: string) {
   return request<MessagePayload[]>(`/api/session/${sessionId}/messages`);
 }
 
-export function createSession(payload: CreateSessionRequest) {
+export function createSession(payload: CreateSessionRequest, hfToken?: string | null) {
   return request<SessionSummary>('/api/session', {
     method: 'POST',
     body: JSON.stringify(payload),
-  });
+  }, hfToken);
 }
 
-export function sendChatMessage(sessionId: string, payload: ChatRequest) {
+export function sendChatMessage(sessionId: string, payload: ChatRequest, hfToken?: string | null) {
   return request<ChatResponse>(`/api/chat/${sessionId}`, {
     method: 'POST',
     body: JSON.stringify(payload),
-  });
+  }, hfToken);
 }
 
-export function resolveApproval(sessionId: string, approvalId: string, payload: ApprovalDecisionRequest) {
+export function resolveApproval(
+  sessionId: string,
+  approvalId: string,
+  payload: ApprovalDecisionRequest,
+  hfToken?: string | null,
+) {
   return request<ChatResponse>(`/api/approval/${sessionId}/${approvalId}`, {
     method: 'POST',
     body: JSON.stringify(payload),
-  });
+  }, hfToken);
 }
 
 export function createSessionEventSource(
@@ -77,7 +88,9 @@ export function createSessionEventSource(
   },
 ) {
   const query = options.after !== undefined ? `?after=${options.after}` : '';
-  const source = new EventSource(`${API_BASE_URL}/api/events/${sessionId}${query}`);
+  const source = new EventSource(`${API_BASE_URL}/api/events/${sessionId}${query}`, {
+    withCredentials: true,
+  });
 
   source.onmessage = (message) => {
     options.onEvent(JSON.parse(message.data) as SessionEventPayload);

--- a/frontend/src/components/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar.tsx
@@ -4,6 +4,7 @@ import type { MessagePayload, SessionDetail, SessionSummary } from '../types';
 interface SessionSidebarProps {
   activeSession: SessionDetail | null;
   creating: boolean;
+  draftHfToken: string;
   draftModel: string;
   draftTitle: string;
   messages: MessagePayload[];
@@ -12,6 +13,7 @@ interface SessionSidebarProps {
   onSelectSession: (sessionId: string) => void;
   selectedSessionId: string | null;
   sessions: SessionSummary[];
+  setDraftHfToken: (value: string) => void;
   setDraftModel: (value: string) => void;
   setDraftTitle: (value: string) => void;
 }
@@ -59,6 +61,7 @@ function roleLabel(role: string) {
 export default function SessionSidebar({
   activeSession,
   creating,
+  draftHfToken,
   draftModel,
   draftTitle,
   messages,
@@ -67,6 +70,7 @@ export default function SessionSidebar({
   onSelectSession,
   selectedSessionId,
   sessions,
+  setDraftHfToken,
   setDraftModel,
   setDraftTitle,
 }: SessionSidebarProps) {
@@ -102,6 +106,16 @@ export default function SessionSidebar({
             onChange={(event) => setDraftModel(event.target.value)}
             placeholder="gpt-5.4"
           />
+        </label>
+        <label>
+          Hugging Face token
+          <input
+            type="password"
+            value={draftHfToken}
+            onChange={(event) => setDraftHfToken(event.target.value)}
+            placeholder="hf_xxx"
+          />
+          <span className="hint">Kept in memory only and sent with requests for this browser session.</span>
         </label>
         <button className="primary-button" type="submit" disabled={creating}>
           {creating ? 'Creating...' : 'Create session'}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -272,6 +272,14 @@ button {
   font-size: 0.84rem;
 }
 
+.hint {
+  display: block;
+  margin-top: -2px;
+  color: var(--muted);
+  font-size: 0.74rem;
+  line-height: 1.35;
+}
+
 .composer-card input,
 .composer-shell textarea {
   width: 100%;

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -57,6 +57,38 @@ class ApprovalFlowLLMClient:
         return LLMResponse(model="gpt-test", content=self.final_content, finish_reason="stop")
 
 
+class TokenAwareLoop:
+    def __init__(self) -> None:
+        self.run_turn_tokens: list[str | None] = []
+        self.resume_tokens: list[str | None] = []
+        self._handlers: list[object] = []
+
+    def add_event_handler(self, handler) -> None:
+        self._handlers.append(handler)
+
+    def remove_event_handler(self, handler) -> None:
+        if handler in self._handlers:
+            self._handlers.remove(handler)
+
+    async def run_turn(self, *, session, user_message, system_prompt=None, hf_token=None):
+        self.run_turn_tokens.append(hf_token)
+        return {"status": "complete", "content": "Token-aware response.", "iterations": 1}
+
+    async def resume_pending_approval(
+        self,
+        *,
+        session,
+        approval_id,
+        approved,
+        user_feedback=None,
+        edited_arguments=None,
+        system_prompt=None,
+        hf_token=None,
+    ):
+        self.resume_tokens.append(hf_token)
+        return {"status": "complete", "content": "Token-aware response.", "iterations": 1}
+
+
 def _settings(tmp_path: Path) -> AppSettings:
     return AppSettings.load(
         environ={
@@ -87,6 +119,37 @@ def test_create_and_list_sessions_via_api(tmp_path: Path) -> None:
     assert len(listed_body) == 1
     assert listed_body[0]["id"] == created_body["id"]
     assert listed_body[0]["message_count"] == 0
+
+
+def test_session_token_is_stored_and_reused_for_turns(tmp_path: Path) -> None:
+    token_loop = TokenAwareLoop()
+
+    def loop_factory(app_settings: AppSettings, repository: SQLiteRepository):
+        return token_loop
+
+    app = create_app(_settings(tmp_path), loop_factory=loop_factory)
+    client = TestClient(app)
+
+    created = client.post(
+        "/api/session",
+        json={
+            "title": "Token Session",
+            "metadata": {"source": "test", "hf_token": "should-not-persist"},
+        },
+        headers={"Authorization": "Bearer hf-session-token"},
+    )
+    assert created.status_code == 201
+    session_id = created.json()["id"]
+    assert created.json()["metadata"] == {"source": "test"}
+    assert client.app.state.session_auth_manager.get_token(session_id) == "hf-session-token"
+
+    response = client.post(
+        f"/api/chat/{session_id}",
+        json={"message": "Use the stored token"},
+    )
+
+    assert response.status_code == 200
+    assert token_loop.run_turn_tokens == ["hf-session-token"]
 
 
 def test_chat_route_persists_messages_and_session_state(tmp_path: Path) -> None:

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.config import AppPaths, AppSettings
+from app.tools.context import ToolExecutionContext, use_tool_execution_context
 from app.tools.datasets import (
     _inspect_csv,
     _inspect_json,
@@ -31,6 +32,50 @@ class TestLooksLikeLocalPath:
 
     def test_nonexistent(self, tmp_path: Path) -> None:
         assert _looks_like_local_path("user/dataset", tmp_path) is False
+
+
+@pytest.mark.asyncio
+async def test_inspect_hf_dataset_uses_session_token(tmp_path: Path) -> None:
+    class FakeResponse:
+        def __init__(self, payload: dict[str, object]):
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        instances: list["FakeAsyncClient"] = []
+
+        def __init__(self, *args, **kwargs):
+            self.headers = kwargs.get("headers", {})
+            FakeAsyncClient.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, params=None):
+            if url.endswith("/is-valid"):
+                return FakeResponse({"preview": True})
+            if url.endswith("/splits"):
+                return FakeResponse({"splits": [{"config": "default", "split": "train"}]})
+            if url.endswith("/info"):
+                return FakeResponse({"dataset_info": {"features": {"text": {"dtype": "string"}}}})
+            if url.endswith("/first-rows"):
+                return FakeResponse({"rows": [{"row": {"text": "hello"}}]})
+            return FakeResponse({})
+
+    with patch("app.tools.datasets.httpx.AsyncClient", new=FakeAsyncClient):
+        with use_tool_execution_context(ToolExecutionContext(session_id="session-1", hf_token="hf-session-token")):
+            result = await inspect_dataset_handler({"source": "hf-user/imdb"}, _settings(tmp_path))
+
+    assert "hf-user/imdb (Hugging Face)" in result
+    assert FakeAsyncClient.instances[0].headers["Authorization"] == "Bearer hf-session-token"
 
 
 class TestInspectCsv:

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.config import AppPaths, AppSettings
+from app.tools.context import ToolExecutionContext, use_tool_execution_context
 from app.tools.docs import (
     DOC_ENDPOINTS,
     _format_results,
@@ -174,6 +175,40 @@ class TestFetchDocPageHandler:
             await fetch_doc_page_handler({"url": "https://huggingface.co/docs/trl/sft"}, _settings(tmp_path))
             call_url = mock_client.get.call_args[0][0]
         assert call_url.endswith(".md")
+
+    @pytest.mark.asyncio
+    async def test_uses_session_token(self, tmp_path: Path) -> None:
+        class FakeResponse:
+            text = "# DPO Trainer\n\nContent here."
+
+            def raise_for_status(self) -> None:
+                return None
+
+        class FakeAsyncClient:
+            instances: list["FakeAsyncClient"] = []
+
+            def __init__(self, *args, **kwargs):
+                self.headers = kwargs.get("headers", {})
+                FakeAsyncClient.instances.append(self)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def get(self, url):
+                return FakeResponse()
+
+        with patch("app.tools.docs.httpx.AsyncClient", new=FakeAsyncClient):
+            with use_tool_execution_context(ToolExecutionContext(session_id="session-1", hf_token="hf-session-token")):
+                result = await fetch_doc_page_handler(
+                    {"url": "https://huggingface.co/docs/trl/dpo_trainer"},
+                    _settings(tmp_path),
+                )
+
+        assert "DPO Trainer" in result
+        assert FakeAsyncClient.instances[0].headers["Authorization"] == "Bearer hf-session-token"
 
     @pytest.mark.asyncio
     async def test_rejects_non_hf_docs_urls(self, tmp_path: Path) -> None:

--- a/tests/unit/test_hf_auth.py
+++ b/tests/unit/test_hf_auth.py
@@ -1,0 +1,38 @@
+"""Tests for Hugging Face token request helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.auth import bearer_token_from_header, clean_hf_token, resolve_hf_request_token
+
+
+def test_clean_hf_token_trims_and_drops_newlines() -> None:
+    assert clean_hf_token("  hf_token\n") == "hf_token"
+    assert clean_hf_token("   ") is None
+
+
+def test_bearer_token_from_header_handles_bearer_prefix() -> None:
+    assert bearer_token_from_header("Bearer hf_token") == "hf_token"
+    assert bearer_token_from_header("Token hf_token") is None
+
+
+def test_resolve_hf_request_token_prefers_header_over_cookie() -> None:
+    request = SimpleNamespace(
+        headers={
+            "Authorization": "Bearer header-token",
+            "X-HF-Token": "fallback-token",
+        },
+        cookies={"hf_access_token": "cookie-token"},
+    )
+
+    assert resolve_hf_request_token(request, include_env_fallback=False) == "header-token"
+
+
+def test_resolve_hf_request_token_uses_custom_header_then_cookie() -> None:
+    request = SimpleNamespace(
+        headers={"X-HF-Token": "  header-token  "},
+        cookies={"hf_access_token": "cookie-token"},
+    )
+
+    assert resolve_hf_request_token(request, include_env_fallback=False) == "header-token"

--- a/tests/unit/test_papers.py
+++ b/tests/unit/test_papers.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 from app.config import AppPaths, AppSettings
+from app.tools.context import ToolExecutionContext, use_tool_execution_context
 from app.tools.papers import (
     _format_paper_details,
     _normalize_arxiv_id,
@@ -49,6 +50,53 @@ def test_format_paper_details() -> None:
     assert "org/repo" in result
     assert "AI Summary" in result
     assert "Abstract" in result
+
+
+@pytest.mark.asyncio
+async def test_paper_details_handler_uses_session_token(tmp_path: Path) -> None:
+    class FakeResponse:
+        def __init__(self, payload: dict[str, object]):
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        instances: list["FakeAsyncClient"] = []
+
+        def __init__(self, *args, **kwargs):
+            self.headers = kwargs.get("headers", {})
+            FakeAsyncClient.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, params=None):
+            return FakeResponse(
+                {
+                    "id": "2305.18290",
+                    "title": "A Sample Paper",
+                    "upvotes": 10,
+                    "summary": "Paper abstract.",
+                    "authors": [{"name": "Ada"}],
+                }
+            )
+
+    with patch("app.tools.papers.httpx.AsyncClient", new=FakeAsyncClient):
+        with use_tool_execution_context(ToolExecutionContext(session_id="session-1", hf_token="hf-session-token")):
+            result = await paper_details_handler(
+                {"arxiv_id": "https://huggingface.co/papers/2305.18290"},
+                _settings(tmp_path),
+            )
+
+    assert "A Sample Paper" in result
+    assert FakeAsyncClient.instances[0].headers["Authorization"] == "Bearer hf-session-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add request/session Hugging Face token resolution with bearer, `X-HF-Token`, cookie, and optional environment fallback support
- keep per-session HF tokens in backend memory and propagate them through agent tool execution without exposing tokens in tool schemas or session metadata
- send optional HF tokens from the web UI and apply them to gated dataset/model docs/paper calls, with unit coverage for auth resolution and HF-facing tools

## Testing
- `python -m pytest -q tests/unit/test_hf_auth.py tests/unit/test_datasets.py tests/unit/test_papers.py tests/unit/test_docs.py tests/unit/test_api.py tests/unit/test_config.py`
- `python -m ruff format --check app tests`
- `python -m ruff check app tests`
- `python -m pytest -q`
- `python -m mypy app --ignore-missing-imports --follow-imports=skip`
- `npm run build`
- `python -m pre_commit run --all-files`

## Notes
Tokens are stored only in the backend process session map for active sessions. If the backend restarts, the client can send the token again on the next request, or the app can fall back to configured Hugging Face environment credentials.

## Reference
Issue: #82