### PR TITLE
ML-308 / Add deterministic eval baseline runner

### DIFF
--- a/app/evals/__init__.py
+++ b/app/evals/__init__.py
@@ -1,6 +1,6 @@
 """Evaluation package for reproducible agent tasks."""
 
-from app.evals.runner import EvalFixture, EvalRunner, EvalRunResult, load_fixture
+from app.evals.runner import EvalFixture, EvalRunner, EvalRunResult, load_fixture, run_scripted_fixture
 from app.evals.suite import EvalSuiteRunner, EvalSuiteRunResult, discover_fixture_paths
 
 __all__ = [
@@ -11,4 +11,5 @@ __all__ = [
     "EvalSuiteRunResult",
     "discover_fixture_paths",
     "load_fixture",
+    "run_scripted_fixture",
 ]

--- a/app/evals/runner.py
+++ b/app/evals/runner.py
@@ -38,6 +38,8 @@ class EvalFixture:
     prompt: str
     name: str | None = None
     workspace_files: list[EvalFile] = field(default_factory=list)
+    solution_files: list[EvalFile] = field(default_factory=list)
+    solution_response: str | None = None
     checks: list[EvalCheck] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -195,6 +197,26 @@ async def run_agent_fixture(
     }
 
 
+async def run_scripted_fixture(
+    fixture: EvalFixture,
+    workspace_path: Path,
+    _settings: AppSettings,
+    _session: SessionRecord,
+) -> dict[str, Any]:
+    """Deterministic fixture executor that applies declared solution files."""
+    for file in fixture.solution_files:
+        target = _resolve_workspace_file(workspace_path, file.path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(file.content, encoding="utf-8")
+
+    return {
+        "content": fixture.solution_response or "Scripted eval fixture completed.",
+        "mode": "scripted",
+        "workspace_path": str(workspace_path),
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
 def load_fixture(path: Path) -> EvalFixture:
     raw = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
@@ -210,6 +232,8 @@ def fixture_from_dict(raw: dict[str, Any]) -> EvalFixture:
         name=_optional_str(raw.get("name")),
         prompt=prompt,
         workspace_files=_parse_files(raw.get("workspace_files", raw.get("files", []))),
+        solution_files=_parse_files(raw.get("solution_files", [])),
+        solution_response=_optional_str(raw.get("solution_response")),
         checks=_parse_checks(raw.get("checks", [])),
         metadata=raw.get("metadata", {}) if isinstance(raw.get("metadata", {}), dict) else {},
     )

--- a/app/main.py
+++ b/app/main.py
@@ -145,6 +145,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print the persisted eval report JSON instead of a short summary",
     )
+    eval_parser.add_argument(
+        "--agent-mode",
+        choices=["live", "scripted"],
+        default="live",
+        help="Executor for eval fixtures: live agent turn or scripted fixture-declared outputs",
+    )
 
     return parser
 
@@ -390,11 +396,15 @@ async def cmd_reject(args: argparse.Namespace, settings: AppSettings) -> int:
 
 async def cmd_eval(args: argparse.Namespace, settings: AppSettings) -> int:
     """Execute the 'eval' command."""
-    from app.evals import EvalRunner, EvalSuiteRunner, discover_fixture_paths, load_fixture
+    from app.evals import EvalRunner, EvalSuiteRunner, discover_fixture_paths, load_fixture, run_scripted_fixture
 
     fixture_paths = discover_fixture_paths(args.fixture)
+    agent_runner = run_scripted_fixture if args.agent_mode == "scripted" else None
     if len(fixture_paths) > 1 or args.fixture.resolve().is_dir():
-        suite_result = await EvalSuiteRunner(settings).run_fixture_paths(fixture_paths, output_dir=args.output_dir)
+        suite_result = await EvalSuiteRunner(settings, agent_runner=agent_runner).run_fixture_paths(
+            fixture_paths,
+            output_dir=args.output_dir,
+        )
         if args.json:
             print(suite_result.report_json)
         else:
@@ -407,7 +417,7 @@ async def cmd_eval(args: argparse.Namespace, settings: AppSettings) -> int:
         return 0 if suite_result.status == "passed" else 1
 
     fixture = load_fixture(fixture_paths[0])
-    runner = EvalRunner(settings)
+    runner = EvalRunner(settings, agent_runner=agent_runner)
     result = await runner.run_fixture(fixture, output_dir=args.output_dir)
 
     if args.json:

--- a/docs/phase-3-eval-runner.md
+++ b/docs/phase-3-eval-runner.md
@@ -12,6 +12,7 @@ The runner executes JSON task fixtures with:
 
 - a clean workspace rendered from fixture files
 - one agent turn against the fixture prompt
+- an optional scripted baseline that applies fixture-declared solution files
 - deterministic scoring checks
 - persisted `eval_runs` records
 - JSON and Markdown artifacts for each run
@@ -29,6 +30,13 @@ The runner executes JSON task fixtures with:
       "content": "# Sample project\n"
     }
   ],
