### PR TITLE
ML-303 / Add Hugging Face Jobs orchestration and monitoring

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -929,7 +929,7 @@ def create_agent_loop(
 
 def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
     """Create and populate the built-in and configured tool registry."""
-    from app.tools import datasets, docs, hub, mcp, papers, repo_analyzer, reporting, workspace
+    from app.tools import datasets, docs, hub, jobs, mcp, papers, repo_analyzer, reporting, workspace
 
     registry = ToolRegistry()
     workspace_specs = workspace.get_tool_specs()
@@ -969,6 +969,15 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
             handler=_make_hub_handler(spec["name"], settings),
+        )
+        registry.register(tool_spec)
+
+    for spec in jobs.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_jobs_handler(settings),
         )
         registry.register(tool_spec)
 
@@ -1064,6 +1073,16 @@ def _make_hub_handler(name: str, settings: AppSettings) -> ToolHandler:
 
     async def _handler(args: dict[str, Any]) -> str:
         return await handlers[name](args, settings)
+
+    return _handler
+
+
+def _make_jobs_handler(settings: AppSettings) -> ToolHandler:
+    """Create a handler for the Hugging Face Jobs orchestration tool."""
+    from app.tools import jobs
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await jobs.manage_job_handler(args, settings)
 
     return _handler
 

