### PR TITLE
ML-301 / Add Hub model and dataset discovery plus BYOD ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Assistant responds
 - React + Vite frontend shell for chat, approvals, and tool traces
 - release packaging and documentation hardening
 
+### Phase 4
+
+- per-session Hugging Face authentication
+- Hub model and dataset discovery with task, license, and schema fit signals
+- BYOD upload and workspace-local dataset ingestion with validated previews
+
 ## Repo Boundaries
 
 This repository is only for the actual `ML Copilot` product.

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -928,8 +928,8 @@ def create_agent_loop(
 
 
 def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
-    """Create and populate the tool registry with workspace, reporting, dataset, docs, paper, and repo tools."""
-    from app.tools import datasets, docs, mcp, papers, repo_analyzer, reporting, workspace
+    """Create and populate the built-in and configured tool registry."""
+    from app.tools import datasets, docs, hub, mcp, papers, repo_analyzer, reporting, workspace
 
     registry = ToolRegistry()
     workspace_specs = workspace.get_tool_specs()
@@ -959,7 +959,16 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             name=spec["name"],
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
-            handler=_make_dataset_handler(settings),
+            handler=_make_dataset_handler(spec["name"], settings),
+        )
+        registry.register(tool_spec)
+
+    for spec in hub.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_hub_handler(spec["name"], settings),
         )
         registry.register(tool_spec)
 
@@ -1029,12 +1038,32 @@ def _make_report_handler(settings: AppSettings) -> ToolHandler:
     return _handler
 
 
-def _make_dataset_handler(settings: AppSettings) -> ToolHandler:
-    """Create a handler for the inspect_dataset tool."""
+def _make_dataset_handler(name: str, settings: AppSettings) -> ToolHandler:
+    """Create a handler for dataset inspection and BYOD ingestion tools."""
     from app.tools import datasets
 
+    handlers = {
+        "inspect_dataset": datasets.inspect_dataset_handler,
+        "ingest_dataset": datasets.ingest_dataset_handler,
+    }
+
     async def _handler(args: dict[str, Any]) -> str:
-        return await datasets.inspect_dataset_handler(args, settings)
+        return await handlers[name](args, settings)
+
+    return _handler
+
+
+def _make_hub_handler(name: str, settings: AppSettings) -> ToolHandler:
+    """Create a handler for Hub discovery and repository inspection."""
+    from app.tools import hub
+
+    handlers = {
+        "search_hub": hub.search_hub_handler,
+        "inspect_hub_repo": hub.inspect_hub_repo_handler,
+    }
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await handlers[name](args, settings)
 
     return _handler
 

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from typing import Annotated, Any, Callable
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
@@ -23,6 +24,7 @@ from app.storage.models import (
     SessionMetricsSummary as SessionMetricsRecord,
 )
 from app.storage.repository import SQLiteRepository