+  "solution_files": [
+    {
+      "path": "summary.md",
+      "content": "# Summary\n\nSample project summary.\n"
+    }
+  ],
+  "solution_response": "Wrote summary.md.",
   "checks": [
     {
       "type": "contains",
@@ -47,6 +55,10 @@ The runner executes JSON task fixtures with:
 }
 ```
 
+`solution_files` and `solution_response` are used only by scripted eval mode.
+They provide a deterministic baseline for fixture plumbing, scoring, and suite
+reporting without requiring a live LLM or API key.
+
 Supported check types:
 
 - `contains`: final agent response includes `value`
@@ -62,10 +74,22 @@ Run an eval fixture:
 python -m app.main eval path/to/fixture.json
 ```
 
+Run an eval fixture with deterministic fixture-declared outputs:
+
+```bash
+python -m app.main eval path/to/fixture.json --agent-mode scripted
+```
+
 Run every fixture in a directory as a suite:
 
 ```bash
 python -m app.main eval tests/fixtures/evals
+```
+
+Run every bundled fixture as a deterministic scripted suite:
+
+```bash
+python -m app.main eval tests/fixtures/evals --agent-mode scripted
 ```
 
 Use a custom artifact directory:

--- a/tests/fixtures/evals/ml-201-dataset-validation.json
+++ b/tests/fixtures/evals/ml-201-dataset-validation.json
@@ -12,6 +12,13 @@
       "content": "from pathlib import Path\n\n\ndef main() -> None:\n    data_path = Path('data/train.csv')\n    print(f'Validating {data_path}')\n\n\nif __name__ == '__main__':\n    main()\n"
     }
   ],
+  "solution_files": [
+    {
+      "path": "dataset_report.md",
+      "content": "# Dataset Report\n\n- rows: 3\n- missing values: 1\n\nThe training data has three rows and one missing feature_b value.\n"
+    }
+  ],
+  "solution_response": "Wrote dataset_report.md with row and missing value findings.",
   "checks": [
     {
       "type": "file_exists",

--- a/tests/fixtures/evals/ml-201-eval-script.json
+++ b/tests/fixtures/evals/ml-201-eval-script.json
@@ -16,6 +16,17 @@
       "content": "import json\nfrom pathlib import Path\n\n\ndef main() -> None:\n    predictions = json.loads(Path('predictions.json').read_text(encoding='utf-8'))\n    references = json.loads(Path('references.json').read_text(encoding='utf-8'))\n    print(len(predictions), len(references))\n\n\nif __name__ == '__main__':\n    main()\n"
     }
   ],
+  "solution_files": [
+    {
+      "path": "evaluate.py",
+      "content": "import json\nfrom pathlib import Path\n\n\ndef main() -> None:\n    predictions = json.loads(Path('predictions.json').read_text(encoding='utf-8'))\n    references = json.loads(Path('references.json').read_text(encoding='utf-8'))\n    correct = sum(pred == ref for pred, ref in zip(predictions, references))\n    accuracy = correct / len(references) if references else 0.0\n    Path('eval_report.json').write_text(json.dumps({'accuracy': accuracy}, indent=2) + '\\n', encoding='utf-8')\n\n\nif __name__ == '__main__':\n    main()\n"
+    },
+    {
+      "path": "eval_report.json",
+      "content": "{\n  \"accuracy\": 0.6666666666666666\n}\n"
+    }
+  ],
+  "solution_response": "Implemented accuracy calculation and wrote eval_report.json.",
   "checks": [
     {
       "type": "file_contains",

--- a/tests/fixtures/evals/ml-201-model-card-inference.json
+++ b/tests/fixtures/evals/ml-201-model-card-inference.json
@@ -8,6 +8,13 @@
       "content": "# Model Card\n\n## Overview\nA small text classifier.\n\n## Training\nTrained on a toy dataset.\n"
     }
   ],