--- a/app/tools/jobs.py
+++ b/app/tools/jobs.py
@@ -1,0 +1,442 @@
+"""Hugging Face Jobs orchestration and monitoring tools."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from app.config import AppSettings
+from app.tools.context import current_hf_token
+
+# Default Docker image for Python jobs. Uses the uv runner image so inline
+# scripts and dependency installation stay fast and predictable.
+DEFAULT_PYTHON_IMAGE = "ghcr.io/astral-sh/uv:python3.12-bookworm"
+DEFAULT_DOCKER_IMAGE = "python:3.12"
+
+DEFAULT_HARDWARE_FLAVOR = "cpu-basic"
+DEFAULT_TIMEOUT = "30m"
+MAX_LOG_LINES = 500
+
+# Hardware flavors recognized by the Hugging Face Jobs API. Validation keeps
+# the agent from submitting unsupported flavors that the API would reject.
+CPU_FLAVORS = {"cpu-basic", "cpu-upgrade"}
+GPU_FLAVORS = {
+    "t4-small",
+    "t4-medium",
+    "a10g-small",
+    "a10g-large",
+    "a10g-largex2",
+    "a10g-largex4",
+    "a100-large",
+    "a100x4",
+    "a100x8",
+    "l4x1",
+    "l4x4",
+    "l40sx1",
+    "l40sx4",
+    "l40sx8",
+}
+SUPPORTED_FLAVORS = CPU_FLAVORS | GPU_FLAVORS
+
+# Environment variables injected by default to keep job output clean.
+DEFAULT_ENV: dict[str, str] = {
+    "HF_HUB_DISABLE_PROGRESS_BARS": "1",
+    "TQDM_DISABLE": "1",
+    "TRANSFORMERS_VERBOSITY": "warning",
+}
+
+
+# ---------------------------------------------------------------------------
+# Hugging Face API bridge
+# ---------------------------------------------------------------------------
+
+
+def _hf_api() -> Any:
+    """Build a Hugging Face API client using the active per-session token."""
+    from huggingface_hub import HfApi
+
+    return HfApi(token=current_hf_token())
+
+
+async def _to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+    """Run a blocking Hugging Face API call off the event loop."""
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+def _auth_headers() -> dict[str, str]:
+    token = current_hf_token()
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+# ---------------------------------------------------------------------------
+# Argument validation and helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_hardware_flavor(flavor: str) -> str | None:
+    """Return an error message when the hardware flavor is unsupported."""
+    if flavor not in SUPPORTED_FLAVORS:
+        return (
+            f"Error: Unsupported hardware flavor '{flavor}'. Supported flavors: {', '.join(sorted(SUPPORTED_FLAVORS))}."
+        )
+    return None
+
+
+def _normalize_command(value: Any) -> list[str] | None:
+    """Normalize a raw command argument into a list, or None when missing."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped.split() if stripped else None
+    if isinstance(value, list):
+        normalized = [str(item).strip() for item in value if str(item).strip()]
+        return normalized or None
+    return None
+
+
+def _normalize_env(value: Any) -> dict[str, str]:
+    """Normalize env vars and layer them on top of the defaults."""
+    result = dict(DEFAULT_ENV)
+    if isinstance(value, dict):
+        for key, raw in value.items():
+            result[str(key)] = str(raw)
+    return result
+
+
+def _normalize_secrets(value: Any) -> dict[str, str]:
+    """Normalize secret values. The HF token is always injected last."""
+    result: dict[str, str] = {}
+    if isinstance(value, dict):
+        for key, raw in value.items():
+            if str(raw).strip().startswith("$"):
+                continue
+            result[str(key)] = str(raw)
+
+    token = current_hf_token()
+    if token:
+        result["HF_TOKEN"] = token
+        result["HUGGING_FACE_HUB_TOKEN"] = token
+    return result
+
+
+def _is_billing_error(message: str) -> bool:
+    """Detect namespace credit or billing rejection from an API error."""
+    lowered = message.lower()
+    return any(token in lowered for token in ("no available credits", "billing", "quota", "payment required", "402"))
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_job(job: Any) -> str:
+    """Format a single job object as readable Markdown."""
+    job_id = getattr(job, "id", "?")
+    status = getattr(getattr(job, "status", None), "stage", "UNKNOWN")
+    message = getattr(getattr(job, "status", None), "message", "") or ""
+    flavor = getattr(job, "flavor", "") or DEFAULT_HARDWARE_FLAVOR
+    image = getattr(job, "docker_image", "") or ""
+    created_at = getattr(job, "created_at", "")
+    command = getattr(job, "command", []) or []
+    url = getattr(job, "url", "") or f"https://huggingface.co/jobs/{job_id}"
+
+    lines = [f"### Job {job_id}"]
+    lines.append(f"- **Status:** {status}")
+    if message:
+        lines.append(f"- **Message:** {message}")
+    lines.append(f"- **Hardware:** {flavor}")
+    if image:
+        lines.append(f"- **Image:** {image}")
+    if created_at:
+        lines.append(f"- **Created:** {created_at}")
+    if command:
+        lines.append(f"- **Command:** `{' '.join(command)}`")
+    lines.append(f"- **URL:** {url}")
+    return "\n".join(lines)
+
+
+def _format_job_list(jobs: list[Any]) -> str:
+    if not jobs:
+        return "No jobs found."
+    lines = [f"# Jobs ({len(jobs)})\n"]
+    for job in jobs:
+        lines.append(_format_job(job))
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Operation handlers
+# ---------------------------------------------------------------------------
+
+
+async def _run_job(args: dict[str, Any]) -> str:
+    """Launch a Python or Docker job on Hugging Face compute."""
+    script = args.get("script")
+    command = _normalize_command(args.get("command"))
+
+    if script and command:
+        return "Error: Provide either 'script' or 'command', not both."
+    if not script and not command:
+        return "Error: Provide either 'script' (Python) or 'command' (Docker) to run a job."
+
+    flavor = str(args.get("hardware_flavor", DEFAULT_HARDWARE_FLAVOR)).strip()
+    flavor_error = _validate_hardware_flavor(flavor)
+    if flavor_error:
+        return flavor_error
+
+    timeout = str(args.get("timeout", DEFAULT_TIMEOUT)).strip() or DEFAULT_TIMEOUT
+    namespace = args.get("namespace")
+    image = args.get("image")
+
+    if script:
+        command = _build_python_command(str(script))
+        image = image or DEFAULT_PYTHON_IMAGE
+
+    try:
+        api = _hf_api()
+        job = await _to_thread(
+            api.run_job,
+            image=image,
+            command=command,
+            env=_normalize_env(args.get("env")),
+            secrets=_normalize_secrets(args.get("secrets")),
+            flavor=flavor,
+            timeout=timeout,
+            namespace=namespace,
+        )
+    except Exception as exc:
+        message = str(exc)
+        if _is_billing_error(message):
+            return (
+                "Error: Hugging Face rejected this run because the namespace has no available "
+                "credits. HF Jobs are billed with namespace credits, which are separate from "
+                "HF Pro membership. Add credits at https://huggingface.co/settings/billing and "
+                "re-run the job."
+            )
+        return f"Error launching job: {message}"
+
+    lines = ["# Job launched\n"]
+    lines.append(_format_job(job))
+    lines.append("")
+    lines.append("**Next:** Use manage_job with operation 'inspect', 'logs', or 'cancel'.")
+    return "\n".join(lines)
+
+
+def _build_python_command(script: str) -> list[str]:
+    """Build a uv run command for an inline script, URL, or file path."""
+    parts = ["uv", "run"]
+    if script.startswith(("http://", "https://")):
+        parts.append(script)
+    else:
+        # Inline scripts are passed via stdin so the job never needs a file.
+        parts.append("-")
+    return parts
+
+
+async def _list_jobs(args: dict[str, Any]) -> str:
+    """List jobs, optionally filtered by status."""
+    try:
+        api = _hf_api()
+        jobs = await _to_thread(api.list_jobs, namespace=args.get("namespace"))
+    except Exception as exc:
+        return f"Error listing jobs: {exc}"
+
+    jobs = list(jobs or [])
+    status_filter = str(args.get("status", "")).strip().upper()
+    show_all = bool(args.get("all", False))
+
+    if status_filter:
+        jobs = [job for job in jobs if status_filter in str(_job_stage(job)).upper()]
+    elif not show_all:
+        jobs = [job for job in jobs if str(_job_stage(job)).upper() == "RUNNING"]
+
+    if not jobs:
+        hint = " Use all=true to include completed and failed jobs." if not show_all else ""
+        return f"No jobs found.{hint}"
+
+    return _format_job_list(jobs)
+
+
+async def _inspect_job(args: dict[str, Any]) -> str:
+    """Inspect one or more jobs by id."""
+    job_id = args.get("job_id")
+    if not job_id:
+        return "Error: job_id is required to inspect a job."
+
+    job_ids = job_id if isinstance(job_id, list) else [job_id]
+    jobs: list[Any] = []
+    for single_id in job_ids:
+        try:
+            api = _hf_api()
+            job = await _to_thread(api.inspect_job, job_id=str(single_id), namespace=args.get("namespace"))
+        except Exception as exc:
+            return f"Error inspecting job {single_id}: {exc}"
+        jobs.append(job)
+
+    lines = [f"# Job details ({len(jobs)})\n"]
+    for job in jobs:
+        lines.append(_format_job(job))
+        lines.append("")
+    return "\n".join(lines)
+
+
+async def _fetch_logs(args: dict[str, Any]) -> str:
+    """Fetch job logs, truncated to a bounded number of lines."""
+    job_id = args.get("job_id")
+    if not job_id:
+        return "Error: job_id is required to fetch logs."
+
+    try:
+        api = _hf_api()
+        logs_generator = api.fetch_job_logs(job_id=str(job_id), namespace=args.get("namespace"))
+        logs = await _to_thread(list, logs_generator)
+    except Exception as exc:
+        return f"Error fetching logs for job {job_id}: {exc}"
+
+    if not logs:
+        return f"No logs available for job {job_id}."
+
+    log_lines = [str(line).rstrip() for line in logs if str(line).strip()]
+    if len(log_lines) > MAX_LOG_LINES:
+        head = "\n".join(log_lines[:MAX_LOG_LINES])
+        return f"# Logs for {job_id} (first {MAX_LOG_LINES} of {len(log_lines)} lines)\n\n```\n{head}\n```"
+
+    body = "\n".join(log_lines)
+    return f"# Logs for {job_id}\n\n```\n{body}\n```"
+
+
+async def _cancel_job(args: dict[str, Any]) -> str:
+    """Cancel a running or queued job."""
+    job_id = args.get("job_id")
+    if not job_id:
+        return "Error: job_id is required to cancel a job."
+
+    try:
+        api = _hf_api()
+        await _to_thread(api.cancel_job, job_id=str(job_id), namespace=args.get("namespace"))
+    except Exception as exc:
+        return f"Error cancelling job {job_id}: {exc}"
+
+    return f"Job {job_id} has been cancelled.\n\nVerify with manage_job operation 'inspect' and job_id '{job_id}'."
+
+
+def _job_stage(job: Any) -> str:
+    """Safely read a job's stage string."""
+    return str(getattr(getattr(job, "status", None), "stage", "UNKNOWN"))
+
+
+_OPERATIONS = {
+    "run": _run_job,
+    "list": _list_jobs,
+    "inspect": _inspect_job,
+    "logs": _fetch_logs,
+    "cancel": _cancel_job,
+}
+
+
+async def manage_job_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Dispatch a Hugging Face Jobs operation."""
+    del settings
+
+    operation = str(args.get("operation", "")).strip().lower()
+    if not operation:
+        return f"Error: 'operation' is required. Valid operations: {', '.join(sorted(_OPERATIONS))}."
+
+    handler = _OPERATIONS.get(operation)
+    if handler is None:
+        return f"Error: Unknown operation '{operation}'. Valid operations: {', '.join(sorted(_OPERATIONS))}."
+
+    if not current_hf_token():
+        return "Error: A Hugging Face token is required for Jobs operations. Attach a session token or set HF_TOKEN."
+
+    return await handler(args)
+
+
+# ---------------------------------------------------------------------------
+# Tool specification
+# ---------------------------------------------------------------------------
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return the Hugging Face Jobs tool specification."""
+    return [
+        {
+            "name": "manage_job",
+            "description": (
+                "Orchestrate Hugging Face Jobs: launch Python or Docker jobs on HF compute, "
+                "list jobs, inspect status, fetch logs, and cancel runs. Requires a per-session "
+                "Hugging Face token. Use after selecting a model and dataset to actually run "
+                "experiments."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["run", "list", "inspect", "logs", "cancel"],
+                        "description": "Jobs operation to execute.",
+                    },
+                    "script": {
+                        "type": "string",
+                        "description": (
+                            "Python script source, file path, or URL. Triggers Python mode via uv. "
+                            "Mutually exclusive with 'command'."
+                        ),
+                    },
+                    "command": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Docker command to run as a list. Triggers Docker mode. Mutually exclusive with 'script'."
+                        ),
+                    },
+                    "image": {
+                        "type": "string",
+                        "description": "Docker image. Auto-selected when omitted.",
+                    },
+                    "hardware_flavor": {
+                        "type": "string",
+                        "description": (
+                            "Hardware flavor. CPU: cpu-basic, cpu-upgrade. "
+                            "GPU: t4-small, t4-medium, a10g-small, a10g-large, a100-large, "
+                            "l4x1, l4x4, l40sx1, l40sx4, l40sx8. Default: cpu-basic."
+                        ),
+                    },
+                    "timeout": {
+                        "type": "string",
+                        "description": "Maximum job runtime, for example '30m' or '8h'. Default: '30m'.",
+                    },
+                    "env": {
+                        "type": "object",
+                        "description": "Environment variables for the job. HF_TOKEN is auto-included.",
+                    },
+                    "secrets": {
+                        "type": "object",
+                        "description": "Secret environment variables. The HF token is injected automatically.",
+                    },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional namespace to run the job under (own account or an org).",
+                    },
+                    "job_id": {
+                        "type": "string",
+                        "description": (
+                            "Job ID. Required for inspect, logs, and cancel. A list is accepted for inspect."
+                        ),
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Optional status filter for list (e.g. 'running', 'completed').",
+                    },
+                    "all": {
+                        "type": "boolean",
+                        "description": "For list: include completed and failed jobs instead of running only.",
+                    },
+                },
+                "required": ["operation"],
+            },
+        }
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "uvicorn[standard]>=0.32.0,<0.35.0",
     "whoosh>=2.7.4,<3.0.0",
     "beautifulsoup4>=4.12.0,<5.0.0",