+from app.tools.datasets import inspect_dataset_handler, validate_dataset_filename
 
 from .runtime import ActiveTurnManager, SessionAuthManager
 from .schemas import (
@@ -30,6 +32,7 @@ from .schemas import (
     ChatRequest,
     ChatResponse,
     CreateSessionRequest,
+    DatasetUploadResponse,
     InterruptResponse,
     MessagePayload,
     PendingApprovalPayload,
@@ -43,6 +46,7 @@ from .streaming import SessionEventStreamManager, create_event_stream_response
 
 RepositoryFactory = Callable[[AppSettings], SQLiteRepository]
 LoopFactory = Callable[[AppSettings, SQLiteRepository], AgentLoop]
+MAX_DATASET_UPLOAD_BYTES = 25 * 1024 * 1024
 
 
 def create_app(
@@ -86,6 +90,64 @@ def create_app(
         repo: RepositoryDep,
     ) -> list[SessionSummary]:
         return [_serialize_session_summary(repo, session) for session in repo.list_sessions()]
+
+    @router.post(
+        "/datasets/upload",
+        response_model=DatasetUploadResponse,
+        status_code=status.HTTP_201_CREATED,
+    )
+    async def upload_dataset(
+        request: Request,
+        current_settings: SettingsDep,
+    ) -> DatasetUploadResponse:
+        filename = request.headers.get("X-Filename", "").strip()
+        filename_error = validate_dataset_filename(filename)
+        if filename_error:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=filename_error)
+
+        content_length = request.headers.get("Content-Length")
+        if content_length:
+            try:
+                declared_size = int(content_length)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Content-Length must be an integer.",
+                ) from exc
+            if declared_size > MAX_DATASET_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    detail=f"Dataset upload exceeds {MAX_DATASET_UPLOAD_BYTES} bytes.",
+                )
+
+        payload = await request.body()
+        if not payload:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dataset upload is empty.")
+        if len(payload) > MAX_DATASET_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail=f"Dataset upload exceeds {MAX_DATASET_UPLOAD_BYTES} bytes.",
+            )
+
+        upload_dir = current_settings.paths.workspace_root / ".ml-copilot" / "uploads"
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        destination = _available_upload_path(upload_dir, filename)
+        destination.write_bytes(payload)
+        relative_path = destination.relative_to(current_settings.paths.workspace_root).as_posix()
+        preview = await inspect_dataset_handler(
+            {"source": relative_path, "source_kind": "local", "sample_rows": 3},
+            current_settings,
+        )
+        if preview.startswith("Error:"):
+            destination.unlink(missing_ok=True)
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=preview)
+
+        return DatasetUploadResponse(
+            filename=destination.name,
+            path=relative_path,
+            size_bytes=len(payload),
+            preview=preview,
+        )
 
     @router.get("/session/{session_id}", response_model=SessionDetail)
     async def get_session(
@@ -318,6 +380,20 @@ def _sanitize_metadata(value: dict[str, Any]) -> dict[str, Any]:
         return item
 
     return _sanitize(value)
+
+
+def _available_upload_path(directory: Path, filename: str) -> Path:
+    destination = directory / filename
+    if not destination.exists():
+        return destination
+    stem = destination.stem
+    suffix = destination.suffix
+    index = 2
+    while True:
+        candidate = directory / f"{stem}-{index}{suffix}"
+        if not candidate.exists():
+            return candidate
+        index += 1
 
 
 def _is_sensitive_metadata_key(key: str) -> bool:

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -116,3 +116,10 @@ class InterruptResponse(BaseModel):
     status: str
     interrupted: bool
     message: str
+
+
+class DatasetUploadResponse(BaseModel):
+    filename: str
+    path: str
+    size_bytes: int
+    preview: str

--- a/app/tools/datasets.py
+++ b/app/tools/datasets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import csv
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -18,23 +19,89 @@ HF_DATASETS_SERVER = "https://datasets-server.huggingface.co"
 MAX_SAMPLE_ROWS = 5
 MAX_VALUE_LEN = 120
 MAX_LOCAL_ROWS_SCAN = 10_000
+SUPPORTED_DATASET_EXTENSIONS = {".csv", ".tsv", ".jsonl", ".json", ".parquet"}
 
 
 async def inspect_dataset_handler(args: dict[str, Any], settings: AppSettings) -> str:
     """Tool handler: inspect a local file or HF dataset."""
-    source = args.get("source", "")
+    source = str(args.get("source", "")).strip()
     if not source:
         return "Error: No source provided. Pass a local file path or HF dataset name (e.g. 'imdb')."
 
-    # Route: no slash = always local; relative path prefix = local; otherwise check heuristic
-    if "/" not in source and "\\" not in source:
+    source_kind = str(args.get("source_kind", "auto")).strip().lower()
+    if source_kind == "local":
         return await _inspect_local(source, args, settings)
+    if source_kind == "hub":
+        return await _inspect_hf(source, args)
     if source.startswith(("./", "../", ".\\", "..\\", "/")):
         return await _inspect_local(source, args, settings)
     # Has a slash — could be HF namespace (user/dataset) or a local subpath
     if _looks_like_local_path(source, settings.paths.workspace_root):
         return await _inspect_local(source, args, settings)
+    if "/" not in source and "\\" not in source and Path(source).suffix.lower() in SUPPORTED_DATASET_EXTENSIONS:
+        return await _inspect_local(source, args, settings)
     return await _inspect_hf(source, args)
+
+
+async def ingest_dataset_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Validate and copy a workspace-local dataset into managed BYOD storage."""
+    source = str(args.get("source", "")).strip()
+    if not source:
+        return "Error: source is required."
+
+    workspace_root = settings.paths.workspace_root
+    source_path = Path(source) if Path(source).is_absolute() else workspace_root / source
+    safe_source = _safe_path(source_path, workspace_root)
+    if safe_source is None:
+        return f"Error: Path {source!r} is outside workspace root."
+    if not safe_source.exists() or not safe_source.is_file():
+        return f"Error: Dataset file not found: {source}"
+
+    filename_error = validate_dataset_filename(safe_source.name)
+    if filename_error:
+        return f"Error: {filename_error}"
+
+    destination_dir = workspace_root / ".ml-copilot" / "datasets"
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination = _unique_destination(destination_dir, safe_source.name)
+    if safe_source.resolve() != destination.resolve():
+        shutil.copy2(safe_source, destination)
+
+    managed_path = destination.relative_to(workspace_root).as_posix()
+    original_path = safe_source.relative_to(workspace_root).as_posix()
+    preview = await _inspect_local(managed_path, args, settings)
+    return (
+        "## BYOD dataset ingested\n\n"
+        f"**Managed path:** `{managed_path}`\n"
+        f"**Original path:** `{original_path}`\n\n"
+        f"{preview}"
+    )
+
+
+def validate_dataset_filename(filename: str) -> str | None:
+    """Validate a user-provided dataset filename."""
+    safe_name = Path(filename).name
+    if safe_name != filename or safe_name in {"", ".", ".."}:
+        return "Filename must not contain directory components."
+    extension = Path(safe_name).suffix.lower()
+    if extension not in SUPPORTED_DATASET_EXTENSIONS:
+        supported = ", ".join(sorted(SUPPORTED_DATASET_EXTENSIONS))
+        return f"Unsupported file type '{extension}'. Supported: {supported}"
+    return None
+
+
+def _unique_destination(directory: Path, filename: str) -> Path:
+    destination = directory / filename
+    if not destination.exists():
+        return destination
+    stem = destination.stem
+    suffix = destination.suffix
+    index = 2
+    while True:
+        candidate = directory / f"{stem}-{index}{suffix}"
+        if not candidate.exists():
+            return candidate
+        index += 1
 
 
 def _looks_like_local_path(source: str, workspace_root: Path) -> bool:
@@ -441,6 +508,11 @@ def get_tool_specs() -> list[dict[str, Any]]:
                             "(e.g. 'data/train.csv' or 'imdb' or 'username/dataset')."
                         ),
                     },
+                    "source_kind": {
+                        "type": "string",
+                        "enum": ["auto", "local", "hub"],
+                        "description": "Force local or Hub routing when auto-detection is ambiguous.",
+                    },
                     "config": {
                         "type": "string",
                         "description": "HF dataset config name (optional, auto-detected).",
@@ -452,6 +524,27 @@ def get_tool_specs() -> list[dict[str, Any]]:
                     "sample_rows": {
                         "type": "integer",
                         "description": "Number of sample rows to show (default: 3, max: 5).",
+                    },
+                },
+                "required": ["source"],
+            },
+        },
+        {
+            "name": "ingest_dataset",
+            "description": (
+                "Ingest a user-provided dataset from a workspace-local path into managed BYOD "
+                "storage, validate its format, and return a lightweight schema/sample preview."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "Workspace-local CSV, TSV, JSON, JSONL, or Parquet file path.",
+                    },
+                    "sample_rows": {
+                        "type": "integer",
+                        "description": "Number of preview rows to show (default: 5, max: 5).",
                     },
                 },
                 "required": ["source"],

--- a/app/tools/datasets.py
+++ b/app/tools/datasets.py
@@ -80,9 +80,13 @@ async def ingest_dataset_handler(args: dict[str, Any], settings: AppSettings) ->
 
 def validate_dataset_filename(filename: str) -> str | None:
     """Validate a user-provided dataset filename."""
+    if "/" in filename or "\\" in filename:
+        return "Filename must not contain directory components."
     safe_name = Path(filename).name
     if safe_name != filename or safe_name in {"", ".", ".."}:
         return "Filename must not contain directory components."
+    if len(safe_name) > 255:
+        return "Filename must be 255 characters or fewer."
     extension = Path(safe_name).suffix.lower()
     if extension not in SUPPORTED_DATASET_EXTENSIONS:
         supported = ", ".join(sorted(SUPPORTED_DATASET_EXTENSIONS))

--- a/app/tools/hub.py
+++ b/app/tools/hub.py
@@ -1,0 +1,414 @@
+"""Hugging Face Hub discovery and repo inspection tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.config import AppSettings
+from app.tools.context import current_hf_token
+
+HF_API = "https://huggingface.co/api"
+HF_DATASETS_SERVER = "https://datasets-server.huggingface.co"
+MAX_SEARCH_RESULTS = 10
+
+
+async def search_hub_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Search Hub models or datasets and rank lightweight fit signals."""
+    del settings
+
+    repo_type = _repo_type(args.get("repo_type", "model"))
+    query = str(args.get("query", "")).strip()
+    task = str(args.get("task", "")).strip()
+    license_name = str(args.get("license", "")).strip()
+    tags = _normalize_tags(args.get("tags"))
+    limit = _bounded_limit(args.get("limit", 5))
+
+    if not query and not task and not tags:
+        return "Error: Provide at least one of query, task, or tags."
+
+    endpoint = "models" if repo_type == "model" else "datasets"
+    params: dict[str, Any] = {
+        "limit": limit,
+        "sort": str(args.get("sort") or "downloads"),
+        "direction": -1,
+        "full": "true",
+    }
+    if query:
+        params["search"] = query
+    if repo_type == "model" and task:
+        params["pipeline_tag"] = task
+    filters = [*tags]
+    if repo_type == "dataset" and task:
+        filters.insert(0, task)
+    if filters:
+        params["filter"] = ",".join(filters)
+
+    headers = _auth_headers()
+    try:
+        async with httpx.AsyncClient(timeout=20.0, headers=headers) as client:
+            response = await client.get(f"{HF_API}/{endpoint}", params=params)
+            response.raise_for_status()
+            payload = response.json()
+    except Exception as exc:
+        return f"Error searching Hugging Face Hub: {exc}"
+
+    if not isinstance(payload, list) or not payload:
+        return "No matching Hub repositories found."
+
+    scored = [
+        _scored_candidate(item, repo_type=repo_type, query=query, task=task, tags=tags, license_name=license_name)
+        for item in payload[:limit]
+        if isinstance(item, dict)
+    ]
+    scored.sort(key=lambda item: item["score"], reverse=True)
+    return _format_search_results(
+        scored,
+        repo_type=repo_type,
+        query=query,
+        task=task,
+        tags=tags,
+        license_name=license_name,
+    )
+
+
+async def inspect_hub_repo_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Inspect a specific Hub model or dataset for fit and schema signals."""
+    del settings
+
+    repo_id = str(args.get("repo_id", "")).strip()
+    if not repo_id:
+        return "Error: repo_id is required."
+
+    repo_type = _repo_type(args.get("repo_type", "model"))
+    task = str(args.get("task", "")).strip()
+    required_columns = _normalize_tags(args.get("required_columns"))
+
+    endpoint = "models" if repo_type == "model" else "datasets"
+    headers = _auth_headers()
+    try:
+        async with httpx.AsyncClient(timeout=20.0, headers=headers) as client:
+            response = await client.get(f"{HF_API}/{endpoint}/{repo_id}")
+            response.raise_for_status()
+            repo = response.json()
+
+            dataset_schema = None
+            if repo_type == "dataset":
+                dataset_schema = await _fetch_dataset_schema(client, repo_id)
+    except Exception as exc:
+        return f"Error inspecting Hub repository: {exc}"
+
+    if not isinstance(repo, dict):
+        return "Error: Hub repository response was not an object."
+
+    return _format_repo_details(
+        repo,
+        repo_type=repo_type,
+        task=task,
+        required_columns=required_columns,
+        dataset_schema=dataset_schema,
+    )
+
+
+def _auth_headers() -> dict[str, str]:
+    token = current_hf_token()
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _repo_type(value: Any) -> str:
+    repo_type = str(value or "model").strip().lower()
+    return "dataset" if repo_type == "dataset" else "model"
+
+
+def _bounded_limit(value: Any) -> int:
+    try:
+        return max(1, min(int(value), MAX_SEARCH_RESULTS))
+    except (TypeError, ValueError):
+        return 5
+
+
+def _normalize_tags(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw = value.replace(";", ",").split(",")
+    elif isinstance(value, list):
+        raw = [str(item) for item in value]
+    else:
+        raw = [str(value)]
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        tag = item.strip()
+        if tag and tag.lower() not in seen:
+            result.append(tag)
+            seen.add(tag.lower())
+    return result
+
+
+def _repo_id(item: dict[str, Any]) -> str:
+    return str(item.get("id") or item.get("modelId") or item.get("datasetId") or "").strip()
+
+
+def _repo_tags(item: dict[str, Any]) -> list[str]:
+    return [str(tag) for tag in item.get("tags", []) if str(tag).strip()]
+
+
+def _license(item: dict[str, Any]) -> str:
+    card_data_value = item.get("cardData")
+    card_data: dict[str, Any] = card_data_value if isinstance(card_data_value, dict) else {}
+    for value in (item.get("license"), card_data.get("license")):
+        if isinstance(value, str) and value:
+            return value
+    for tag in _repo_tags(item):
+        if tag.startswith("license:"):
+            return tag.split(":", 1)[1]
+    return "unknown"
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _scored_candidate(
+    item: dict[str, Any],
+    *,
+    repo_type: str,
+    query: str,
+    task: str,
+    tags: list[str],
+    license_name: str,
+) -> dict[str, Any]:
+    repo_id = _repo_id(item)
+    repo_tags = _repo_tags(item)
+    repo_task = str(item.get("pipeline_tag") or item.get("task") or "")
+    repo_license = _license(item)
+    downloads = _safe_int(item.get("downloads"))
+    likes = _safe_int(item.get("likes"))
+
+    score = min(downloads, 100_000) // 2_000 + min(likes, 10_000) // 200
+    reasons: list[str] = []
+
+    haystack = " ".join([repo_id, repo_task, repo_license, *repo_tags]).lower()
+    if query and query.lower() in haystack:
+        score += 20
+        reasons.append("query match")
+    if task and (task.lower() == repo_task.lower() or task.lower() in haystack):
+        score += 25
+        reasons.append("task match")
+    for tag in tags:
+        if tag.lower() in haystack:
+            score += 8
+            reasons.append(f"tag:{tag}")
+    if license_name and license_name.lower() in repo_license.lower():
+        score += 10
+        reasons.append("license match")
+    if item.get("gated") or item.get("private"):
+        score -= 5
+        reasons.append("requires access")
+    if repo_type == "dataset" and any(tag in {"parquet", "viewer", "croissant"} for tag in repo_tags):
+        score += 5
+        reasons.append("preview-friendly")
+
+    return {
+        "id": repo_id,
+        "score": score,
+        "task": repo_task or "-",
+        "license": repo_license,
+        "downloads": downloads,
+        "likes": likes,
+        "tags": repo_tags,
+        "gated": bool(item.get("gated") or item.get("private")),
+        "reasons": reasons or ["metadata-ranked"],
+    }
+
+
+def _format_search_results(
+    scored: list[dict[str, Any]],
+    *,
+    repo_type: str,
+    query: str,
+    task: str,
+    tags: list[str],
+    license_name: str,
+) -> str:
+    label = "models" if repo_type == "model" else "datasets"
+    sections = [f"## Hub {label} discovery", ""]
+    filters = []
+    if query:
+        filters.append(f"query={query}")
+    if task:
+        filters.append(f"task={task}")
+    if tags:
+        filters.append("tags=" + ", ".join(tags))
+    if license_name:
+        filters.append(f"license={license_name}")
+    if filters:
+        sections.append("**Filters:** " + " | ".join(filters))
+        sections.append("")
+
+    sections.append("| Score | Repository | Task | License | Downloads | Likes | Fit signals |")
+    sections.append("|---:|---|---|---|---:|---:|---|")
+    for item in scored:
+        repo_url = _hub_url(item["id"], repo_type)
+        signals = ", ".join(item["reasons"])
+        if item["gated"]:
+            signals = f"{signals}, gated/private"
+        sections.append(
+            f"| {item['score']} | [{item['id']}]({repo_url}) | {item['task']} | "
+            f"{item['license']} | {item['downloads']} | {item['likes']} | {signals} |"
+        )
+
+    sections.append("")
+    sections.append("Next step: call `inspect_hub_repo` on the strongest candidates before training.")
+    return "\n".join(sections)
+
+
+async def _fetch_dataset_schema(client: httpx.AsyncClient, repo_id: str) -> dict[str, Any] | None:
+    try:
+        splits_response = await client.get(f"{HF_DATASETS_SERVER}/splits", params={"dataset": repo_id})
+        if splits_response.status_code != 200:
+            return None
+        splits_payload = splits_response.json()
+        splits = splits_payload.get("splits", []) if isinstance(splits_payload, dict) else []
+        config = splits[0].get("config", "default") if splits else "default"
+        split = splits[0].get("split", "train") if splits else "train"
+        info_response = await client.get(f"{HF_DATASETS_SERVER}/info", params={"dataset": repo_id, "config": config})
+        if info_response.status_code != 200:
+            return {"config": config, "split": split, "features": {}}
+        info_payload = info_response.json()
+        features = info_payload.get("dataset_info", {}).get("features", {})
+        return {"config": config, "split": split, "features": features if isinstance(features, dict) else {}}
+    except Exception:  # nosec B110
+        return None
+
+
+def _format_repo_details(
+    repo: dict[str, Any],
+    *,
+    repo_type: str,
+    task: str,
+    required_columns: list[str],
+    dataset_schema: dict[str, Any] | None,
+) -> str:
+    repo_id = _repo_id(repo)
+    repo_tags = _repo_tags(repo)
+    repo_task = str(repo.get("pipeline_tag") or repo.get("task") or "unknown")
+    repo_license = _license(repo)
+    downloads = _safe_int(repo.get("downloads"))
+    likes = _safe_int(repo.get("likes"))
+
+    sections = [f"## {repo_id} ({repo_type})", ""]
+    sections.append(f"**URL:** {_hub_url(repo_id, repo_type)}")
+    sections.append(f"**Task:** {repo_task}")
+    sections.append(f"**License:** {repo_license}")
+    sections.append(f"**Downloads:** {downloads:,} | **Likes:** {likes:,}")
+    if repo.get("gated") or repo.get("private"):
+        sections.append("**Access:** gated/private; requires the active Hugging Face token.")
+    if repo_tags:
+        sections.append(f"**Tags:** {', '.join(repo_tags[:20])}")
+    sections.append("")
+
+    fit = _fit_summary(repo_task=repo_task, task=task, license_name=repo_license)
+    sections.append("### Fit")
+    sections.extend(f"- {line}" for line in fit)
+
+    if dataset_schema is not None:
+        features = dataset_schema.get("features") or {}
+        columns = list(features)
+        sections.append("")
+        sections.append(f"### Dataset Schema ({dataset_schema.get('config')}/{dataset_schema.get('split')})")
+        if columns:
+            sections.append("| Column | Type |")
+            sections.append("|---|---|")
+            for name, info in list(features.items())[:20]:
+                dtype = info.get("dtype") or info.get("_type") or type(info).__name__
+                sections.append(f"| {name} | {dtype} |")
+        else:
+            sections.append("No schema preview was available from datasets-server.")
+        if required_columns:
+            missing = [column for column in required_columns if column not in columns]
+            status = "pass" if not missing else "missing " + ", ".join(missing)
+            sections.append("")
+            sections.append(f"**Required columns check:** {status}")
+
+    return "\n".join(sections)
+
+
+def _fit_summary(*, repo_task: str, task: str, license_name: str) -> list[str]:
+    summary: list[str] = []
+    if task:
+        if task.lower() == repo_task.lower() or task.lower() in repo_task.lower():
+            summary.append(f"Task fit: matches requested task `{task}`.")
+        else:
+            summary.append(f"Task fit: requested `{task}`, repo reports `{repo_task}`.")
+    else:
+        summary.append("Task fit: no requested task supplied; verify against the training recipe.")
+    if license_name == "unknown":
+        summary.append("License fit: unknown; inspect the model/dataset card before commercial use.")
+    else:
+        summary.append(f"License fit: `{license_name}` reported by Hub metadata.")
+    return summary
+
+
+def _hub_url(repo_id: str, repo_type: str) -> str:
+    if repo_type == "dataset":
+        return f"https://huggingface.co/datasets/{repo_id}"
+    return f"https://huggingface.co/{repo_id}"
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return OpenAI-compatible tool specifications."""
+    return [
+        {
+            "name": "search_hub",
+            "description": (
+                "Search Hugging Face Hub models or datasets and rank candidates by task, license, "
+                "tags, popularity, and access signals. Use before selecting a base model or dataset."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "repo_type": {"type": "string", "enum": ["model", "dataset"], "description": "Hub repo type."},
+                    "query": {"type": "string", "description": "Search query such as 'sentiment' or 'qwen instruct'."},
+                    "task": {
+                        "type": "string",
+                        "description": "Desired task/pipeline tag, such as text-classification.",
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Preferred Hub tags, libraries, modalities, or dataset traits.",
+                    },
+                    "license": {"type": "string", "description": "Preferred license keyword."},
+                    "sort": {"type": "string", "description": "Hub sort field, default downloads."},
+                    "limit": {"type": "integer", "description": "Number of candidates to return, max 10."},
+                },
+            },
+        },
+        {
+            "name": "inspect_hub_repo",
+            "description": (
+                "Inspect a Hugging Face model or dataset for license, task compatibility, access "
+                "requirements, and dataset schema. Use after search_hub before training."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "repo_id": {"type": "string", "description": "Hub repository ID, e.g. Qwen/Qwen2.5-0.5B."},
+                    "repo_type": {"type": "string", "enum": ["model", "dataset"], "description": "Hub repo type."},
+                    "task": {"type": "string", "description": "Requested task to compare against repo metadata."},
+                    "required_columns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Dataset columns required by the planned training recipe.",
+                    },
+                },
+                "required": ["repo_id"],
+            },
+        },
+    ]

--- a/app/tools/hub.py
+++ b/app/tools/hub.py
@@ -57,11 +57,22 @@ async def search_hub_handler(args: dict[str, Any], settings: AppSettings) -> str
     if not isinstance(payload, list) or not payload:
         return "No matching Hub repositories found."
 
-    scored = [
-        _scored_candidate(item, repo_type=repo_type, query=query, task=task, tags=tags, license_name=license_name)
-        for item in payload[:limit]
-        if isinstance(item, dict)
-    ]
+    scored = []
+    for item in payload[:limit]:
+        if not isinstance(item, dict) or not _repo_id(item):
+            continue
+        scored.append(
+            _scored_candidate(
+                item,
+                repo_type=repo_type,
+                query=query,
+                task=task,
+                tags=tags,
+                license_name=license_name,
+            )
+        )
+    if not scored:
+        return "No valid Hub repository metadata was returned."
     scored.sort(key=lambda item: item["score"], reverse=True)
     return _format_search_results(
         scored,
@@ -152,7 +163,10 @@ def _repo_id(item: dict[str, Any]) -> str:
 
 
 def _repo_tags(item: dict[str, Any]) -> list[str]:
-    return [str(tag) for tag in item.get("tags", []) if str(tag).strip()]
+    tags = item.get("tags")
+    if not isinstance(tags, list):
+        return []
+    return [str(tag) for tag in tags if str(tag).strip()]
 
 
 def _license(item: dict[str, Any]) -> str:
@@ -326,7 +340,10 @@ def _format_repo_details(
             sections.append("| Column | Type |")
             sections.append("|---|---|")
             for name, info in list(features.items())[:20]:
-                dtype = info.get("dtype") or info.get("_type") or type(info).__name__
+                if isinstance(info, dict):
+                    dtype = info.get("dtype") or info.get("_type") or "unknown"
+                else:
+                    dtype = type(info).__name__
                 sections.append(f"| {name} | {dtype} |")
         else:
             sections.append("No schema preview was available from datasets-server.")

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,6 +11,13 @@ import type {
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? '';
 
+export interface DatasetUploadResponse {
+  filename: string;
+  path: string;
+  size_bytes: number;
+  preview: string;
+}
+
 async function request<T>(path: string, init?: RequestInit, hfToken?: string | null): Promise<T> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -77,6 +84,17 @@ export function resolveApproval(
     method: 'POST',
     body: JSON.stringify(payload),
   }, hfToken);
+}
+
+export function uploadDataset(file: File) {
+  return request<DatasetUploadResponse>('/api/datasets/upload', {
+    method: 'POST',
+    body: file,
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+      'X-Filename': file.name,
+    },
+  });
 }
 
 export function createSessionEventSource(

--- a/frontend/src/components/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar.tsx
@@ -1,4 +1,5 @@
-import type { FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
+import { uploadDataset } from '../api';
 import type { MessagePayload, SessionDetail, SessionSummary } from '../types';
 
 interface SessionSidebarProps {
@@ -74,9 +75,27 @@ export default function SessionSidebar({
   setDraftModel,
   setDraftTitle,
 }: SessionSidebarProps) {
+  const [datasetFile, setDatasetFile] = useState<File | null>(null);
+  const [datasetStatus, setDatasetStatus] = useState('');
+  const [uploadingDataset, setUploadingDataset] = useState(false);
   const isCurrentSession = Boolean(activeSession && activeSession.id === selectedSessionId);
   const currentSession = isCurrentSession ? activeSession : null;
   const recentMessages = isCurrentSession ? [...messages].slice(-3) : [];
+
+  async function handleDatasetUpload() {
+    if (!datasetFile) return;
+    setUploadingDataset(true);
+    setDatasetStatus('');
+    try {
+      const uploaded = await uploadDataset(datasetFile);
+      setDatasetStatus(`Ready at ${uploaded.path}`);
+      setDatasetFile(null);
+    } catch (error) {
+      setDatasetStatus(error instanceof Error ? error.message : 'Dataset upload failed.');
+    } finally {
+      setUploadingDataset(false);
+    }
+  }
 
   return (
     <div className="session-sidebar">
@@ -121,6 +140,27 @@ export default function SessionSidebar({
           {creating ? 'Creating...' : 'Create session'}
         </button>
       </form>
+
+      <section className="dataset-upload-card">
+        <div>
+          <p className="panel-label">Bring your own data</p>
+          <strong>Upload a dataset</strong>
+        </div>
+        <input
+          type="file"
+          accept=".csv,.tsv,.json,.jsonl,.parquet"
+          onChange={(event) => setDatasetFile(event.target.files?.[0] ?? null)}
+        />
+        <button
+          className="ghost-button"
+          type="button"
+          disabled={!datasetFile || uploadingDataset}
+          onClick={handleDatasetUpload}
+        >
+          {uploadingDataset ? 'Uploading...' : 'Upload and preview'}
+        </button>
+        {datasetStatus ? <p className="hint">{datasetStatus}</p> : null}
+      </section>
 
       <div className="session-list">
         {sessions.length === 0 ? (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -245,6 +245,7 @@ button {
 }
 
 .composer-card,
+.dataset-upload-card,
 .info-card,
 .tool-card,
 .session-card,
@@ -262,6 +263,30 @@ button {
   margin-bottom: 16px;
   padding: 14px;
   border-radius: 22px;
+}
+
+.dataset-upload-card {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 2px;
+  padding: 14px;
+  border-radius: 18px;
+}
+
+.dataset-upload-card input[type='file'] {
+  width: 100%;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.dataset-upload-card input[type='file']::file-selector-button {
+  margin-right: 10px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.14);
+  color: var(--text);
+  padding: 8px 11px;
+  cursor: pointer;
 }
 
 .composer-card label,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -153,6 +153,13 @@ def test_dataset_upload_rejects_unsafe_filename(tmp_path: Path) -> None:
     assert response.status_code == 400
     assert "directory components" in response.json()["detail"]
 
+    windows_response = client.post(
+        "/api/datasets/upload",
+        content=b"text\nhello\n",
+        headers={"X-Filename": "..\\train.csv"},
+    )
+    assert windows_response.status_code == 400
+
 
 def test_dataset_upload_rejects_declared_oversize_before_storage(tmp_path: Path) -> None:
     app = create_app(_settings(tmp_path))

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -121,6 +121,56 @@ def test_create_and_list_sessions_via_api(tmp_path: Path) -> None:
     assert listed_body[0]["message_count"] == 0
 
 
+def test_dataset_upload_stores_and_previews_supported_file(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/datasets/upload",
+        content=b"text,label\nhello,1\nworld,0\n",
+        headers={"X-Filename": "train.csv", "Content-Type": "text/csv"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["filename"] == "train.csv"
+    assert body["path"] == ".ml-copilot/uploads/train.csv"
+    assert body["size_bytes"] > 0
+    assert "hello" in body["preview"]
+    assert (tmp_path / body["path"]).exists()
+
+
+def test_dataset_upload_rejects_unsafe_filename(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/datasets/upload",
+        content=b"text\nhello\n",
+        headers={"X-Filename": "../train.csv"},
+    )
+
+    assert response.status_code == 400
+    assert "directory components" in response.json()["detail"]
+
+
+def test_dataset_upload_rejects_declared_oversize_before_storage(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/datasets/upload",
+        content=b"text\nhello\n",
+        headers={
+            "X-Filename": "train.csv",
+            "Content-Length": str(25 * 1024 * 1024 + 1),
+        },
+    )
+
+    assert response.status_code == 413
+    assert not (tmp_path / ".ml-copilot" / "uploads" / "train.csv").exists()
+
+
 def test_session_token_is_stored_and_reused_for_turns(tmp_path: Path) -> None:
     token_loop = TokenAwareLoop()
 

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -16,6 +16,7 @@ from app.tools.datasets import (
     _inspect_jsonl,
     _looks_like_local_path,
     get_tool_specs,
+    ingest_dataset_handler,
     inspect_dataset_handler,
 )
 
@@ -210,10 +211,45 @@ class TestInspectDatasetHandler:
             result = await inspect_dataset_handler({"source": "username/dataset"}, settings)
         assert "Hugging Face" in result
 
+    @pytest.mark.asyncio
+    async def test_bare_hf_dataset_name_routes_to_hub(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        with patch("app.tools.datasets._inspect_hf", new_callable=AsyncMock) as mock_hf:
+            mock_hf.return_value = "## imdb (Hugging Face)"
+            result = await inspect_dataset_handler({"source": "imdb"}, settings)
+        assert "Hugging Face" in result
+        mock_hf.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_source_kind_can_force_local_routing(self, tmp_path: Path) -> None:
+        (tmp_path / "dataset").write_text("text,label\nhello,1\n", encoding="utf-8")
+        result = await inspect_dataset_handler(
+            {"source": "dataset", "source_kind": "local"},
+            _settings(tmp_path),
+        )
+        assert "Unsupported file type" in result
+
+
+@pytest.mark.asyncio
+async def test_ingest_dataset_copies_and_previews_byod_file(tmp_path: Path) -> None:
+    source = tmp_path / "uploads" / "train.csv"
+    source.parent.mkdir()
+    source.write_text("text,label\nhello,1\nworld,0\n", encoding="utf-8")
+
+    result = await ingest_dataset_handler(
+        {"source": "uploads/train.csv", "sample_rows": 2},
+        _settings(tmp_path),
+    )
+
+    managed = tmp_path / ".ml-copilot" / "datasets" / "train.csv"
+    assert managed.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+    assert "BYOD dataset ingested" in result
+    assert ".ml-copilot/datasets/train.csv" in result
+    assert "hello" in result
+
 
 class TestGetToolSpecs:
     def test_spec(self) -> None:
         specs = get_tool_specs()
-        assert len(specs) == 1
-        assert specs[0]["name"] == "inspect_dataset"
+        assert [spec["name"] for spec in specs] == ["inspect_dataset", "ingest_dataset"]
         assert "source" in specs[0]["parameters"]["properties"]

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -53,6 +53,7 @@ async def test_search_hub_ranks_task_and_license_matches(tmp_path: Path, monkeyp
     FakeAsyncClient.responses = {
         "https://huggingface.co/api/models": FakeResponse(
             [
+                {"downloads": 999999, "tags": None},
                 {
                     "id": "org/general-model",
                     "downloads": 1000,
@@ -65,7 +66,8 @@ async def test_search_hub_ranks_task_and_license_matches(tmp_path: Path, monkeyp
                     "downloads": 500,
                     "likes": 5,
                     "pipeline_tag": "text-classification",
-                    "tags": ["license:mit", "transformers"],
+                    "tags": None,
+                    "cardData": {"license": "mit"},
                 },
             ]
         )
@@ -111,7 +113,7 @@ async def test_inspect_dataset_repo_reports_required_column_fit(tmp_path: Path, 
                 "dataset_info": {
                     "features": {
                         "messages": {"_type": "Sequence"},
-                        "source": {"dtype": "string"},
+                        "source": "string",
                     }
                 }
             }
@@ -131,4 +133,5 @@ async def test_inspect_dataset_repo_reports_required_column_fit(tmp_path: Path, 
 
     assert "Dataset Schema (default/train)" in result
     assert "| messages | Sequence |" in result
+    assert "| source | str |" in result
     assert "**Required columns check:** pass" in result

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -1,0 +1,134 @@
+"""Tests for Hugging Face Hub discovery tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.config import AppPaths, AppSettings
+from app.tools.context import ToolExecutionContext, use_tool_execution_context
+from app.tools.hub import inspect_hub_repo_handler, search_hub_handler
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeAsyncClient:
+    responses: dict[str, FakeResponse] = {}
+    instances: list["FakeAsyncClient"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.headers = kwargs.get("headers", {})
+        self.requests: list[tuple[str, dict | None]] = []
+        self.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def get(self, url: str, params=None):
+        self.requests.append((url, params))
+        return self.responses[url]
+
+
+@pytest.mark.asyncio
+async def test_search_hub_ranks_task_and_license_matches(tmp_path: Path, monkeypatch) -> None:
+    FakeAsyncClient.responses = {
+        "https://huggingface.co/api/models": FakeResponse(
+            [
+                {
+                    "id": "org/general-model",
+                    "downloads": 1000,
+                    "likes": 10,
+                    "pipeline_tag": "text-generation",
+                    "tags": ["license:apache-2.0"],
+                },
+                {
+                    "id": "org/sentiment-model",
+                    "downloads": 500,
+                    "likes": 5,
+                    "pipeline_tag": "text-classification",
+                    "tags": ["license:mit", "transformers"],
+                },
+            ]
+        )
+    }
+    FakeAsyncClient.instances = []
+    monkeypatch.setattr("app.tools.hub.httpx.AsyncClient", FakeAsyncClient)
+
+    with use_tool_execution_context(ToolExecutionContext(session_id="session-1", hf_token="hf-token")):
+        result = await search_hub_handler(
+            {
+                "repo_type": "model",
+                "query": "sentiment",
+                "task": "text-classification",
+                "license": "mit",
+            },
+            _settings(tmp_path),
+        )
+
+    assert result.index("org/sentiment-model") < result.index("org/general-model")
+    assert "task match" in result
+    assert "license match" in result
+    assert FakeAsyncClient.instances[0].headers["Authorization"] == "Bearer hf-token"
+    assert FakeAsyncClient.instances[0].requests[0][1]["pipeline_tag"] == "text-classification"
+
+
+@pytest.mark.asyncio
+async def test_inspect_dataset_repo_reports_required_column_fit(tmp_path: Path, monkeypatch) -> None:
+    repo_id = "org/chat-data"
+    FakeAsyncClient.responses = {
+        f"https://huggingface.co/api/datasets/{repo_id}": FakeResponse(
+            {
+                "id": repo_id,
+                "downloads": 2000,
+                "likes": 20,
+                "tags": ["license:apache-2.0", "parquet"],
+            }
+        ),
+        "https://datasets-server.huggingface.co/splits": FakeResponse(
+            {"splits": [{"config": "default", "split": "train"}]}
+        ),
+        "https://datasets-server.huggingface.co/info": FakeResponse(
+            {
+                "dataset_info": {
+                    "features": {
+                        "messages": {"_type": "Sequence"},
+                        "source": {"dtype": "string"},
+                    }
+                }
+            }
+        ),
+    }
+    FakeAsyncClient.instances = []
+    monkeypatch.setattr("app.tools.hub.httpx.AsyncClient", FakeAsyncClient)
+
+    result = await inspect_hub_repo_handler(
+        {
+            "repo_id": repo_id,
+            "repo_type": "dataset",
+            "required_columns": ["messages", "source"],
+        },
+        _settings(tmp_path),
+    )
+
+    assert "Dataset Schema (default/train)" in result
+    assert "| messages | Sequence |" in result
+    assert "**Required columns check:** pass" in result


### PR DESCRIPTION
## Summary
- add token-aware Hugging Face Hub model and dataset search with deterministic task, license, popularity, access, and tag fit signals
- add detailed Hub repo inspection for model metadata and dataset schema/required-column checks
- add BYOD upload and workspace ingestion with safe filenames, size limits, supported-format validation, managed storage, previews, and a frontend upload control

## Testing
- `python -m pytest -q`
- `python -m pytest -q tests/unit/test_api.py tests/unit/test_hub.py tests/unit/test_datasets.py`
- `python -m mypy app --ignore-missing-imports --follow-imports=skip`
- `python -m ruff format --check app tests`
- `python -m ruff check app tests`
- `python -m pre_commit run --all-files`
- `npm run build`

## Notes
Hub search ranking is intentionally lightweight and deterministic. It narrows candidates, but the agent is expected to call `inspect_hub_repo` before selecting a model or dataset for training. Direct uploads are limited to 25 MB and stored under the workspace `.ml-copilot` directory.

## Reference
Issue: #84