+  "solution_files": [
+    {
+      "path": "model_card.md",
+      "content": "# Model Card\n\n## Overview\nA small text classifier.\n\n## Training\nTrained on a toy dataset.\n\n## Inference\nCall the model with a text input and read the predicted label from the returned output.\n\n## Safety\nValidate model outputs before using them in user-facing workflows.\n"
+    }
+  ],
+  "solution_response": "Added inference usage notes and a Safety section to model_card.md.",
   "checks": [
     {
       "type": "file_contains",

--- a/tests/fixtures/evals/ml-201-repo-analysis.json
+++ b/tests/fixtures/evals/ml-201-repo-analysis.json
@@ -16,6 +16,13 @@
       "content": "def tool() -> str:\n    return 'tool'\n"
     }
   ],
+  "solution_files": [
+    {
+      "path": "analysis.md",
+      "content": "# Repository Analysis\n\nThe architecture is a small Python app with source code under app/ and documentation in README.md.\n\nThe main entrypoint is app/main.py, which currently prints a greeting.\n\nNext risks include adding tests, dependency metadata, and clearer tool boundaries.\n"
+    }
+  ],
+  "solution_response": "Wrote analysis.md with architecture, entrypoint, and risk notes.",
   "checks": [
     {
       "type": "file_exists",

--- a/tests/fixtures/evals/ml-201-training-script-fix.json
+++ b/tests/fixtures/evals/ml-201-training-script-fix.json
@@ -12,6 +12,17 @@
       "content": "# Training task\n\nThe script should accept `--epochs` and `--output`.\n"
     }
   ],
