### PR TITLE
ML-302 / Extend paper tooling into citation graph and recipe extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ LLM_API_KEY=replace-me
 # when one is attached to the request.
 # HF_TOKEN=hf_xxx
 
+# Optional Semantic Scholar API key used by the citation graph tool for higher
+# rate limits. Citation traversal still works without it under the public
+# unauthenticated limits.
+# S2_API_KEY=
+
 # Model name for the configured endpoint.
 # Examples:
 # - gpt-5.4

--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -986,7 +986,7 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             name=spec["name"],
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
-            handler=_make_papers_handler(settings),
+            handler=_make_papers_handler(spec["name"], settings),
         )
         registry.register(tool_spec)
 
@@ -1068,12 +1068,19 @@ def _make_hub_handler(name: str, settings: AppSettings) -> ToolHandler:
     return _handler
 
 
-def _make_papers_handler(settings: AppSettings) -> ToolHandler:
-    """Create a handler for the paper_details tool."""
+def _make_papers_handler(name: str, settings: AppSettings) -> ToolHandler:
+    """Create a handler for a paper research tool (metadata, citations, reading, recipes)."""
     from app.tools import papers
 
+    handlers = {
+        "paper_details": papers.paper_details_handler,
+        "paper_citation_graph": papers.paper_citation_graph_handler,
+        "read_paper": papers.read_paper_handler,
+        "extract_training_recipe": papers.extract_training_recipe_handler,
+    }
+
     async def _handler(args: dict[str, Any]) -> str:
-        return await papers.paper_details_handler(args, settings)
+        return await handlers[name](args, settings)
 
     return _handler
 

--- a/app/tools/papers.py
+++ b/app/tools/papers.py
@@ -1,19 +1,51 @@
-"""Paper metadata reader for Hugging Face papers."""
+"""Paper research tools: metadata, citation graph, section reading, and recipe extraction."""
 
 from __future__ import annotations
 
+import asyncio
+import os
+import re
+import time
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+from bs4 import BeautifulSoup, Tag
 
 from app.config import AppSettings
 from app.tools.context import current_hf_token
 
 HF_API = "https://huggingface.co/api"
 
+# arXiv HTML rendering hosts. ar5iv is a fallback for papers without a native
+# arXiv HTML version.
+ARXIV_HTML = "https://arxiv.org/html"
+AR5IV_HTML = "https://ar5iv.labs.arxiv.org/html"
+
+# Semantic Scholar Graph API.
+S2_API = "https://api.semanticscholar.org"
+S2_TIMEOUT = 12.0
+
 MAX_AUTHOR_COUNT = 10
 MAX_SUMMARY_LEN = 500
+MAX_SECTION_TEXT_LEN = 8000
+MAX_SECTION_PREVIEW_LEN = 280
+MAX_CITATION_CONTEXTS = 2
+MAX_CITATION_CONTEXT_LEN = 200
+
+# Citation graph result bounds. One-hop traversal only; the caller can follow
+# individual arxiv ids to go deeper.
+DEFAULT_CITATION_LIMIT = 10
+MAX_CITATION_LIMIT = 50
+
+# Recipe extraction bounds.
+RECIPE_SNIPPET_LEN = 160
+MAX_RECIPE_VALUES = 6
+
+
+# ---------------------------------------------------------------------------
+# arXiv id helpers
+# ---------------------------------------------------------------------------
 
 
 def _normalize_arxiv_id(value: Any) -> str:
@@ -40,6 +72,108 @@ def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[:limit] + "..."
+
+
+# ---------------------------------------------------------------------------
+# Semantic Scholar client (one-hop traversal only)
+# ---------------------------------------------------------------------------
+
+
+def _s2_headers() -> dict[str, str]:
+    """Optional Semantic Scholar API key when provided in the environment."""
+    api_key = os.environ.get("S2_API_KEY")
+    return {"x-api-key": api_key} if api_key else {}
+
+
+# Module-level rate-limiting for the shared Semantic Scholar endpoint. Only
+# applied when authenticated, mirroring the public unauthenticated limits.
+_s2_last_request: float = 0.0
+
+# Lightweight response cache so repeated citation-graph reads within a session
+# do not refetch the same paper.
+_s2_cache: dict[str, Any] = {}
+_S2_CACHE_MAX = 256
+
+
+def _s2_paper_id(arxiv_id: str) -> str:
+    """Convert a bare arxiv id to the Semantic Scholar corpus id format."""
+    return f"ARXIV:{arxiv_id}"
+
+
+def _s2_cache_key(path: str, params: dict[str, Any] | None) -> str:
+    normalized = tuple(sorted((params or {}).items()))
+    return f"{path}:{normalized}"
+
+
+async def _s2_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    **kwargs: Any,
+) -> httpx.Response | None:
+    """Semantic Scholar request with bounded retries on rate limiting and 5xx.
+
+    Returns ``None`` when the endpoint is unavailable so callers can degrade
+    gracefully instead of surfacing raw transport errors to the agent.
+    """
+    global _s2_last_request
+    url = f"{S2_API}{path}"
+    kwargs.setdefault("headers", {}).update(_s2_headers())
+    kwargs.setdefault("timeout", S2_TIMEOUT)
+
+    for attempt in range(3):
+        if _s2_headers():
+            min_interval = 1.0 if "search" in path else 0.1
+            elapsed = time.monotonic() - _s2_last_request
+            if elapsed < min_interval:
+                await asyncio.sleep(min_interval - elapsed)
+        _s2_last_request = time.monotonic()
+
+        try:
+            response = await client.request(method, url, **kwargs)
+        except (httpx.RequestError, httpx.HTTPStatusError):
+            if attempt < 2:
+                await asyncio.sleep(2.0)
+                continue
+            return None
+
+        if response.status_code == 429:
+            if attempt < 2:
+                await asyncio.sleep(5.0)
+                continue
+            return None
+        if response.status_code >= 500:
+            if attempt < 2:
+                await asyncio.sleep(2.0)
+                continue
+            return None
+        return response
+    return None
+
+
+async def _s2_get_json(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Cached Semantic Scholar GET returning parsed JSON or ``None``."""
+    key = _s2_cache_key(path, params)
+    if key in _s2_cache:
+        return _s2_cache[key]
+
+    response = await _s2_request(client, "GET", path, params=params or {})
+    if response is None or response.status_code != 200:
+        return None
+
+    data = response.json()
+    if len(_s2_cache) < _S2_CACHE_MAX:
+        _s2_cache[key] = data
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Paper metadata (paper_details)
+# ---------------------------------------------------------------------------
 
 
 def _format_paper_details(paper: dict[str, Any]) -> str:
@@ -76,7 +210,7 @@ def _format_paper_details(paper: dict[str, Any]) -> str:
     if summary:
         lines.append(f"\n## Abstract\n{_truncate(summary, MAX_SUMMARY_LEN)}")
 
-    lines.append("\n**Next:** Use this metadata before citation graph or paper reading tasks.")
+    lines.append("\n**Next:** Use citation_graph, read_paper, or extract_training_recipe to go deeper.")
     return "\n".join(lines)
 
 
@@ -94,6 +228,8 @@ async def _fetch_paper(arxiv_id: str) -> dict[str, Any]:
 
 async def paper_details_handler(args: dict[str, Any], settings: AppSettings) -> str:
     """Fetch and format Hugging Face paper metadata."""
+    del settings
+
     raw_arxiv_id = args.get("arxiv_id", "")
     arxiv_id = _normalize_arxiv_id(raw_arxiv_id)
     if not arxiv_id:
@@ -113,8 +249,459 @@ async def paper_details_handler(args: dict[str, Any], settings: AppSettings) -> 
     return _format_paper_details(paper)
 
 
+# ---------------------------------------------------------------------------
+# Citation graph (Semantic Scholar, one-hop)
+# ---------------------------------------------------------------------------
+
+
+def _format_citation_entry(entry: dict[str, Any], *, show_context: bool) -> str:
+    """Format a single reference or citation entry."""
+    paper = entry.get("citingPaper") or entry.get("citedPaper") or {}
+    title = paper.get("title") or "(untitled)"
+    year = paper.get("year") or "?"
+    cites = paper.get("citationCount", 0)
+    ext_ids = paper.get("externalIds") or {}
+    aid = ext_ids.get("ArXiv", "")
+    influential_marker = " **[influential]**" if entry.get("isInfluential") else ""
+
+    first_line = f"- **{title}** ({year}, {cites} cites){influential_marker}"
+    if aid:
+        first_line += f" arxiv:{aid}"
+    parts = [first_line]
+
+    if show_context:
+        intents = entry.get("intents") or []
+        if intents:
+            parts.append(f"  Intent: {', '.join(intents)}")
+        contexts = entry.get("contexts") or []
+        for context in contexts[:MAX_CITATION_CONTEXTS]:
+            if context:
+                parts.append(f"  > {_truncate(context, MAX_CITATION_CONTEXT_LEN)}")
+
+    return "\n".join(parts)
+
+
+def _format_citation_graph(
+    arxiv_id: str,
+    references: list[dict[str, Any]] | None,
+    citations: list[dict[str, Any]] | None,
+) -> str:
+    lines = [f"# Citation graph for {arxiv_id}"]
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}\n")
+
+    if references is not None:
+        lines.append(f"## References ({len(references)})")
+        if references:
+            for entry in references:
+                lines.append(_format_citation_entry(entry, show_context=False))
+        else:
+            lines.append("No references found.")
+        lines.append("")
+
+    if citations is not None:
+        lines.append(f"## Citations ({len(citations)})")
+        if citations:
+            for entry in citations:
+                lines.append(_format_citation_entry(entry, show_context=True))
+        else:
+            lines.append("No citations found.")
+        lines.append("")
+
+    lines.append("**Next:** Use paper_details or read_paper with an arxiv_id above to explore further.")
+    return "\n".join(lines)
+
+
+def _bounded_citation_limit(raw: Any) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_CITATION_LIMIT
+    return max(1, min(value, MAX_CITATION_LIMIT))
+
+
+async def _fetch_citation_side(
+    client: httpx.AsyncClient,
+    s2_id: str,
+    side: str,
+    limit: int,
+) -> list[dict[str, Any]] | None:
+    """Fetch one side of the citation graph (references or citations)."""
+    fields = "title,externalIds,year,citationCount,influentialCitationCount,contexts,intents,isInfluential"
+    params = {"fields": fields, "limit": limit}
+    data = await _s2_get_json(client, f"/graph/v1/paper/{s2_id}/{side}", params)
+    if data is None:
+        return None
+    entries = data.get("data") or []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+async def paper_citation_graph_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Return a one-hop citation graph for a paper via Semantic Scholar."""
+    del settings
+
+    raw_arxiv_id = args.get("arxiv_id", "")
+    arxiv_id = _normalize_arxiv_id(raw_arxiv_id)
+    if not arxiv_id:
+        return "Error: No arxiv_id provided. Pass an arXiv ID or paper URL."
+
+    direction = str(args.get("direction", "both")).strip().lower()
+    if direction not in {"references", "citations", "both"}:
+        return "Error: direction must be one of 'references', 'citations', or 'both'."
+
+    limit = _bounded_citation_limit(args.get("limit", DEFAULT_CITATION_LIMIT))
+    s2_id = _s2_paper_id(arxiv_id)
+
+    references: list[dict[str, Any]] | None = None
+    citations: list[dict[str, Any]] | None = None
+
+    async with httpx.AsyncClient(timeout=S2_TIMEOUT) as client:
+        tasks: list[tuple[str, Any]] = []
+        if direction in {"references", "both"}:
+            tasks.append(("references", _fetch_citation_side(client, s2_id, "references", limit)))
+        if direction in {"citations", "both"}:
+            tasks.append(("citations", _fetch_citation_side(client, s2_id, "citations", limit)))
+        results = await asyncio.gather(*(task for _, task in tasks), return_exceptions=True)
+        for (label, _), result in zip(tasks, results, strict=True):
+            if isinstance(result, BaseException):
+                continue
+            fetched: list[dict[str, Any]] | None = result
+            if label == "references":
+                references = fetched
+            else:
+                citations = fetched
+
+    if references is None and citations is None:
+        return (
+            f"Error: Could not fetch citation data for {arxiv_id}. "
+            "The paper may not be indexed by Semantic Scholar yet, or the service is unavailable."
+        )
+
+    return _format_citation_graph(arxiv_id, references, citations)
+
+
+# ---------------------------------------------------------------------------
+# Paper section reading (arXiv HTML)
+# ---------------------------------------------------------------------------
+
+
+def _parse_paper_html(html: str) -> dict[str, Any]:
+    """Parse rendered arXiv HTML into a title, abstract, and section list.
+
+    Returns a dict with ``title``, ``abstract``, and ``sections``. Each section
+    carries an ``id`` (section number when present), ``title``, ``level``, and
+    the concatenated ``text`` between headings.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    title_el = soup.find("h1", class_="ltx_title")
+    title = title_el.get_text(strip=True).removeprefix("Title:").strip() if title_el else ""
+
+    abstract = ""
+    abstract_el = soup.find("div", class_="ltx_abstract")
+    if abstract_el:
+        for child in abstract_el.children:
+            if isinstance(child, Tag) and child.name in ("h6", "h2", "h3", "p", "span"):
+                if child.get_text(strip=True).lower() == "abstract":
+                    continue
+            if isinstance(child, Tag) and child.name == "p":
+                abstract += child.get_text(separator=" ", strip=True) + " "
+        abstract = abstract.strip()
+
+    sections: list[dict[str, Any]] = []
+    headings = soup.find_all(["h2", "h3"], class_=lambda cls: bool(cls) and "ltx_title" in cls)
+
+    for heading in headings:
+        level = 2 if heading.name == "h2" else 3
+        heading_text = heading.get_text(separator=" ", strip=True)
+
+        text_parts: list[str] = []
+        sibling = heading.find_next_sibling()
+        while sibling:
+            if isinstance(sibling, Tag):
+                sibling_classes = sibling.get("class") or []
+                if sibling.name in ("h2", "h3") and "ltx_title" in sibling_classes:
+                    break
+                if sibling.name == "h2" and level == 3:
+                    break
+                text_parts.append(sibling.get_text(separator=" ", strip=True))
+            sibling = sibling.find_next_sibling()
+
+        parent_section = heading.find_parent("section")
+        if parent_section and not text_parts:
+            for paragraph in parent_section.find_all("p", recursive=False):
+                text_parts.append(paragraph.get_text(separator=" ", strip=True))
+
+        section_text = "\n\n".join(part for part in text_parts if part)
+        number_match = re.match(r"^([A-Z]?\d+(?:\.\d+)*)\s", heading_text)
+        section_id = number_match.group(1) if number_match else ""
+
+        sections.append(
+            {
+                "id": section_id,
+                "title": heading_text,
+                "level": level,
+                "text": section_text,
+            }
+        )
+
+    return {"title": title, "abstract": abstract, "sections": sections}
+
+
+def _find_section(sections: list[dict[str, Any]], query: str) -> dict[str, Any] | None:
+    """Locate a section by number or title (fuzzy substring match as a fallback)."""
+    query_lower = query.lower().strip()
+
+    for section in sections:
+        if section["id"] in (query_lower, query):
+            return section
+    for section in sections:
+        if query_lower == section["title"].lower():
+            return section
+    for section in sections:
+        if query_lower in section["title"].lower():
+            return section
+    for section in sections:
+        if section["id"].startswith(f"{query_lower}.") or section["id"] == query_lower:
+            return section
+    return None
+
+
+async def _fetch_paper_html(arxiv_id: str) -> dict[str, Any] | None:
+    """Fetch and parse rendered arXiv HTML, trying native then ar5iv hosts."""
+    async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+        for base_url in (ARXIV_HTML, AR5IV_HTML):
+            try:
+                response = await client.get(f"{base_url}/{arxiv_id}")
+            except httpx.RequestError:
+                continue
+            if response.status_code != 200:
+                continue
+            parsed = _parse_paper_html(response.text)
+            if parsed["sections"]:
+                return parsed
+    return None
+
+
+def _format_paper_toc(parsed: dict[str, Any], arxiv_id: str) -> str:
+    """Format a table of contents: abstract plus section previews."""
+    lines = [f"# {parsed['title'] or arxiv_id}"]
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}\n")
+
+    if parsed["abstract"]:
+        lines.append(f"## Abstract\n{parsed['abstract']}\n")
+
+    lines.append("## Sections")
+    for section in parsed["sections"]:
+        indent = "  " if section["level"] == 3 else ""
+        preview = _truncate(section["text"], MAX_SECTION_PREVIEW_LEN) if section["text"] else "(empty)"
+        lines.append(f"{indent}- **{section['title']}**: {preview}")
+
+    lines.append(
+        '\nCall read_paper with section (e.g. section="4" or section="Experiments") to read a specific section.'
+    )
+    return "\n".join(lines)
+
+
+def _format_paper_section(section: dict[str, Any], arxiv_id: str) -> str:
+    """Format a single section's full text."""
+    lines = [f"# {section['title']}"]
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}\n")
+
+    text = section["text"]
+    if len(text) > MAX_SECTION_TEXT_LEN:
+        text = text[:MAX_SECTION_TEXT_LEN] + f"\n\n... (truncated at {MAX_SECTION_TEXT_LEN} chars)"
+
+    lines.append(text if text else "(This section has no extractable text content.)")
+    return "\n".join(lines)
+
+
+async def read_paper_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Read the table of contents or a specific section of a paper."""
+    del settings
+
+    raw_arxiv_id = args.get("arxiv_id", "")
+    arxiv_id = _normalize_arxiv_id(raw_arxiv_id)
+    if not arxiv_id:
+        return "Error: No arxiv_id provided. Pass an arXiv ID or paper URL."
+
+    section_query = str(args.get("section", "")).strip()
+
+    parsed = await _fetch_paper_html(arxiv_id)
+    if not parsed or not parsed["sections"]:
+        # Fall back to the abstract when no rendered HTML is available.
+        try:
+            paper = await _fetch_paper(arxiv_id)
+        except Exception as exc:
+            return f"Error: Could not fetch paper {arxiv_id}: {exc}"
+
+        title = paper.get("title", "")
+        abstract = paper.get("summary", "")
+        message = f"# {title}\nhttps://arxiv.org/abs/{arxiv_id}\n\n## Abstract\n{abstract}\n\n"
+        message += "HTML version not available for this paper. Only the abstract is shown.\n"
+        message += f"PDF: https://arxiv.org/pdf/{arxiv_id}"
+        return message
+
+    if not section_query:
+        return _format_paper_toc(parsed, arxiv_id)
+
+    section = _find_section(parsed["sections"], section_query)
+    if not section:
+        available = "\n".join(f"- {item['title']}" for item in parsed["sections"])
+        return f"Error: Section '{section_query}' not found. Available sections:\n{available}"
+
+    return _format_paper_section(section, arxiv_id)
+
+
+# ---------------------------------------------------------------------------
+# Training recipe extraction (deterministic + evidence-linked)
+# ---------------------------------------------------------------------------
+
+
+# Each pattern maps a recipe field to the labels/terms that commonly introduce
+# it in method and experiment sections. Matches are case-insensitive and
+# anchored to the sentence immediately following the label so the extracted
+# value stays tightly scoped to its evidence.
+_RECIPE_PATTERNS: dict[str, list[str]] = {
+    "dataset": ["dataset", "datasets", "training data", "train on", "trained on"],
+    "architecture": ["architecture", "model architecture", "backbone", "encoder", "decoder"],
+    "optimizer": ["optimizer", "optimiser", "adamw", "adam", "sgd"],
+    "learning_rate": ["learning rate", "lr"],
+    "batch_size": ["batch size", "batch"],
+    "epochs": ["epochs", "epoch", "training steps", "steps"],
+    "hardware": ["gpu", "gpus", "tpu", "tpus", "a100", "h100", "v100", "hardware"],
+}
+
+_RECIPE_FIELD_ORDER = [
+    "dataset",
+    "architecture",
+    "optimizer",
+    "learning_rate",
+    "batch_size",
+    "epochs",
+    "hardware",
+]
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split free text into sentences for evidence extraction.
+
+    Splits on sentence-ending punctuation followed by whitespace while keeping
+    numeric abbreviations (e.g. ``3.5``) intact.
+    """
+    cleaned = re.sub(r"\s+", " ", text).strip()
+    if not cleaned:
+        return []
+    parts = re.split(r"(?<=[.!?])\s+(?=[A-Z0-9])", cleaned)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _extract_recipe_values(section_texts: list[str]) -> dict[str, list[dict[str, str]]]:
+    """Extract evidence-linked recipe values from section text.
+
+    Returns a mapping of field name to a list of ``{"value", "evidence"}``
+    entries, each quoting the sentence the value was taken from.
+    """
+    sentences: list[str] = []
+    for text in section_texts:
+        sentences.extend(_split_sentences(text))
+
+    findings: dict[str, list[dict[str, str]]] = {field: [] for field in _RECIPE_FIELD_ORDER}
+
+    for sentence in sentences:
+        sentence_lower = sentence.lower()
+        for field, labels in _RECIPE_PATTERNS.items():
+            if len(findings[field]) >= MAX_RECIPE_VALUES:
+                continue
+            if any(label in sentence_lower for label in labels):
+                findings[field].append(
+                    {
+                        "value": _truncate(sentence, RECIPE_SNIPPET_LEN),
+                        "evidence": _truncate(sentence, RECIPE_SNIPPET_LEN),
+                    }
+                )
+
+    return findings
+
+
+def _format_training_recipe(
+    arxiv_id: str,
+    title: str,
+    parsed_sections: list[dict[str, Any]],
+    findings: dict[str, list[dict[str, str]]],
+) -> str:
+    lines = [f"# Training recipe for {title or arxiv_id}"]
+    lines.append(f"https://arxiv.org/abs/{arxiv_id}\n")
+    lines.append(f"Scanned {len(parsed_sections)} method/experiment section(s).\n")
+
+    any_found = False
+    for field in _RECIPE_FIELD_ORDER:
+        entries = findings.get(field) or []
+        if not entries:
+            continue
+        any_found = True
+        lines.append(f"## {field.replace('_', ' ').title()}")
+        for entry in entries[:MAX_RECIPE_VALUES]:
+            lines.append(f"- {entry['value']}")
+            lines.append(f'  - evidence: "{entry["evidence"]}"')
+        lines.append("")
+
+    if not any_found:
+        lines.append("No method or experiment details were detected in the available sections.")
+        lines.append("Use read_paper to inspect the paper sections directly.")
+
+    lines.append(
+        "**Note:** Recipe values are extracted deterministically from method and experiment "
+        "sections. Verify against read_paper before relying on them for training."
+    )
+    return "\n".join(lines)
+
+
+def _recipe_section_names() -> list[str]:
+    """Lowercase title fragments that usually carry recipe details."""
+    return ["method", "experiment", "setup", "implementation", "training", "approach"]
+
+
+def _select_recipe_sections(sections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Pick the sections most likely to contain training recipe details."""
+    wanted = _recipe_section_names()
+    matched = [section for section in sections if any(token in section["title"].lower() for token in wanted)]
+    if matched:
+        return matched
+    # Fall back to the longest non-empty sections when titles are unhelpful.
+    populated = [section for section in sections if section["text"]]
+    populated.sort(key=lambda section: len(section["text"]), reverse=True)
+    return populated[:3]
+
+
+async def extract_training_recipe_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Extract a deterministic, evidence-linked training recipe from a paper."""
+    del settings
+
+    raw_arxiv_id = args.get("arxiv_id", "")
+    arxiv_id = _normalize_arxiv_id(raw_arxiv_id)
+    if not arxiv_id:
+        return "Error: No arxiv_id provided. Pass an arXiv ID or paper URL."
+
+    parsed = await _fetch_paper_html(arxiv_id)
+    if not parsed or not parsed["sections"]:
+        return (
+            f"Error: Could not read the paper sections for {arxiv_id}. Rendered HTML is required for recipe extraction."
+        )
+
+    recipe_sections = _select_recipe_sections(parsed["sections"])
+    section_texts = [section["text"] for section in recipe_sections if section["text"]]
+    findings = _extract_recipe_values(section_texts)
+
+    return _format_training_recipe(arxiv_id, parsed.get("title", ""), recipe_sections, findings)
+
+
+# ---------------------------------------------------------------------------
+# Tool specifications
+# ---------------------------------------------------------------------------
+
+
 def get_tool_specs() -> list[dict[str, Any]]:
-    """Return the paper metadata tool specification."""
+    """Return the paper research tool specifications."""
     return [
         {
             "name": "paper_details",
@@ -135,5 +722,76 @@ def get_tool_specs() -> list[dict[str, Any]]:
                 },
                 "required": ["arxiv_id"],
             },
-        }
+        },
+        {
+            "name": "paper_citation_graph",
+            "description": (
+                "Trace a one-hop citation graph for a paper via Semantic Scholar. "
+                "Returns references (papers this work cites) and citations (papers citing this work) "
+                "with influence flags and citation intents. Use to gauge impact and find related work."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "arxiv_id": {
+                        "type": "string",
+                        "description": "ArXiv paper ID or paper URL.",
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": ["references", "citations", "both"],
+                        "description": "Which side of the graph to return. Default: both.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum entries per side (default: 10, max: 50).",
+                    },
+                },
+                "required": ["arxiv_id"],
+            },
+        },
+        {
+            "name": "read_paper",
+            "description": (
+                "Read a paper's rendered arXiv HTML. Without a section, returns the abstract and a "
+                "table of contents. With a section name or number, returns that section's full text. "
+                "Use after paper_details to inspect method or experiment sections."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "arxiv_id": {
+                        "type": "string",
+                        "description": "ArXiv paper ID or paper URL.",
+                    },
+                    "section": {
+                        "type": "string",
+                        "description": (
+                            "Section name or number to read, for example '4', 'Experiments', or '4.2'. "
+                            "Omit to get the abstract and table of contents."
+                        ),
+                    },
+                },
+                "required": ["arxiv_id"],
+            },
+        },
+        {
+            "name": "extract_training_recipe",
+            "description": (
+                "Extract a deterministic, evidence-linked training recipe from a paper's method and "
+                "experiment sections. Surfaces dataset, architecture, optimizer, learning rate, "
+                "batch size, epochs, and hardware, each with a quoted source sentence. "
+                "Use before selecting models or datasets for training."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "arxiv_id": {
+                        "type": "string",
+                        "description": "ArXiv paper ID or paper URL.",
+                    },
+                },
+                "required": ["arxiv_id"],
+            },
+        },
     ]

