### PR TITLE
ML-306 / Add model publishing, model card generation, and final report

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -937,6 +937,7 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
         jobs,
         mcp,
         papers,
+        publishing,
         repo_analyzer,
         reporting,
         sandbox,
@@ -1008,6 +1009,15 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
             handler=_make_experiment_loop_handler(settings),
+        )
+        registry.register(tool_spec)
+
+    for spec in publishing.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_publishing_handler(settings),
         )
         registry.register(tool_spec)
 
@@ -1133,6 +1143,16 @@ def _make_experiment_loop_handler(settings: AppSettings) -> ToolHandler:
 
     async def _handler(args: dict[str, Any]) -> str:
         return await experiments.manage_experiment_loop_handler(args, settings)
+
+    return _handler
+
+
+def _make_publishing_handler(settings: AppSettings) -> ToolHandler:
+    """Create a handler for model publishing assets and final reports."""
+    from app.tools import publishing
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await publishing.publish_model_report_handler(args, settings)
 
     return _handler
 

--- a/app/tools/publishing.py
+++ b/app/tools/publishing.py
@@ -1,0 +1,308 @@
+"""Model publishing, model card, and final report tooling."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.config import AppSettings
+from app.tools.context import current_hf_token, current_session_id
+from app.tools.workspace import _safe_path
+
+DEFAULT_OUTPUT_ROOT = "reports/model-publishing"
+PUBLISH_MANIFEST = "publish_manifest.json"
+_SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return tool specs for model publishing and report generation."""
+    return [
+        {
+            "name": "publish_model_report",
+            "description": (
+                "Prepare Hub-ready model publishing assets locally: README model card, final reproducibility "
+                "report, manifest, and optional explicit Hugging Face Hub upload."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "repo_id": {"type": "string", "description": "Target Hugging Face model repo id."},
+                    "model_name": {"type": "string", "description": "Human-readable model name."},
+                    "task": {"type": "string", "description": "Primary task or pipeline tag."},
+                    "license": {"type": "string", "description": "Model license for card metadata."},
+                    "datasets": {"type": "array", "items": {"type": "string"}},
+                    "base_models": {"type": "array", "items": {"type": "string"}},
+                    "papers": {"type": "array", "items": {"type": "string"}},
+                    "jobs": {"type": "array", "items": {"type": "string"}},
+                    "sandbox_commands": {"type": "array", "items": {"type": "string"}},
+                    "metrics": {"type": "object", "description": "Final model metrics."},
+                    "recommendation": {"type": "string", "description": "Final recommendation and rationale."},
+                    "limitations": {"type": "array", "items": {"type": "string"}},
+                    "output_dir": {"type": "string", "description": "Workspace-relative output directory."},
+                    "publish": {
+                        "type": "boolean",
+                        "description": "When true, upload the prepared folder to the Hugging Face Hub.",
+                    },
+                    "private": {"type": "boolean", "description": "Create/update the Hub repo as private."},
+                },
+                "required": ["repo_id"],
+            },
+        }
+    ]
+
+
+async def _to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+def _hf_api() -> Any:
+    from huggingface_hub import HfApi
+
+    return HfApi(token=current_hf_token())
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _slug(value: str) -> str:
+    cleaned = _SAFE_NAME_RE.sub("-", value.strip()).strip(".-_")
+    return cleaned or "model"
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [item.strip() for item in value.replace(";", ",").split(",") if item.strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _normalize_metrics(value: Any) -> dict[str, float | str]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, float | str] = {}
+    for key, raw in value.items():
+        try:
+            result[str(key)] = float(raw)
+        except (TypeError, ValueError):
+            result[str(key)] = str(raw)
+    return result
+
+
+def _format_metrics(metrics: dict[str, float | str]) -> list[str]:
+    if not metrics:
+        return ["- No final metrics were provided."]
+    lines = []
+    for key, value in metrics.items():
+        if isinstance(value, float):
+            lines.append(f"- {key}: {value:g}")
+        else:
+            lines.append(f"- {key}: {value}")
+    return lines
+
+
+def _bullets_or_empty(values: list[str]) -> list[str]:
+    return [f"- {value}" for value in values] if values else ["- Not specified."]
+
+
+def _resolve_output_dir(args: dict[str, Any], settings: AppSettings, repo_id: str) -> Path | str:
+    raw = str(args.get("output_dir") or "").strip()
+    if not raw:
+        raw = f"{DEFAULT_OUTPUT_ROOT}/{_slug(repo_id.rsplit('/', 1)[-1])}"
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        safe = _safe_path(candidate, settings.paths.workspace_root)
+    else:
+        safe = _safe_path(settings.paths.workspace_root / candidate, settings.paths.workspace_root)
+    if safe is None:
+        return f"Error: output_dir {raw!r} is outside workspace root {settings.paths.workspace_root}"
+    return safe
+
+
+def _model_name(args: dict[str, Any], repo_id: str) -> str:
+    return str(args.get("model_name") or repo_id.rsplit("/", 1)[-1]).strip()
+
+
+def _model_card(args: dict[str, Any], repo_id: str) -> str:
+    model_name = _model_name(args, repo_id)
+    task = str(args.get("task") or "model").strip()
+    license_name = str(args.get("license") or "unknown").strip()
+    datasets = _as_list(args.get("datasets"))
+    base_models = _as_list(args.get("base_models"))
+    limitations = _as_list(args.get("limitations"))
+    metrics = _normalize_metrics(args.get("metrics"))
+
+    tags = [task, "ml-copilot", "generated-report"]
+    metadata = [
+        "---",
+        f"license: {license_name}",
+        "tags:",
+        *[f"- {tag}" for tag in tags if tag],
+        "---",
+        "",
+    ]
+
+    lines = [
+        *metadata,
+        f"# {model_name}",
+        "",
+        "## Model Details",
+        "",
+        f"- Repository: `{repo_id}`",
+        f"- Task: {task}",
+        f"- License: {license_name}",
+        f"- Generated: {_now()}",
+        "",
+        "## Training Inputs",
+        "",
+        "### Datasets",
+        *_bullets_or_empty(datasets),
+        "",
+        "### Base Models",
+        *_bullets_or_empty(base_models),
+        "",
+        "## Metrics",
+        "",
+        *_format_metrics(metrics),
+        "",
+        "## Usage",
+        "",
+        "```python",
+        "from transformers import AutoModel, AutoTokenizer",
+        "",
+        f'model_id = "{repo_id}"',
+        "tokenizer = AutoTokenizer.from_pretrained(model_id)",
+        "model = AutoModel.from_pretrained(model_id)",
+        "```",
+        "",
+        "## Limitations",
+        "",
+        *([f"- {item}" for item in limitations] if limitations else ["- Limitations were not specified."]),
+        "",
+        "## Provenance",
+        "",
+        "Generated by ML Copilot from the supplied experiment, job, dataset, and paper context.",
+    ]
+    return "\n".join(lines).strip() + "\n"
+
+
+def _final_report(args: dict[str, Any], repo_id: str) -> str:
+    model_name = _model_name(args, repo_id)
+    metrics = _normalize_metrics(args.get("metrics"))
+    sections = [
+        f"# Final Report: {model_name}",
+        "",
+        "## Recommendation",
+        "",
+        str(args.get("recommendation") or "No final recommendation was provided.").strip(),
+        "",
+        "## Final Metrics",
+        "",
+        *_format_metrics(metrics),
+        "",
+        "## Reproducibility",
+        "",
+        "### Datasets",
+        *_bullets_or_empty(_as_list(args.get("datasets"))),
+        "",
+        "### Papers",
+        *_bullets_or_empty(_as_list(args.get("papers"))),
+        "",
+        "### Jobs",
+        *_bullets_or_empty(_as_list(args.get("jobs"))),
+        "",
+        "### Sandbox Commands",
+        *_bullets_or_empty(_as_list(args.get("sandbox_commands"))),
+        "",
+        "## What Worked",
+        "",
+        "Use the metrics and recommendation above to identify the best observed run.",
+        "",
+        "## What Failed",
+        "",
+        "Review failed jobs, sandbox commands, and experiment attempts linked above before broadening scope.",
+    ]
+    return "\n".join(sections).strip() + "\n"
+
+
+def _manifest(args: dict[str, Any], repo_id: str) -> dict[str, Any]:
+    return {
+        "repo_id": repo_id,
+        "repo_type": "model",
+        "model_name": _model_name(args, repo_id),
+        "task": str(args.get("task") or "").strip(),
+        "license": str(args.get("license") or "").strip(),
+        "datasets": _as_list(args.get("datasets")),
+        "base_models": _as_list(args.get("base_models")),
+        "papers": _as_list(args.get("papers")),
+        "jobs": _as_list(args.get("jobs")),
+        "sandbox_commands": _as_list(args.get("sandbox_commands")),
+        "metrics": _normalize_metrics(args.get("metrics")),
+        "recommendation": str(args.get("recommendation") or "").strip(),
+        "files": ["README.md", "FINAL_REPORT.md", PUBLISH_MANIFEST],
+        "generated_at": _now(),
+        "session_id": current_session_id(),
+    }
+
+
+def _write_assets(args: dict[str, Any], settings: AppSettings, repo_id: str) -> Path | str:
+    output_dir = _resolve_output_dir(args, settings, repo_id)
+    if isinstance(output_dir, str):
+        return output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "README.md").write_text(_model_card(args, repo_id), encoding="utf-8")
+    (output_dir / "FINAL_REPORT.md").write_text(_final_report(args, repo_id), encoding="utf-8")
+    (output_dir / PUBLISH_MANIFEST).write_text(json.dumps(_manifest(args, repo_id), indent=2), encoding="utf-8")
+    return output_dir
+
+
+async def _publish(output_dir: Path, args: dict[str, Any], repo_id: str) -> str:
+    token = current_hf_token()
+    if not token:
+        return "Error: A Hugging Face token is required when publish=true."
+
+    api = _hf_api()
+    private = bool(args.get("private", True))
+    await _to_thread(api.create_repo, repo_id=repo_id, repo_type="model", private=private, exist_ok=True)
+    await _to_thread(
+        api.upload_folder,
+        repo_id=repo_id,
+        repo_type="model",
+        folder_path=str(output_dir),
+        commit_message="ML Copilot model card and final report",
+    )
+    return f"Published model assets to https://huggingface.co/{repo_id}"
+
+
+async def publish_model_report_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Prepare local model publishing assets and optionally upload them to the Hub."""
+    repo_id = str(args.get("repo_id") or "").strip()
+    if not repo_id:
+        return "Error: repo_id is required."
+    if "/" not in repo_id:
+        return "Error: repo_id must include a namespace, e.g. 'owner/model-name'."
+
+    output_dir = _write_assets(args, settings, repo_id)
+    if isinstance(output_dir, str):
+        return output_dir
+
+    if bool(args.get("publish", False)):
+        publish_result = await _publish(output_dir, args, repo_id)
+        if publish_result.startswith("Error:"):
+            return publish_result
+        return f"{publish_result}\nLocal assets: {output_dir}"
+
+    return (
+        "Prepared model publishing assets.\n"
+        f"- README: {output_dir / 'README.md'}\n"
+        f"- Final report: {output_dir / 'FINAL_REPORT.md'}\n"
+        f"- Manifest: {output_dir / PUBLISH_MANIFEST}\n"
+        "Set publish=true to upload these assets to the Hugging Face Hub."
+    )

--- a/tests/unit/test_publishing.py
+++ b/tests/unit/test_publishing.py
@@ -1,0 +1,168 @@
+"""Tests for model publishing, model card, and final report tooling."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.agent.loop import _create_tool_registry
+from app.config import AppPaths, AppSettings
+from app.tools.context import ToolExecutionContext, use_tool_execution_context
+from app.tools.publishing import get_tool_specs, publish_model_report_handler
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+def _token_context(session_id: str = "session-1"):
+    return use_tool_execution_context(ToolExecutionContext(session_id=session_id, hf_token="hf-session-token"))
+
+
+class _FakeHfApi:
+    instances: list["_FakeHfApi"] = []
+
+    def __init__(self, token=None):
+        self.token = token
+        self.create_repo_calls: list[dict] = []
+        self.upload_folder_calls: list[dict] = []
+        _FakeHfApi.instances.append(self)
+
+    def create_repo(self, **kwargs):
+        self.create_repo_calls.append(kwargs)
+        return types.SimpleNamespace(url=f"https://huggingface.co/{kwargs['repo_id']}")
+
+    def upload_folder(self, **kwargs):
+        self.upload_folder_calls.append(kwargs)
+        return "commit-123"
+
+
+@pytest.fixture(autouse=True)
+def _stub_huggingface_hub():
+    fake_module = types.ModuleType("huggingface_hub")
+    fake_module.HfApi = _FakeHfApi
+    original = sys.modules.get("huggingface_hub")
+    _FakeHfApi.instances.clear()
+    sys.modules["huggingface_hub"] = fake_module
+    try:
+        yield
+    finally:
+        _FakeHfApi.instances.clear()
+        if original is not None:
+            sys.modules["huggingface_hub"] = original
+        else:
+            sys.modules.pop("huggingface_hub", None)
+
+
+def _payload(**overrides):
+    payload = {
+        "repo_id": "owner/tiny-classifier",
+        "model_name": "Tiny Classifier",
+        "task": "text-classification",
+        "license": "apache-2.0",
+        "datasets": ["owner/sentiment-data"],
+        "base_models": ["distilbert-base-uncased"],
+        "papers": ["Attention Is All You Need"],
+        "jobs": ["job-123"],
+        "sandbox_commands": ["python smoke.py"],
+        "metrics": {"accuracy": 0.91, "f1": 0.88},
+        "recommendation": "Publish this model; it met the target accuracy with acceptable validation loss.",
+        "limitations": ["Evaluated on a small validation split."],
+        "output_dir": "reports/tiny-classifier",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_get_tool_specs() -> None:
+    specs = get_tool_specs()
+    assert len(specs) == 1
+    assert specs[0]["name"] == "publish_model_report"
+    props = specs[0]["parameters"]["properties"]
+    assert "repo_id" in props
+    assert "publish" in props
+    assert "metrics" in props
+
+
+@pytest.mark.asyncio
+async def test_prepare_writes_model_card_report_and_manifest(tmp_path: Path) -> None:
+    with _token_context():
+        result = await publish_model_report_handler(_payload(), _settings(tmp_path))
+
+    output_dir = tmp_path / "reports" / "tiny-classifier"
+    readme = output_dir / "README.md"
+    report = output_dir / "FINAL_REPORT.md"
+    manifest = output_dir / "publish_manifest.json"
+
+    assert "Prepared model publishing assets" in result
+    assert readme.exists()
+    assert report.exists()
+    assert manifest.exists()
+
+    readme_text = readme.read_text(encoding="utf-8")
+    assert "license: apache-2.0" in readme_text
+    assert "- text-classification" in readme_text
+    assert "# Tiny Classifier" in readme_text
+    assert "owner/sentiment-data" in readme_text
+    assert "accuracy: 0.91" in readme_text
+    assert "AutoModel" in readme_text
+
+    report_text = report.read_text(encoding="utf-8")
+    assert "## Reproducibility" in report_text
+    assert "job-123" in report_text
+    assert "python smoke.py" in report_text
+    assert "Publish this model" in report_text
+
+    manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+    assert manifest_data["repo_id"] == "owner/tiny-classifier"
+    assert manifest_data["files"] == ["README.md", "FINAL_REPORT.md", "publish_manifest.json"]
+    assert "hf-session-token" not in readme_text + report_text + json.dumps(manifest_data)
+
+
+@pytest.mark.asyncio
+async def test_rejects_output_dir_outside_workspace(tmp_path: Path) -> None:
+    with _token_context():
+        result = await publish_model_report_handler(_payload(output_dir="../outside"), _settings(tmp_path))
+
+    assert "Error" in result
+    assert "outside workspace" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_publish_requires_hf_token(tmp_path: Path) -> None:
+    with patch("app.tools.publishing.current_hf_token", return_value=None):
+        result = await publish_model_report_handler(_payload(publish=True), _settings(tmp_path))
+
+    assert "Error" in result
+    assert "token" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_publish_uploads_prepared_folder_to_hub(tmp_path: Path) -> None:
+    with _token_context():
+        result = await publish_model_report_handler(_payload(publish=True, private=True), _settings(tmp_path))
+
+    assert "Published model assets" in result
+    api = _FakeHfApi.instances[-1]
+    assert api.token == "hf-session-token"
+    assert api.create_repo_calls[-1] == {
+        "repo_id": "owner/tiny-classifier",
+        "repo_type": "model",
+        "private": True,
+        "exist_ok": True,
+    }
+    upload_call = api.upload_folder_calls[-1]
+    assert upload_call["repo_id"] == "owner/tiny-classifier"
+    assert upload_call["repo_type"] == "model"
+    assert Path(upload_call["folder_path"]).name == "tiny-classifier"
+    assert "ML Copilot" in upload_call["commit_message"]
+
+
+def test_tool_registry_includes_publish_model_report(tmp_path: Path) -> None:
+    registry = _create_tool_registry(_settings(tmp_path))
+    assert registry.get("publish_model_report").name == "publish_model_report"


### PR DESCRIPTION
## Summary
- add a `publish_model_report` tool that prepares Hub-ready local model artifacts
- generate a model card, final reproducibility report, and publishing manifest without persisting Hugging Face tokens
- wire the publishing tool into the agent registry and cover local/publish paths with unit tests

## Validation
- `python -m pytest tests/unit/test_publishing.py`
- `python -m pytest tests/unit/test_publishing.py tests/unit/test_agent_loop.py tests/unit/test_hub.py tests/unit/test_experiments.py`
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m pytest -q`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `git diff --check`

## Reference
Closes #96