+  "solution_files": [
+    {
+      "path": "train.py",
+      "content": "import argparse\nfrom pathlib import Path\n\n\ndef main() -> None:\n    parser = argparse.ArgumentParser()\n    parser.add_argument('--epochs', type=int, required=True)\n    parser.add_argument('--output', required=True)\n    args = parser.parse_args()\n    Path(args.output).mkdir(parents=True, exist_ok=True)\n    Path('training_report.md').write_text(f'Training completed for {args.epochs} epochs.\\n', encoding='utf-8')\n\n\nif __name__ == '__main__':\n    main()\n"
+    },
+    {
+      "path": "training_report.md",
+      "content": "Training completed for 3 epochs.\n"
+    }
+  ],
+  "solution_response": "Updated train.py argument parsing and wrote training_report.md.",
   "checks": [
     {
       "type": "file_contains",

--- a/tests/unit/test_eval_runner.py
+++ b/tests/unit/test_eval_runner.py
@@ -8,13 +8,64 @@ from pathlib import Path
 import pytest
 
 from app.config import AppPaths, AppSettings
-from app.evals.runner import EvalFixture, EvalRunner, fixture_from_dict, load_fixture
+from app.evals.runner import EvalFixture, EvalRunner, fixture_from_dict, load_fixture, run_scripted_fixture
 from app.storage.models import SessionRecord
 from app.storage.repository import SQLiteRepository
 
 
 def _settings(tmp_path: Path) -> AppSettings:
     return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_scripted_fixture_writes_declared_solution_files(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    fixture = fixture_from_dict(
+        {
+            "id": "fixture-scripted",
+            "prompt": "Create the report",
+            "workspace_files": [{"path": "input.txt", "content": "seed\n"}],
+            "solution_files": [{"path": "report.md", "content": "done\n"}],
+            "solution_response": "scripted completion",
+            "checks": [
+                {"type": "contains", "value": "scripted completion"},
+                {"type": "file_contains", "path": "report.md", "value": "done"},
+            ],
+        }
+    )
+
+    result = await EvalRunner(settings, agent_runner=run_scripted_fixture).run_fixture(
+        fixture,
+        output_dir=tmp_path / "eval-output",
+    )
+    report = json.loads(result.record.report_json)
+
+    assert result.record.status == "passed"
+    assert result.record.score == 1.0
+    assert (result.workspace_path / "report.md").read_text(encoding="utf-8") == "done\n"
+    assert report["agent_output"]["mode"] == "scripted"
+    assert report["scoring"]["token_usage"]["total_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scripted_fixture_rejects_solution_paths_that_escape_workspace(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    fixture = fixture_from_dict(
+        {
+            "id": "fixture-scripted-escape",
+            "prompt": "Create the report",
+            "solution_files": [{"path": "../outside.txt", "content": "bad\n"}],
+        }
+    )
+
+    result = await EvalRunner(settings, agent_runner=run_scripted_fixture).run_fixture(
+        fixture,
+        output_dir=tmp_path / "eval-output",
+    )
+    report = json.loads(result.record.report_json)
+
+    assert result.record.status == "error"
+    assert "escapes workspace" in report["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_eval_suite.py
+++ b/tests/unit/test_eval_suite.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from app.config import AppPaths, AppSettings
-from app.evals.runner import EvalFixture
+from app.evals.runner import EvalFixture, run_scripted_fixture
 from app.evals.suite import EvalSuiteRunner, discover_fixture_paths
 from app.storage.models import SessionRecord
 from app.storage.repository import SQLiteRepository
@@ -92,3 +92,20 @@ async def test_eval_suite_runner_writes_aggregate_reports(tmp_path: Path) -> Non
     assert "# Eval Suite Report" in markdown
     assert "fixture-pass" in markdown
     assert "fixture-fail" in markdown
+
+
+@pytest.mark.asyncio
+async def test_bundled_eval_fixtures_pass_with_scripted_runner(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    fixture_dir = Path(__file__).resolve().parents[1] / "fixtures" / "evals"
+
+    result = await EvalSuiteRunner(settings, agent_runner=run_scripted_fixture).run_path(
+        fixture_dir,
+        output_dir=tmp_path / "eval-output",
+    )
+
+    assert result.status == "passed"
+    assert result.score == 1.0
+    assert result.report["summary"]["fixtures_total"] == 5
+    assert result.report["summary"]["fixtures_passed"] == 5
+    assert result.report["summary"]["total_tokens"] == 0

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -11,11 +11,12 @@ def test_build_parser_uses_project_name() -> None:
 def test_build_parser_accepts_eval_command() -> None:
     parser = build_parser()
 
-    args = parser.parse_args(["eval", "fixtures/basic.json", "--json"])
+    args = parser.parse_args(["eval", "fixtures/basic.json", "--json", "--agent-mode", "scripted"])
 
     assert args.command == "eval"
     assert str(args.fixture) == "fixtures\\basic.json" or str(args.fixture) == "fixtures/basic.json"
     assert args.json is True
+    assert args.agent_mode == "scripted"
 
 
 def test_format_layout_includes_expected_directories() -> None:


### PR DESCRIPTION
## Summary

- add a scripted/offline eval executor that applies fixture-declared `solution_files` and `solution_response`
- expose `python -m app.main eval ... --agent-mode scripted` for single-fixture and directory suite runs
- seed deterministic scripted outputs for all five bundled eval fixtures and document the mode

## Validation

- Red run: `python -m pytest tests/unit/test_eval_runner.py tests/unit/test_eval_suite.py tests/unit/test_main.py -q` failed on missing `run_scripted_fixture`
- `python -m pytest tests/unit/test_eval_runner.py tests/unit/test_eval_suite.py tests/unit/test_main.py -q` (`17 passed`)
- `python -m app.main eval tests/fixtures/evals --agent-mode scripted --output-dir .ml-copilot/evals-ml-308-smoke` (`5/5` fixtures passed, score `1.0`)
- `python -m pytest -q` (`246 passed`)
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `git diff --check`

## Reference

Closes #100