--- a/tests/unit/test_papers.py
+++ b/tests/unit/test_papers.py
@@ -11,15 +11,28 @@ import pytest
 from app.config import AppPaths, AppSettings
 from app.tools.context import ToolExecutionContext, use_tool_execution_context
 from app.tools.papers import (
+    _extract_recipe_values,
+    _find_section,
     _format_paper_details,
+    _format_training_recipe,
     _normalize_arxiv_id,
+    _parse_paper_html,
+    _select_recipe_sections,
+    extract_training_recipe_handler,
     get_tool_specs,
+    paper_citation_graph_handler,
     paper_details_handler,
+    read_paper_handler,
 )
 
 
 def _settings(tmp_path: Path) -> AppSettings:
     return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# paper_details (existing behavior preserved)
+# ---------------------------------------------------------------------------
 
 
 def test_normalize_arxiv_id_from_urls() -> None:
@@ -152,9 +165,331 @@ async def test_paper_details_handler_not_found(tmp_path: Path) -> None:
     assert "not found" in result.lower()
 
 
+# ---------------------------------------------------------------------------
+# Tool specs
+# ---------------------------------------------------------------------------
+
+
 def test_get_tool_specs() -> None:
     specs = get_tool_specs()
+    names = [spec["name"] for spec in specs]
 
