### PR TITLE
ML-303 follow-up / Land HF Jobs Python command fix on main

### DIFF
--- a/app/tools/jobs.py
+++ b/app/tools/jobs.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import shlex
 from typing import Any
 
 from app.config import AppSettings
@@ -227,13 +229,25 @@ async def _run_job(args: dict[str, Any]) -> str:
 
 def _build_python_command(script: str) -> list[str]:
     """Build a uv run command for an inline script, URL, or file path."""
+    script = script.strip()
     parts = ["uv", "run"]
     if script.startswith(("http://", "https://")):
         parts.append(script)
+    elif _looks_like_inline_script(script):
+        encoded = base64.b64encode(script.encode("utf-8")).decode("utf-8")
+        shell = f"printf %s {shlex.quote(encoded)} | base64 -d | uv run -"
+        return ["/bin/sh", "-lc", shell]
     else:
-        # Inline scripts are passed via stdin so the job never needs a file.
-        parts.append("-")
+        parts.append(script)
     return parts
+
+
+def _looks_like_inline_script(script: str) -> bool:
+    """Return true when a script value is Python source rather than a path/URL."""
+    if "\n" in script:
+        return True
+    stripped = script.lstrip()
+    return stripped.startswith(("import ", "from ", "print(", "def ", "class ", "if __name__"))
 
 
 async def _list_jobs(args: dict[str, Any]) -> str:
@@ -422,7 +436,8 @@ def get_tool_specs() -> list[dict[str, Any]]:
                         "description": "Optional namespace to run the job under (own account or an org).",
                     },
                     "job_id": {
-                        "type": "string",
+                        "type": ["string", "array"],
+                        "items": {"type": "string"},
                         "description": (
                             "Job ID. Required for inspect, logs, and cancel. A list is accepted for inspect."
                         ),

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import sys
 import types
 from pathlib import Path
@@ -132,9 +133,16 @@ def test_is_billing_error_detects_credit_messages() -> None:
     assert not _is_billing_error("invalid flavor")
 
 
-def test_build_python_command_for_url_and_inline() -> None:
+def test_build_python_command_for_url_file_and_inline() -> None:
     assert _build_python_command("https://example.com/train.py") == ["uv", "run", "https://example.com/train.py"]
-    assert _build_python_command("import torch") == ["uv", "run", "-"]
+    assert _build_python_command("train.py") == ["uv", "run", "train.py"]
+
+    inline_command = _build_python_command("import torch\nprint('hello')")
+    encoded = base64.b64encode("import torch\nprint('hello')".encode("utf-8")).decode("utf-8")
+
+    assert inline_command[:2] == ["/bin/sh", "-lc"]
+    assert encoded in inline_command[2]
+    assert "base64 -d | uv run -" in inline_command[2]
 
 
 def test_get_tool_specs() -> None:
@@ -146,6 +154,8 @@ def test_get_tool_specs() -> None:
     assert "script" in props
     assert "command" in props
     assert "job_id" in props
+    assert props["job_id"]["type"] == ["string", "array"]
+    assert props["job_id"]["items"] == {"type": "string"}
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +211,8 @@ async def test_run_python_job(tmp_path: Path) -> None:
     call = _FakeHfApi.instances[-1].run_job_calls[-1]
     assert call["flavor"] == "cpu-basic"
     assert call["timeout"] == "1h"
-    assert call["command"] == ["uv", "run", "-"]
+    assert call["command"][:2] == ["/bin/sh", "-lc"]
+    assert "base64 -d | uv run -" in call["command"][2]
     assert call["secrets"]["HF_TOKEN"] == "hf-session-token"
 
 


### PR DESCRIPTION
## Summary
- land the ML-303 Python script command fix on `main` after the stacked PR #90 merged into the already-merged feature branch
- preserve URL/file Python scripts as `uv run <path-or-url>` and pipe inline Python scripts into `uv run -` via base64
- align the `job_id` tool schema with the handler's multi-inspect support

## Why
PR #90 was merged into `feature/ML-303-hf-jobs-orchestration-monitoring` after PR #89 had already merged to `main`, so GitHub marked the stacked PR merged but its fix was stranded off `origin/main`.

## Testing
- `python -m pytest -q tests/unit/test_jobs.py` ? 27 passed
- `python -m ruff check app tests` ? passed
- `python -m mypy app --ignore-missing-imports --follow-imports=skip` ? passed