+    "huggingface_hub>=0.30.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,0 +1,417 @@
+"""Tests for app.tools.jobs module."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.config import AppPaths, AppSettings
+from app.tools.context import ToolExecutionContext, use_tool_execution_context
+from app.tools.jobs import (
+    _build_python_command,
+    _is_billing_error,
+    _normalize_command,
+    _normalize_env,
+    _normalize_secrets,
+    get_tool_specs,
+    manage_job_handler,
+)
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+class _FakeStatus:
+    def __init__(self, stage: str = "RUNNING", message: str = ""):
+        self.stage = stage
+        self.message = message
+
+
+class _FakeJob:
+    def __init__(self, job_id: str = "job-1", stage: str = "RUNNING"):
+        self.id = job_id
+        self.status = _FakeStatus(stage=stage)
+        self.flavor = "cpu-basic"
+        self.docker_image = "ghcr.io/astral-sh/uv:python3.12-bookworm"
+        self.created_at = "2026-06-28T12:00:00Z"
+        self.command = ["uv", "run", "-"]
+        self.url = f"https://huggingface.co/jobs/{job_id}"
+
+
+class _FakeHfApi:
+    """Minimal stand-in for huggingface_hub.HfApi exercising job methods."""
+
+    instances: list["_FakeHfApi"] = []
+
+    def __init__(self, token=None):
+        self.token = token
+        self.run_job_calls: list[dict] = []
+        _FakeHfApi.instances.append(self)
+
+    def run_job(self, **kwargs):
+        self.run_job_calls.append(kwargs)
+        return _FakeJob(job_id="job-123", stage="QUEUED")
+
+    def list_jobs(self, namespace=None):
+        return [_FakeJob("job-1", "RUNNING"), _FakeJob("job-2", "COMPLETED")]
+
+    def inspect_job(self, job_id, namespace=None):
+        return _FakeJob(job_id=job_id, stage="RUNNING")
+
+    def fetch_job_logs(self, job_id, namespace=None):
+        return iter([f"[{job_id}] step 1 ok", f"[{job_id}] step 2 ok", ""])
+
+    def cancel_job(self, job_id, namespace=None):
+        self.cancelled = job_id
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_api():
+    _FakeHfApi.instances.clear()
+    yield
+    _FakeHfApi.instances.clear()
+
+
+@pytest.fixture(autouse=True)
+def _stub_huggingface_hub():
+    """Inject a fake huggingface_hub module for the duration of each test."""
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = _FakeHfApi
+    original = sys.modules.get("huggingface_hub")
+    sys.modules["huggingface_hub"] = fake_module
+    try:
+        yield
+    finally:
+        if original is not None:
+            sys.modules["huggingface_hub"] = original
+        else:
+            sys.modules.pop("huggingface_hub", None)
+
+
+def _token_context():
+    return use_tool_execution_context(ToolExecutionContext(session_id="session-1", hf_token="hf-session-token"))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_command_accepts_string_and_list() -> None:
+    assert _normalize_command("uv run train.py") == ["uv", "run", "train.py"]
+    assert _normalize_command(["uv", "run", " train.py "]) == ["uv", "run", "train.py"]
+    assert _normalize_command(None) is None
+    assert _normalize_command("   ") is None
+    assert _normalize_command([]) is None
+
+
+def test_normalize_env_layers_over_defaults() -> None:
+    env = _normalize_env({"CUDA_VISIBLE_DEVICES": "0", "TQDM_DISABLE": "0"})
+    assert env["CUDA_VISIBLE_DEVICES"] == "0"
+    assert env["TQDM_DISABLE"] == "0"  # user override wins
+    assert env["HF_HUB_DISABLE_PROGRESS_BARS"] == "1"  # default retained
+
+
+def test_normalize_secrets_injects_token_and_drops_placeholders() -> None:
+    with _token_context():
+        secrets = _normalize_secrets({"WANDB_API_KEY": "abc", "SKIP": "$SKIP_ME"})
+    assert secrets["HF_TOKEN"] == "hf-session-token"
+    assert secrets["HUGGING_FACE_HUB_TOKEN"] == "hf-session-token"
+    assert secrets["WANDB_API_KEY"] == "abc"
+    assert "SKIP" not in secrets
+
+
+def test_is_billing_error_detects_credit_messages() -> None:
+    assert _is_billing_error("namespace has no available credits")
+    assert _is_billing_error("HTTP 402 payment required")
+    assert not _is_billing_error("invalid flavor")
+
+
+def test_build_python_command_for_url_and_inline() -> None:
+    assert _build_python_command("https://example.com/train.py") == ["uv", "run", "https://example.com/train.py"]
+    assert _build_python_command("import torch") == ["uv", "run", "-"]
+
+
+def test_get_tool_specs() -> None:
+    specs = get_tool_specs()
+    assert len(specs) == 1
+    assert specs[0]["name"] == "manage_job"
+    props = specs[0]["parameters"]["properties"]
+    assert "operation" in props
+    assert "script" in props
+    assert "command" in props
+    assert "job_id" in props
+
+
+# ---------------------------------------------------------------------------
+# Dispatch validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_operation(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler({}, _settings(tmp_path))
+    assert "Error" in result
+    assert "operation" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_operation(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler({"operation": "fly"}, _settings(tmp_path))
+    assert "Error" in result
+    assert "fly" in result
+
+
+@pytest.mark.asyncio
+async def test_missing_token(tmp_path: Path) -> None:
+    # No token in context or environment.
+    with patch("app.tools.jobs.current_hf_token", return_value=None):
+        result = await manage_job_handler({"operation": "list"}, _settings(tmp_path))
+    assert "Error" in result
+    assert "token" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# run operation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_python_job(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {
+                "operation": "run",
+                "script": "import torch\nprint('hello')",
+                "hardware_flavor": "cpu-basic",
+                "timeout": "1h",
+            },
+            _settings(tmp_path),
+        )
+
+    assert "Job launched" in result
+    assert "job-123" in result
+    call = _FakeHfApi.instances[-1].run_job_calls[-1]
+    assert call["flavor"] == "cpu-basic"
+    assert call["timeout"] == "1h"
+    assert call["command"] == ["uv", "run", "-"]
+    assert call["secrets"]["HF_TOKEN"] == "hf-session-token"
+
+
+@pytest.mark.asyncio
+async def test_run_docker_job(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {
+                "operation": "run",
+                "command": ["duckdb", "-c", "select 1"],
+                "image": "duckdb/duckdb",
+                "hardware_flavor": "cpu-upgrade",
+            },
+            _settings(tmp_path),
+        )
+
+    assert "Job launched" in result
+    call = _FakeHfApi.instances[-1].run_job_calls[-1]
+    assert call["command"] == ["duckdb", "-c", "select 1"]
+    assert call["image"] == "duckdb/duckdb"
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_both_script_and_command(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {"operation": "run", "script": "print(1)", "command": ["echo", "hi"]},
+            _settings(tmp_path),
+        )
+    assert "Error" in result
+    assert "both" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_run_requires_script_or_command(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler({"operation": "run"}, _settings(tmp_path))
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_unsupported_flavor(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {"operation": "run", "script": "print(1)", "hardware_flavor": "rtx-4090"},
+            _settings(tmp_path),
+        )
+    assert "Error" in result
+    assert "rtx-4090" in result
+
+
+@pytest.mark.asyncio
+async def test_run_surfaces_billing_error(tmp_path: Path) -> None:
+    class _BillingApi(_FakeHfApi):
+        def run_job(self, **kwargs):
+            raise RuntimeError("namespace has no available credits for jobs")
+
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = _BillingApi
+    with patch.dict(sys.modules, {"huggingface_hub": fake_module}):
+        with _token_context():
+            result = await manage_job_handler(
+                {"operation": "run", "script": "print(1)"},
+                _settings(tmp_path),
+            )
+
+    assert "Error" in result
+    assert "credits" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# list / inspect / logs / cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_defaults_to_running(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler({"operation": "list"}, _settings(tmp_path))
+    assert "Jobs (1)" in result
+    assert "job-1" in result
+    assert "job-2" not in result  # completed filtered out
+
+
+@pytest.mark.asyncio
+async def test_list_all_includes_every_status(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {"operation": "list", "all": True},
+            _settings(tmp_path),
+        )
+    assert "Jobs (2)" in result
+
+
+@pytest.mark.asyncio
+async def test_list_empty(tmp_path: Path) -> None:
+    class _EmptyApi(_FakeHfApi):
+        def list_jobs(self, namespace=None):
+            return []
+
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = _EmptyApi
+    with patch.dict(sys.modules, {"huggingface_hub": fake_module}):
+        with _token_context():
+            result = await manage_job_handler({"operation": "list"}, _settings(tmp_path))
+    assert "No jobs found" in result
+
+
+@pytest.mark.asyncio
+async def test_inspect_requires_job_id(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler({"operation": "inspect"}, _settings(tmp_path))
+    assert "Error" in result
+    assert "job_id" in result
+
+
+@pytest.mark.asyncio
+async def test_inspect_success(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {"operation": "inspect", "job_id": "job-1"},
+            _settings(tmp_path),
+        )
+    assert "Job details" in result
+    assert "job-1" in result
+
+
+@pytest.mark.asyncio
+async def test_logs_success(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {"operation": "logs", "job_id": "job-1"},
+            _settings(tmp_path),
+        )
+    assert "Logs for job-1" in result
+    assert "step 1 ok" in result
+
+
+@pytest.mark.asyncio
+async def test_logs_requires_job_id(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler({"operation": "logs"}, _settings(tmp_path))
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_logs_empty(tmp_path: Path) -> None:
+    class _NoLogsApi(_FakeHfApi):
+        def fetch_job_logs(self, job_id, namespace=None):
+            return iter([])
+
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = _NoLogsApi
+    with patch.dict(sys.modules, {"huggingface_hub": fake_module}):
+        with _token_context():
+            result = await manage_job_handler(
+                {"operation": "logs", "job_id": "job-1"},
+                _settings(tmp_path),
+            )
+    assert "No logs available" in result
+
+
+@pytest.mark.asyncio
+async def test_logs_truncates_long_output(tmp_path: Path) -> None:
+    class _VerboseApi(_FakeHfApi):
+        def fetch_job_logs(self, job_id, namespace=None):
+            return iter([f"line {i}" for i in range(1000)])
+
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = _VerboseApi
+    with patch.dict(sys.modules, {"huggingface_hub": fake_module}):
+        with _token_context():
+            result = await manage_job_handler(
+                {"operation": "logs", "job_id": "job-1"},
+                _settings(tmp_path),
+            )
+    assert "first 500 of 1000" in result
+
+
+@pytest.mark.asyncio
+async def test_cancel_success(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler(
+            {"operation": "cancel", "job_id": "job-1"},
+            _settings(tmp_path),
+        )
+    assert "cancelled" in result.lower()
+    assert "job-1" in result
+
+
+@pytest.mark.asyncio
+async def test_cancel_requires_job_id(tmp_path: Path) -> None:
+    with _token_context():
+        result = await manage_job_handler({"operation": "cancel"}, _settings(tmp_path))
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_cancel_surfaces_api_error(tmp_path: Path) -> None:
+    class _FailApi(_FakeHfApi):
+        def cancel_job(self, job_id, namespace=None):
+            raise RuntimeError("not authorized to cancel")
+
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = _FailApi
+    with patch.dict(sys.modules, {"huggingface_hub": fake_module}):
+        with _token_context():
+            result = await manage_job_handler(
+                {"operation": "cancel", "job_id": "job-1"},
+                _settings(tmp_path),
+            )
+    assert "Error" in result
+    assert "not authorized" in result


### PR DESCRIPTION
Closes #88

## Summary
- add **manage_job**: a single tool that launches Python or Docker jobs on Hugging Face compute and supports list, inspect, logs, and cancel through the official Hugging Face Jobs API
- propagate the per-session HF token into job launches, env vars, and secret injection (HF_TOKEN and HUGGING_FACE_HUB_TOKEN) without exposing it in tool schemas or responses
- validate job arguments up front: script vs command exclusivity, supported CPU/GPU hardware flavors, required job ids, and a clear billing/quota error path for namespace credit rejections
- keep job output clean with default env vars and bounded, truncated log retrieval
- add huggingface_hub as a runtime dependency and wire the tool into the agent registry

## Testing
- 218 tests pass (was 191; +27 new unit tests covering dispatch validation, Python/Docker run modes, exclusivity/flavor/billing errors, list filtering, inspect, log retrieval with empty/long output, and cancel)
- ruff check + ruff format clean
- mypy clean on app
- pre-commit clean
- registry smoke test confirms manage_job registers (20 tools total)
- frontend build passes

## Notes
This task focuses on launch, inspect, list, fetch logs, and cancel so later experiment-loop tasks can build on it. Long-blocking log streaming and scheduled jobs are intentionally out of scope here. Billing errors are surfaced with the HF settings/billing URL so the caller can top up credits and re-run.

## Reference
Cross-checked the Hugging Face ml-intern jobs tool for hardware flavor coverage, token/secret propagation, and billing-error detection while shaping the tool boundary. Notion task: ML-303.