-    assert len(specs) == 1
-    assert specs[0]["name"] == "paper_details"
-    assert "arxiv_id" in specs[0]["parameters"]["properties"]
+    assert "paper_details" in names
+    assert "paper_citation_graph" in names
+    assert "read_paper" in names
+    assert "extract_training_recipe" in names
+    for spec in specs:
+        assert "arxiv_id" in spec["parameters"]["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Citation graph
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_missing_id(tmp_path: Path) -> None:
+    result = await paper_citation_graph_handler({}, _settings(tmp_path))
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_invalid_direction(tmp_path: Path) -> None:
+    result = await paper_citation_graph_handler(
+        {"arxiv_id": "2305.18290", "direction": "sideways"},
+        _settings(tmp_path),
+    )
+    assert "Error" in result
+    assert "direction" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_success(tmp_path: Path) -> None:
+    async def fake_fetch(client, s2_id, side, limit):
+        if side == "references":
+            return [
+                {
+                    "citedPaper": {
+                        "title": "Referenced Work",
+                        "year": 2021,
+                        "citationCount": 30,
+                        "externalIds": {"ArXiv": "2101.00001"},
+                    },
+                    "isInfluential": False,
+                }
+            ]
+        return [
+            {
+                "citingPaper": {
+                    "title": "Citing Work",
+                    "year": 2024,
+                    "citationCount": 5,
+                    "externalIds": {"ArXiv": "2401.00002"},
+                },
+                "isInfluential": True,
+                "intents": ["methodology"],
+                "contexts": ["We build on the method from 2305.18290."],
+            }
+        ]
+
+    with patch("app.tools.papers._fetch_citation_side", new=fake_fetch):
+        result = await paper_citation_graph_handler(
+            {"arxiv_id": "2305.18290", "direction": "both"},
+            _settings(tmp_path),
+        )
+
+    assert "Citation graph for 2305.18290" in result
+    assert "References (1)" in result
+    assert "Referenced Work" in result
+    assert "Citations (1)" in result
+    assert "Citing Work" in result
+    assert "[influential]" in result
+    assert "Intent: methodology" in result
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_unavailable(tmp_path: Path) -> None:
+    async def fake_fetch(client, s2_id, side, limit):
+        return None
+
+    with patch("app.tools.papers._fetch_citation_side", new=fake_fetch):
+        result = await paper_citation_graph_handler(
+            {"arxiv_id": "2305.18290"},
+            _settings(tmp_path),
+        )
+
+    assert "Error" in result
+    assert "Semantic Scholar" in result
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_respects_limit(tmp_path: Path) -> None:
+    captured: dict[str, int] = {}
+
+    async def fake_fetch(client, s2_id, side, limit):
+        captured[side] = limit
+        return []
+
+    with patch("app.tools.papers._fetch_citation_side", new=fake_fetch):
+        await paper_citation_graph_handler(
+            {"arxiv_id": "2305.18290", "limit": 3},
+            _settings(tmp_path),
+        )
+
+    assert captured["references"] == 3
+    assert captured["citations"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Paper section reading
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_ARXIV_HTML = """
+<html><body>
+<h1 class="ltx_title">Title: Attention Is All You Need</h1>
+<div class="ltx_abstract"><h6>Abstract</h6><p>The dominant sequence transduction models are based on
+complex recurrent or convolutional neural networks.</p></div>
+<h2 class="ltx_title">1 Introduction</h2>
+<p>We propose a new simple network architecture.</p>
+<h2 class="ltx_title">3 Model Architecture</h2>
+<p>The encoder maps an input sequence to a representation. Most competitive
+neural sequence transduction models have an encoder and a decoder.</p>
+<h3 class="ltx_title">3.1 Scaled Dot-Product Attention</h3>
+<p>We compute the dot products of the query with all keys.</p>
+<h2 class="ltx_title">5 Results</h2>
+<p>On the WMT 2014 English-to-German task we trained for 100000 steps with
+batch size 2048 using Adam with learning rate 0.5 on 8 GPUs.</p>
+</body></html>
+"""
+
+
+def test_parse_paper_html_extracts_sections() -> None:
+    parsed = _parse_paper_html(SAMPLE_ARXIV_HTML)
+
+    assert parsed["title"] == "Attention Is All You Need"
+    assert "dominant sequence transduction" in parsed["abstract"]
+    titles = [section["title"] for section in parsed["sections"]]
+    assert "1 Introduction" in titles
+    assert "3 Model Architecture" in titles
+    assert "3.1 Scaled Dot-Product Attention" in titles
+
+
+def test_find_section_by_number_and_name() -> None:
+    sections = _parse_paper_html(SAMPLE_ARXIV_HTML)["sections"]
+
+    assert _find_section(sections, "3")["title"] == "3 Model Architecture"
+    assert _find_section(sections, "Model Architecture") is not None
+    assert _find_section(sections, "nonexistent") is None
+
+
+@pytest.mark.asyncio
+async def test_read_paper_toc(tmp_path: Path) -> None:
+    async def fake_fetch(arxiv_id):
+        return _parse_paper_html(SAMPLE_ARXIV_HTML)
+
+    with patch("app.tools.papers._fetch_paper_html", new=fake_fetch):
+        result = await read_paper_handler({"arxiv_id": "1706.03762"}, _settings(tmp_path))
+
+    assert "Attention Is All You Need" in result
+    assert "## Sections" in result
+    assert "1 Introduction" in result
+    assert "table of contents" in result.lower() or "section" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_read_paper_specific_section(tmp_path: Path) -> None:
+    async def fake_fetch(arxiv_id):
+        return _parse_paper_html(SAMPLE_ARXIV_HTML)
+
+    with patch("app.tools.papers._fetch_paper_html", new=fake_fetch):
+        result = await read_paper_handler(
+            {"arxiv_id": "1706.03762", "section": "3"},
+            _settings(tmp_path),
+        )
+
+    assert "3 Model Architecture" in result
+    assert "encoder" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_read_paper_missing_section_falls_back_to_abstract(tmp_path: Path) -> None:
+    async def fake_fetch_paper_html(arxiv_id):
+        return None
+
+    async def fake_fetch_paper(arxiv_id):
+        return {"title": "Fallback Title", "summary": "Fallback abstract text."}
+
+    with (
+        patch("app.tools.papers._fetch_paper_html", new=fake_fetch_paper_html),
+        patch("app.tools.papers._fetch_paper", new=fake_fetch_paper),
+    ):
+        result = await read_paper_handler({"arxiv_id": "1706.03762"}, _settings(tmp_path))
+
+    assert "Fallback Title" in result
+    assert "Fallback abstract text." in result
+    assert "HTML version not available" in result
+
+
+@pytest.mark.asyncio
+async def test_read_paper_missing_id(tmp_path: Path) -> None:
+    result = await read_paper_handler({}, _settings(tmp_path))
+    assert "Error" in result
+
+
+# ---------------------------------------------------------------------------
+# Training recipe extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_recipe_values_finds_fields_with_evidence() -> None:
+    text = (
+        "We train on the WMT 2014 English-to-German dataset. "
+        "Our architecture is a transformer encoder-decoder. "
+        "We use the Adam optimizer with a learning rate of 0.5. "
+        "Training used a batch size of 2048 for 100000 steps on 8 GPUs."
+    )
+
+    findings = _extract_recipe_values([text])
+
+    assert findings["dataset"]
+    assert findings["architecture"]
+    assert findings["optimizer"]
+    assert findings["learning_rate"]
+    assert findings["batch_size"]
+    assert findings["epochs"]
+    assert findings["hardware"]
+    for field in ("dataset", "optimizer", "hardware"):
+        entry = findings[field][0]
+        assert entry["value"]
+        assert entry["evidence"]
+
+
+def test_extract_recipe_values_handles_empty_text() -> None:
+    findings = _extract_recipe_values([""])
+    for field in findings:
+        assert findings[field] == []
+
+
+def test_select_recipe_sections_prefers_method_sections() -> None:
+    sections = [
+        {"id": "1", "title": "1 Introduction", "level": 2, "text": "short"},
+        {"id": "4", "title": "4 Experiments", "level": 2, "text": "long experiment text"},
+        {"id": "3", "title": "3 Method", "level": 2, "text": "method details"},
+    ]
+
+    selected = _select_recipe_sections(sections)
+    selected_titles = [section["title"] for section in selected]
+
+    assert "4 Experiments" in selected_titles
+    assert "3 Method" in selected_titles
+    assert "1 Introduction" not in selected_titles
+
+
+def test_format_training_recipe_lists_findings_with_evidence() -> None:
+    findings = {
+        "dataset": [{"value": "WMT 2014 dataset.", "evidence": "WMT 2014 dataset."}],
+        "architecture": [{"value": "Transformer encoder-decoder.", "evidence": "Transformer encoder-decoder."}],
+        "optimizer": [],
+        "learning_rate": [],
+        "batch_size": [],
+        "epochs": [],
+        "hardware": [],
+    }
+    sections = [{"id": "4", "title": "4 Experiments", "level": 2, "text": "..."}]
+
+    result = _format_training_recipe("1706.03762", "Attention Is All You Need", sections, findings)
+
+    assert "Training recipe for Attention Is All You Need" in result
+    assert "## Dataset" in result
+    assert "## Architecture" in result
+    assert "evidence:" in result
+    assert "Optimizer" not in result  # empty fields are omitted
+
+
+def test_format_training_recipe_handles_no_findings() -> None:
+    findings = {
+        field: []
+        for field in ("dataset", "architecture", "optimizer", "learning_rate", "batch_size", "epochs", "hardware")
+    }
+
+    result = _format_training_recipe("1706.03762", "Title", [], findings)
+
+    assert "No method or experiment details" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_training_recipe_handler_success(tmp_path: Path) -> None:
+    async def fake_fetch(arxiv_id):
+        return _parse_paper_html(SAMPLE_ARXIV_HTML)
+
+    with patch("app.tools.papers._fetch_paper_html", new=fake_fetch):
+        result = await extract_training_recipe_handler(
+            {"arxiv_id": "1706.03762"},
+            _settings(tmp_path),
+        )
+
+    assert "Training recipe" in result
+    assert "batch size" in result.lower() or "Batch Size" in result
+    assert "evidence:" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_training_recipe_handler_no_html(tmp_path: Path) -> None:
+    async def fake_fetch(arxiv_id):
+        return None
+
+    with patch("app.tools.papers._fetch_paper_html", new=fake_fetch):
+        result = await extract_training_recipe_handler(
+            {"arxiv_id": "1706.03762"},
+            _settings(tmp_path),
+        )
+
+    assert "Error" in result
+    assert "HTML" in result
+
+
+@pytest.mark.asyncio
+async def test_extract_training_recipe_handler_missing_id(tmp_path: Path) -> None:
+    result = await extract_training_recipe_handler({}, _settings(tmp_path))
+    assert "Error" in result


### PR DESCRIPTION
Closes #86

## Summary
- add **paper_citation_graph**: one-hop Semantic Scholar traversal of references and citations with influence flags, citation intents, and quote-backed contexts; bounded limits and graceful degradation when the service is unavailable or unauthenticated
- add **read_paper**: bounded arXiv HTML section reading returning a table of contents (abstract + section previews) by default, and a named/numbered section's full text on demand; falls back to the abstract when rendered HTML is unavailable
- add **extract_training_recipe**: deterministic, evidence-linked extraction of dataset, architecture, optimizer, learning rate, batch size, epochs, and hardware, each with a quoted source sentence so recommendations stay paper-backed
- generalize the paper tool handler dispatch in the agent loop so all four paper tools wire into the registry alongside the existing paper_details behavior
- add an S2_API_KEY note to .env.example for optional higher Semantic Scholar rate limits

## Testing
- 191 tests pass (was 172; +19 new unit tests covering citation graph success/unavailable/limit/validation, HTML parsing, section lookup, recipe extraction with evidence, handler edge cases)
- ruff check + ruff format clean
- mypy clean on app
- pre-commit clean (ruff, ruff-format, trailing whitespace, eof, yaml/toml/debug checks)
- registry smoke test confirms all four paper tools (paper_details, paper_citation_graph, read_paper, extract_training_recipe) register and dispatch
- frontend build passes

## Notes
Citation traversal is intentionally one-hop to avoid runaway graph walks; the agent can follow individual arxiv ids to go deeper. Recipe extraction is heuristic and quote-backed rather than model-based so it stays cheap and inspectable. Semantic Scholar access stays optional with graceful fallback.

## Reference
Cross-checked the Hugging Face ml-intern citation-graph and paper-reading patterns while shaping the tool boundaries. Notion task: ML-302.