### PR TITLE
ML-307 / Add ML task evaluation suite

### DIFF
--- a/app/evals/__init__.py
+++ b/app/evals/__init__.py
@@ -1,5 +1,14 @@
 """Evaluation package for reproducible agent tasks."""
 
 from app.evals.runner import EvalFixture, EvalRunner, EvalRunResult, load_fixture
+from app.evals.suite import EvalSuiteRunner, EvalSuiteRunResult, discover_fixture_paths
 
-__all__ = ["EvalFixture", "EvalRunner", "EvalRunResult", "load_fixture"]
+__all__ = [
+    "EvalFixture",
+    "EvalRunner",
+    "EvalRunResult",
+    "EvalSuiteRunner",
+    "EvalSuiteRunResult",
+    "discover_fixture_paths",
+    "load_fixture",
+]

--- a/app/evals/suite.py
+++ b/app/evals/suite.py
@@ -1,0 +1,186 @@
+"""Suite-level orchestration for fixture-based evals."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.config import AppSettings
+from app.evals.runner import AgentRunCallable, EvalRunner, EvalRunResult, load_fixture
+from app.storage.repository import SQLiteRepository
+
+
+@dataclass(frozen=True)
+class EvalSuiteRunResult:
+    """Aggregate result for a run of multiple eval fixtures."""
+
+    status: str
+    score: float
+    fixture_results: list[EvalRunResult]
+    report: dict[str, Any]
+    report_path: Path
+    markdown_path: Path
+
+    @property
+    def report_json(self) -> str:
+        return json.dumps(self.report, sort_keys=True)
+
+
+class EvalSuiteRunner:
+    """Run a directory or list of eval fixtures and write aggregate reports."""
+
+    def __init__(
+        self,
+        settings: AppSettings,
+        *,
+        repository: SQLiteRepository | None = None,
+        agent_runner: AgentRunCallable | None = None,
+    ) -> None:
+        self.settings = settings
+        self.repository = repository or SQLiteRepository(settings.db_path)
+        self.repository.initialize()
+        self.agent_runner = agent_runner
+
+    async def run_path(self, path: Path, *, output_dir: Path | None = None) -> EvalSuiteRunResult:
+        """Discover and run fixtures from a JSON fixture path or directory."""
+        return await self.run_fixture_paths(discover_fixture_paths(path), output_dir=output_dir)
+
+    async def run_fixture_paths(
+        self,
+        fixture_paths: list[Path],
+        *,
+        output_dir: Path | None = None,
+    ) -> EvalSuiteRunResult:
+        """Run the provided fixture files in deterministic order."""
+        if not fixture_paths:
+            raise ValueError("At least one eval fixture is required.")
+
+        eval_output_dir = (output_dir or self.settings.paths.workspace_root / ".ml-copilot" / "evals").resolve()
+        eval_output_dir.mkdir(parents=True, exist_ok=True)
+        suite_dir = eval_output_dir / "suites" / _suite_id(fixture_paths)
+        suite_dir.mkdir(parents=True, exist_ok=True)
+
+        runner = EvalRunner(self.settings, repository=self.repository, agent_runner=self.agent_runner)
+        runtime_start = time.perf_counter()
+        results: list[EvalRunResult] = []
+        for fixture_path in fixture_paths:
+            results.append(await runner.run_fixture(load_fixture(fixture_path), output_dir=eval_output_dir))
+
+        runtime_seconds = round(time.perf_counter() - runtime_start, 4)
+        report = build_suite_report(results, runtime_seconds=runtime_seconds)
+        report_path = suite_dir / "suite-report.json"
+        markdown_path = suite_dir / "suite-report.md"
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        markdown_path.write_text(format_suite_markdown_report(report), encoding="utf-8")
+        return EvalSuiteRunResult(
+            status=report["status"],
+            score=report["summary"]["average_score"],
+            fixture_results=results,
+            report=report,
+            report_path=report_path,
+            markdown_path=markdown_path,
+        )
+
+
+def discover_fixture_paths(path: Path) -> list[Path]:
+    """Return sorted fixture JSON files from a fixture path or directory."""
+    resolved = path.resolve()
+    if resolved.is_file():
+        if resolved.suffix.lower() != ".json":
+            raise ValueError(f"Eval fixture must be a JSON file: {path}")
+        return [resolved]
+    if not resolved.exists():
+        raise ValueError(f"Eval fixture path does not exist: {path}")
+    if not resolved.is_dir():
+        raise ValueError(f"Eval fixture path must be a file or directory: {path}")
+
+    fixture_paths = sorted(item for item in resolved.glob("*.json") if item.is_file())
+    if not fixture_paths:
+        raise ValueError(f"No eval fixture JSON files found in {path}")
+    return fixture_paths
+
+
+def build_suite_report(results: list[EvalRunResult], *, runtime_seconds: float) -> dict[str, Any]:
+    """Build a JSON-serializable aggregate report for fixture results."""
+    fixture_reports = [_decode_report(result) for result in results]
+    statuses = [result.record.status for result in results]
+    fixtures_total = len(results)
+    fixtures_passed = sum(1 for status in statuses if status == "passed")
+    fixtures_failed = sum(1 for status in statuses if status == "failed")
+    fixtures_error = sum(1 for status in statuses if status == "error")
+    average_score = round(sum(float(result.record.score or 0.0) for result in results) / fixtures_total, 4)
+    status = "passed" if fixtures_passed == fixtures_total else "error" if fixtures_error else "failed"
+    total_tokens = sum(
+        int(((report.get("scoring") or {}).get("token_usage") or {}).get("total_tokens") or 0)
+        for report in fixture_reports
+    )
+    return {
+        "status": status,
+        "summary": {
+            "fixtures_total": fixtures_total,
+            "fixtures_passed": fixtures_passed,
+            "fixtures_failed": fixtures_failed,
+            "fixtures_error": fixtures_error,
+            "average_score": average_score,
+            "runtime_seconds": runtime_seconds,
+            "total_tokens": total_tokens,
+        },
+        "fixtures": [
+            {
+                "fixture_id": result.record.task_id,
+                "eval_run_id": result.record.id,
+                "status": result.record.status,
+                "score": result.record.score,
+                "report_path": str(result.report_path),
+                "markdown_path": str(result.markdown_path),
+                "workspace_path": str(result.workspace_path),
+            }
+            for result in results
+        ],
+    }
+
+
+def format_suite_markdown_report(report: dict[str, Any]) -> str:
+    """Render a compact Markdown summary for a suite run."""
+    summary = report["summary"]
+    lines = [
+        "# Eval Suite Report",
+        "",
+        f"- Status: `{report['status']}`",
+        f"- Fixtures: `{summary['fixtures_passed']}/{summary['fixtures_total']}` passed",
+        f"- Failed: `{summary['fixtures_failed']}`",
+        f"- Errors: `{summary['fixtures_error']}`",
+        f"- Average score: `{summary['average_score']}`",
+        f"- Runtime: `{summary['runtime_seconds']}` seconds",
+        f"- Tokens: `{summary['total_tokens']}` total",
+        "",
+        "## Fixtures",
+    ]
+    for fixture in report["fixtures"]:
+        lines.append(
+            f"- `{fixture['status']}` `{fixture['fixture_id']}` "
+            f"score=`{fixture['score']}` report=`{fixture['markdown_path']}`"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _decode_report(result: EvalRunResult) -> dict[str, Any]:
+    try:
+        loaded = json.loads(result.record.report_json)
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _suite_id(fixture_paths: list[Path]) -> str:
+    stem = fixture_paths[0].parent.name if len(fixture_paths) > 1 else fixture_paths[0].stem
+    return _safe_slug(f"{stem}-{int(time.time() * 1000)}")
+
+
+def _safe_slug(value: str) -> str:
+    slug = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in value.strip())
+    return slug.strip("-") or "suite"

--- a/app/main.py
+++ b/app/main.py
@@ -133,7 +133,7 @@ def build_parser() -> argparse.ArgumentParser:
     eval_parser.add_argument(
         "fixture",
         type=Path,
-        help="Path to an eval fixture JSON file",
+        help="Path to an eval fixture JSON file or a directory of fixture JSON files",
     )
     eval_parser.add_argument(
         "--output-dir",
@@ -390,9 +390,23 @@ async def cmd_reject(args: argparse.Namespace, settings: AppSettings) -> int:
 
 async def cmd_eval(args: argparse.Namespace, settings: AppSettings) -> int:
     """Execute the 'eval' command."""
-    from app.evals import EvalRunner, load_fixture
+    from app.evals import EvalRunner, EvalSuiteRunner, discover_fixture_paths, load_fixture
 
-    fixture = load_fixture(args.fixture)
+    fixture_paths = discover_fixture_paths(args.fixture)
+    if len(fixture_paths) > 1 or args.fixture.resolve().is_dir():
+        suite_result = await EvalSuiteRunner(settings).run_fixture_paths(fixture_paths, output_dir=args.output_dir)
+        if args.json:
+            print(suite_result.report_json)
+        else:
+            summary = suite_result.report["summary"]
+            print("Eval suite run")
+            print(f"Status: {suite_result.status}")
+            print(f"Fixtures: {summary['fixtures_passed']}/{summary['fixtures_total']} passed")
+            print(f"Average score: {suite_result.score}")
+            print(f"Report: {suite_result.markdown_path}")
+        return 0 if suite_result.status == "passed" else 1
+
+    fixture = load_fixture(fixture_paths[0])
     runner = EvalRunner(settings)
     result = await runner.run_fixture(fixture, output_dir=args.output_dir)
 

--- a/docs/phase-3-eval-runner.md
+++ b/docs/phase-3-eval-runner.md
@@ -62,6 +62,12 @@ Run an eval fixture:
 python -m app.main eval path/to/fixture.json
 ```
 
+Run every fixture in a directory as a suite:
+
+```bash
+python -m app.main eval tests/fixtures/evals
+```
+
 Use a custom artifact directory:
 
 ```bash
@@ -75,6 +81,7 @@ python -m app.main eval path/to/fixture.json --json
 ```
 
 The command exits with `0` when all checks pass and `1` when the eval fails or errors.
+For directory suite runs, the command exits with `0` only when every fixture passes.
 
 ## Artifacts
 
@@ -83,6 +90,8 @@ Each run writes:
 - `workspaces/<fixture-id>/<eval-run-id>/` for the reproducible fixture workspace
 - `artifacts/<eval-run-id>/report.json` for machine-readable results
 - `artifacts/<eval-run-id>/report.md` for reviewer-friendly results
+- `suites/<suite-id>/suite-report.json` for aggregate directory runs
+- `suites/<suite-id>/suite-report.md` for reviewer-friendly aggregate directory runs
 
 The same report payload is persisted in SQLite under `eval_runs.report_json`.
 
@@ -101,6 +110,17 @@ automation:
 
 The Markdown report mirrors the same information with dedicated sections for
 changed files, safety events, and check results.
+
+## Suite Report Format
+
+Directory runs reuse the same fixture runner for each task and then write one
+aggregate report with:
+
+- overall suite status: `passed`, `failed`, or `error`
+- fixture counts for passed, failed, and errored tasks
+- average score across fixtures
+- total runtime and token count
+- per-fixture eval run IDs, status, score, workspaces, and report paths
 
 ## Bundled Fixtures
 

--- a/tests/unit/test_eval_suite.py
+++ b/tests/unit/test_eval_suite.py
@@ -1,0 +1,94 @@
+"""Tests for running eval fixtures as a suite."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.config import AppPaths, AppSettings
+from app.evals.runner import EvalFixture
+from app.evals.suite import EvalSuiteRunner, discover_fixture_paths
+from app.storage.models import SessionRecord
+from app.storage.repository import SQLiteRepository
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+def _write_fixture(path: Path, fixture_id: str, expected: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "id": fixture_id,
+                "prompt": f"Complete {fixture_id}",
+                "checks": [{"type": "contains", "value": expected}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_discover_fixture_paths_returns_sorted_json_files(tmp_path: Path) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    _write_fixture(fixture_dir / "b.json", "b", "ok")
+    _write_fixture(fixture_dir / "a.json", "a", "ok")
+    (fixture_dir / "notes.md").write_text("ignore me", encoding="utf-8")
+
+    paths = discover_fixture_paths(fixture_dir)
+
+    assert [path.name for path in paths] == ["a.json", "b.json"]
+
+
+def test_discover_fixture_paths_rejects_empty_directories(tmp_path: Path) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+
+    with pytest.raises(ValueError, match="No eval fixture JSON files"):
+        discover_fixture_paths(fixture_dir)
+
+
+@pytest.mark.asyncio
+async def test_eval_suite_runner_writes_aggregate_reports(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    repository = SQLiteRepository(settings.db_path)
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    _write_fixture(fixture_dir / "first.json", "fixture-pass", "ok")
+    _write_fixture(fixture_dir / "second.json", "fixture-fail", "missing")
+
+    async def fake_agent(
+        fixture: EvalFixture,
+        _workspace_path: Path,
+        _settings: AppSettings,
+        _session: SessionRecord,
+    ) -> dict[str, object]:
+        content = "ok" if fixture.id == "fixture-pass" else "not enough"
+        return {"content": content, "usage": {"total_tokens": 3}}
+
+    result = await EvalSuiteRunner(settings, repository=repository, agent_runner=fake_agent).run_path(
+        fixture_dir,
+        output_dir=tmp_path / "eval-output",
+    )
+
+    assert result.status == "failed"
+    assert result.score == pytest.approx(0.5)
+    assert result.report_path.exists()
+    assert result.markdown_path.exists()
+
+    report = json.loads(result.report_json)
+    assert report["summary"]["fixtures_total"] == 2
+    assert report["summary"]["fixtures_passed"] == 1
+    assert report["summary"]["fixtures_failed"] == 1
+    assert report["summary"]["fixtures_error"] == 0
+    assert report["summary"]["average_score"] == pytest.approx(0.5)
+    assert [item["fixture_id"] for item in report["fixtures"]] == ["fixture-pass", "fixture-fail"]
+    assert {record.status for record in repository.list_eval_runs()} == {"passed", "failed"}
+
+    markdown = result.markdown_path.read_text(encoding="utf-8")
+    assert "# Eval Suite Report" in markdown
+    assert "fixture-pass" in markdown
+    assert "fixture-fail" in markdown


### PR DESCRIPTION
## Summary
- add suite-level eval orchestration on top of the existing single-fixture `EvalRunner`
- support running a directory of fixture JSON files through `python -m app.main eval <fixture-dir>`
- write aggregate suite JSON/Markdown reports with pass/fail counts, average score, runtime, token totals, and per-fixture artifact links
- document directory suite runs in the eval runner guide

## Testing
- `python -m pytest tests/unit/test_eval_suite.py -q` (red first, failed on missing `app.evals.suite`)
- `python -m pytest tests/unit/test_eval_suite.py tests/unit/test_eval_runner.py tests/unit/test_eval_fixtures.py tests/unit/test_main.py -q`
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m pytest -q`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `git diff --check`

## Notes
This reuses the existing fixture schema and per-fixture reports instead of creating a parallel eval framework. Directory runs fail the command if any fixture fails or errors.

## Reference
Closes #98