### PR TITLE
ML-401 / Upgrade tool trace visualization cards

### DIFF
--- a/frontend/src/components/ToolTracePanel.test.tsx
+++ b/frontend/src/components/ToolTracePanel.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import ToolTracePanel from './ToolTracePanel';
+import type { SessionEventPayload, ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'tool-call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-06-30T06:00:00Z',
+    finished_at: '2026-06-30T06:02:05Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+function liveEvent(overrides: Partial<SessionEventPayload>): SessionEventPayload {
+  return {
+    id: 'event-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    event_type: 'tool_call_started',
+    data: {},
+    sequence: 1,
+    created_at: '2026-06-30T06:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ToolTracePanel', () => {
+  it('renders categorized tool cards with summarized output and expandable raw details', async () => {
+    const user = userEvent.setup();
+    const longLog = `${'training log line\n'.repeat(40)}final validation accuracy: 0.91`;
+
+    render(
+      <ToolTracePanel
+        metrics={{
+          session_id: 'session-1',
+          turn_count: 1,
+          prompt_tokens: 1200,
+          completion_tokens: 700,
+          total_tokens: 1900,
+          estimated_cost_usd: 0.0432,
+          tool_calls: 3,
+          tool_errors: 1,
+          tool_retries: 0,
+          tool_latency_ms: 125000,
+          average_tool_latency_ms: 41666,
+          error_count: 1,
+          last_updated_at: '2026-06-30T06:03:00Z',
+        }}
+        pendingApprovals={[]}
+        liveEvents={[
+          liveEvent({
+            id: 'event-job',
+            event_type: 'tool_call_started',
+            data: { tool_name: 'manage_job', operation: 'run' },
+            sequence: 7,
+          }),
+        ]}
+        toolCalls={[
+          toolCall({
+            id: 'job-call',
+            tool_name: 'manage_job',
+            arguments: { operation: 'run', hardware: 'cpu-basic', timeout_seconds: 600 },
+            output: [
+              'Job hf-job-123 started.',
+              'Status: RUNNING',
+              'Hardware: cpu-basic',
+              'URL: https://huggingface.co/jobs/hf-job-123',
+              longLog,
+            ].join('\n'),
+          }),
+          toolCall({
+            id: 'sandbox-call',
+            tool_name: 'experiment_workspace',
+            arguments: { operation: 'run', command: 'python train.py' },
+            status: 'failed',
+            success: false,
+            error: 'Command failed with CUDA out of memory while training.',
+          }),
+          toolCall({
+            id: 'publish-call',
+            tool_name: 'publish_model_report',
+            arguments: { output_dir: '.ml-copilot/reports/model-a' },
+            output: 'Prepared README.md, FINAL_REPORT.md, and publish_manifest.json.',
+          }),
+        ]}
+      />,
+    );
+
+    const jobCard = screen.getByTestId('tool-card-job-call');
+    expect(within(jobCard).getByText('Job orchestration')).toBeInTheDocument();
+    expect(within(jobCard).getByText('Hugging Face job')).toBeInTheDocument();
+    expect(within(jobCard).getByText('RUNNING')).toBeInTheDocument();
+    expect(within(jobCard).getByText('cpu-basic')).toBeInTheDocument();
+    expect(within(jobCard).getByRole('link', { name: 'Open job' })).toHaveAttribute(
+      'href',
+      'https://huggingface.co/jobs/hf-job-123',
+    );
+    expect(within(jobCard).queryByText(/final validation accuracy/)).not.toBeInTheDocument();
+
+    await user.click(within(jobCard).getByRole('button', { name: 'Show details for Hugging Face job' }));
+
+    expect(within(jobCard).getByText(/final validation accuracy: 0\.91/)).toBeInTheDocument();
+    expect(within(jobCard).getByText(/"timeout_seconds": 600/)).toBeInTheDocument();
+
+    const sandboxCard = screen.getByTestId('tool-card-sandbox-call');
+    expect(within(sandboxCard).getByText('Sandbox runtime')).toBeInTheDocument();
+    expect(within(sandboxCard).getByText('Command failed with CUDA out of memory while training.')).toBeInTheDocument();
+
+    const publishCard = screen.getByTestId('tool-card-publish-call');
+    expect(within(publishCard).getByText('Publishing')).toBeInTheDocument();
+    expect(within(publishCard).getByText('.ml-copilot/reports/model-a')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ToolTracePanel.tsx
+++ b/frontend/src/components/ToolTracePanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import type {
   PendingApprovalPayload,
   SessionEventPayload,
@@ -11,6 +12,23 @@ interface ToolTracePanelProps {
   metrics: SessionMetricsSummary | null;
   toolCalls: ToolCallPayload[];
 }
+
+interface ToolMetadataItem {
+  label: string;
+  value: string;
+  href?: string;
+  linkLabel?: string;
+}
+
+interface ToolProfile {
+  category: string;
+  title: string;
+  description: string;
+  icon: string;
+  metadata: ToolMetadataItem[];
+}
+
+const PREVIEW_LIMIT = 520;
 
 function shortId(value: string) {
   return value.slice(0, 8);
@@ -32,6 +50,21 @@ function formatArgs(args: Record<string, unknown>) {
     .slice(0, 3)
     .map(([key, value]) => `${key}: ${formatValue(value)}`)
     .join(' | ');
+}
+
+function safeStringify(value: unknown) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function sentenceCase(value: string) {
+  return value
+    .replace(/^mcp__[^_]+__/, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 function formatDuration(startedAt: string | null, finishedAt: string | null) {
@@ -61,7 +94,7 @@ function eventSummary(event: SessionEventPayload) {
   const error = event.data.error;
   if (typeof error === 'string' && error.trim()) return error;
 
-  const tool = event.data.tool;
+  const tool = event.data.tool ?? event.data.tool_name;
   if (typeof tool === 'string' && tool.trim()) return tool;
 
   return JSON.stringify(event.data);
@@ -114,6 +147,261 @@ function groupToolCalls(toolCalls: ToolCallPayload[]) {
   }
 
   return groups;
+}
+
+function textOutput(call: ToolCallPayload) {
+  return firstNonEmptyText(call.error, call.output);
+}
+
+function previewText(value: string) {
+  if (value.length <= PREVIEW_LIMIT) {
+    return { text: value, truncated: false };
+  }
+  return { text: `${value.slice(0, PREVIEW_LIMIT).trimEnd()}\n...`, truncated: true };
+}
+
+function getArgText(args: Record<string, unknown>, key: string) {
+  const value = args[key];
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+}
+
+function matchLine(text: string | null | undefined, pattern: RegExp) {
+  if (!text) return null;
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(pattern);
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+  return null;
+}
+
+function firstUrl(text: string | null | undefined) {
+  return text?.match(/https?:\/\/[^\s)]+/)?.[0] ?? null;
+}
+
+function addMetadata(items: ToolMetadataItem[], item: ToolMetadataItem | null) {
+  if (!item) return;
+  if (!item.value.trim()) return;
+  if (items.some((existing) => existing.label === item.label && existing.value === item.value)) return;
+  items.push(item);
+}
+
+function buildToolProfile(call: ToolCallPayload): ToolProfile {
+  const args = call.arguments;
+  const output = textOutput(call);
+  const metadata: ToolMetadataItem[] = [];
+  const operation = getArgText(args, 'operation');
+
+  if (operation) {
+    addMetadata(metadata, { label: 'Operation', value: operation });
+  }
+
+  switch (call.tool_name) {
+    case 'manage_job': {
+      const status = matchLine(output, /^Status:\s*(.+)$/i);
+      const hardware = getArgText(args, 'hardware') ?? matchLine(output, /^Hardware:\s*(.+)$/i);
+      const jobId = getArgText(args, 'job_id') ?? matchLine(output, /^Job(?: ID)?:\s*(.+)$/i);
+      const url = firstUrl(output);
+
+      if (status) addMetadata(metadata, { label: 'Status', value: status });
+      if (hardware) addMetadata(metadata, { label: 'Hardware', value: hardware });
+      if (jobId) addMetadata(metadata, { label: 'Job', value: jobId });
+      if (url) addMetadata(metadata, { label: 'Link', value: url, href: url, linkLabel: 'Open job' });
+
+      return {
+        category: 'Job orchestration',
+        title: 'Hugging Face job',
+        description: 'Run, inspect, stream logs, or cancel long-running Hugging Face Jobs.',
+        icon: '⚙️',
+        metadata,
+      };
+    }
+    case 'experiment_workspace': {
+      const path = getArgText(args, 'path') ?? getArgText(args, 'workspace_path');
+      const command = getArgText(args, 'command');
+      const sandboxId = getArgText(args, 'sandbox_id');
+
+      if (command) addMetadata(metadata, { label: 'Command', value: command });
+      if (path) addMetadata(metadata, { label: 'Path', value: path });
+      if (sandboxId) addMetadata(metadata, { label: 'Sandbox', value: sandboxId });
+
+      return {
+        category: 'Sandbox runtime',
+        title: 'Experiment workspace',
+        description: 'Create, inspect, run, and tear down sandboxed experiment workspaces.',
+        icon: '🧪',
+        metadata,
+      };
+    }
+    case 'manage_experiment_loop': {
+      const targetMetric = getArgText(args, 'target_metric');
+      const maxAttempts = getArgText(args, 'max_attempts');
+
+      if (targetMetric) addMetadata(metadata, { label: 'Target', value: targetMetric });
+      if (maxAttempts) addMetadata(metadata, { label: 'Max attempts', value: maxAttempts });
+
+      return {
+        category: 'Experiment loop',
+        title: 'Autonomous experiment loop',
+        description: 'Track attempts, diagnose failures, and decide the next ML experiment action.',
+        icon: '🔁',
+        metadata,
+      };
+    }
+    case 'publish_model_report': {
+      const outputDir = getArgText(args, 'output_dir');
+      const repoId = getArgText(args, 'repo_id');
+
+      if (outputDir) addMetadata(metadata, { label: 'Output', value: outputDir });
+      if (repoId) addMetadata(metadata, { label: 'Repository', value: repoId });
+
+      return {
+        category: 'Publishing',
+        title: 'Model report',
+        description: 'Prepare model cards, final reports, manifests, and optional Hub publishing.',
+        icon: '🚀',
+        metadata,
+      };
+    }
+    case 'hf_papers':
+      addMetadata(metadata, { label: 'Query', value: getArgText(args, 'query') ?? getArgText(args, 'arxiv_id') ?? '' });
+      return {
+        category: 'Research',
+        title: 'Paper search',
+        description: 'Search, inspect, and connect papers, citations, datasets, and models.',
+        icon: '📄',
+        metadata,
+      };
+    case 'fetch_hf_docs':
+    case 'explore_hf_docs':
+    case 'find_hf_api':
+      addMetadata(metadata, { label: 'Topic', value: getArgText(args, 'query') ?? getArgText(args, 'url') ?? '' });
+      return {
+        category: 'Documentation',
+        title: sentenceCase(call.tool_name),
+        description: 'Read Hugging Face documentation and API guidance.',
+        icon: '📚',
+        metadata,
+      };
+    case 'hf_inspect_dataset':
+    case 'hf_repo_files':
+    case 'hf_search_hub':
+      addMetadata(metadata, {
+        label: 'Resource',
+        value: getArgText(args, 'dataset') ?? getArgText(args, 'repo_id') ?? getArgText(args, 'query') ?? '',
+      });
+      return {
+        category: 'Hub operation',
+        title: sentenceCase(call.tool_name),
+        description: 'Inspect Hugging Face Hub resources and repository metadata.',
+        icon: '🤗',
+        metadata,
+      };
+    case 'analyze_repository':
+      addMetadata(metadata, { label: 'Path', value: getArgText(args, 'path') ?? '' });
+      return {
+        category: 'Repository analysis',
+        title: 'Repository analyzer',
+        description: 'Review project files, ML structure, dependency gaps, and reproducibility signals.',
+        icon: '🧭',
+        metadata,
+      };
+    default:
+      return {
+        category: call.tool_name.startsWith('mcp__') ? 'External integration' : 'Workspace tool',
+        title: sentenceCase(call.tool_name),
+        description: 'Tool call captured from the persisted session trace.',
+        icon: '🛠️',
+        metadata,
+      };
+  }
+}
+
+function ToolCallCard({ call }: { call: ToolCallPayload }) {
+  const [expanded, setExpanded] = useState(false);
+  const profile = useMemo(() => buildToolProfile(call), [call]);
+  const duration = formatDuration(call.started_at, call.finished_at);
+  const resultText = textOutput(call) ?? 'Waiting for output';
+  const resultPreview = previewText(resultText);
+  const resultLabel = call.success === false || call.error ? 'Error' : 'Output';
+  const statusTone = toneForStatus(call.status);
+  const showDetails = expanded || resultPreview.truncated || Object.keys(call.arguments).length > 0;
+
+  return (
+    <article className={`tool-card ${statusTone}`} data-testid={`tool-card-${call.id}`}>
+      <div className="tool-card-head">
+        <div className="tool-card-title-row">
+          <span className="tool-card-icon" aria-hidden="true">
+            {profile.icon}
+          </span>
+          <div>
+            <span className="tool-card-category">{profile.category}</span>
+            <h5>{profile.title}</h5>
+            <p>{profile.description}</p>
+          </div>
+        </div>
+        <span className={`status-chip ${statusTone}`}>{call.status}</span>
+      </div>
+
+      {profile.metadata.length ? (
+        <dl className="tool-card-metadata">
+          {profile.metadata.map((item) => (
+            <div key={`${item.label}-${item.value}`}>
+              <dt>{item.label}</dt>
+              <dd>
+                {item.href ? (
+                  <a href={item.href} rel="noopener noreferrer" target="_blank">
+                    {item.linkLabel ?? item.value}
+                  </a>
+                ) : (
+                  item.value
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p className="tool-card-args">{formatArgs(call.arguments)}</p>
+      )}
+
+      <div className={`tool-card-output ${call.success === false || call.error ? 'danger' : ''}`}>
+        <span>{resultLabel}</span>
+        <p>{resultPreview.text}</p>
+      </div>
+
+      <div className="tool-card-meta-row">
+        <span>{call.requires_approval ? 'approval required' : 'no approval required'}</span>
+        {duration ? <span>{duration}</span> : null}
+        {call.approval_id ? <span>approval {shortId(call.approval_id)}</span> : null}
+      </div>
+
+      {showDetails ? (
+        <button
+          className="ghost-button tool-card-details-toggle"
+          type="button"
+          aria-label={`${expanded ? 'Hide' : 'Show'} details for ${profile.title}`}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+      ) : null}
+
+      {expanded ? (
+        <div className="tool-card-details">
+          <div>
+            <span>Arguments</span>
+            <pre>{safeStringify(call.arguments)}</pre>
+          </div>
+          <div>
+            <span>{resultLabel}</span>
+            <pre>{resultText}</pre>
+          </div>
+        </div>
+      ) : null}
+    </article>
+  );
 }
 
 export default function ToolTracePanel({ liveEvents, pendingApprovals, metrics, toolCalls }: ToolTracePanelProps) {
@@ -185,32 +473,9 @@ export default function ToolTracePanel({ liveEvents, pendingApprovals, metrics, 
                 </div>
 
                 <div className="tool-trace-call-list">
-                  {group.calls.map((call) => {
-                    const duration = formatDuration(call.started_at, call.finished_at);
-                    const summary = firstNonEmptyText(call.output, call.error) ?? 'Waiting for output';
-                    return (
-                      <div key={call.id} className="tool-trace-call">
-                        <div className="tool-trace-call-head">
-                          <div>
-                            <strong>{call.tool_name}</strong>
-                            <p>{formatArgs(call.arguments)}</p>
-                          </div>
-                          <span className={`status-chip ${toneForStatus(call.status)}`}>{call.status}</span>
-                        </div>
-
-                        <div className="tool-trace-call-meta">
-                          <span>{call.requires_approval ? 'approval required' : 'no approval required'}</span>
-                          {duration ? <span>{duration}</span> : null}
-                          {call.approval_id ? <span>approval {shortId(call.approval_id)}</span> : null}
-                        </div>
-
-                        <div className="tool-trace-output">
-                          <span>{call.success === false ? 'Error' : 'Output'}</span>
-                          <p>{summary}</p>
-                        </div>
-                      </div>
-                    );
-                  })}
+                  {group.calls.map((call) => (
+                    <ToolCallCard key={call.id} call={call} />
+                  ))}
                 </div>
               </article>
             ))}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -919,6 +919,180 @@ button {
   font-size: 0.76rem;
 }
 
+.tool-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 34%),
+    rgba(3, 7, 18, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.tool-card.success {
+  border-color: rgba(34, 197, 94, 0.24);
+}
+
+.tool-card.warning {
+  border-color: rgba(245, 158, 11, 0.26);
+}
+
+.tool-card.danger {
+  border-color: rgba(248, 113, 113, 0.28);
+}
+
+.tool-card-head,
+.tool-card-title-row,
+.tool-card-meta-row {
+  display: flex;
+  gap: 10px;
+}
+
+.tool-card-head {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.tool-card-title-row {
+  min-width: 0;
+}
+
+.tool-card-icon {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.tool-card-category {
+  display: block;
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.tool-card h5 {
+  margin: 3px 0;
+  font-size: 0.96rem;
+  letter-spacing: -0.02em;
+}
+
+.tool-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.tool-card-metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.tool-card-metadata div {
+  min-width: 0;
+  padding: 9px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.64);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.tool-card-metadata dt {
+  color: var(--muted);
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tool-card-metadata dd {
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-card-metadata a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.tool-card-metadata a:hover {
+  text-decoration: underline;
+}
+
+.tool-card-args {
+  font-family: monospace;
+  font-size: 0.78rem;
+}
+
+.tool-card-output {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.tool-card-output.danger {
+  background: rgba(127, 29, 29, 0.16);
+  border-color: rgba(248, 113, 113, 0.16);
+}
+
+.tool-card-output span,
+.tool-card-details span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.tool-card-output p {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.tool-card-meta-row {
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+.tool-card-details-toggle {
+  justify-self: flex-start;
+}
+
+.tool-card-details {
+  display: grid;
+  gap: 10px;
+}
+
+.tool-card-details pre {
+  max-height: 280px;
+  margin: 0;
+  overflow: auto;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(2, 6, 23, 0.88);
+  color: #dbeafe;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
 .tool-trace-output {
   margin-top: 10px;
   padding-top: 10px;


### PR DESCRIPTION
﻿## Summary
- replace flat tool-call rows with categorized product-grade cards for jobs, sandboxes, experiment loops, publishing, papers, docs, Hub operations, repository analysis, external integrations, and generic workspace tools
- extract useful metadata from persisted tool call arguments/output, including job status, hardware, job links, commands, output directories, resources, and operation names
- summarize long outputs with expandable raw arguments/output details while preserving historical replay from existing ToolCallPayload records
- add frontend regression coverage for categorized cards, safe long-output summarization, links, errors, and details expansion

## Testing
- `npm test -- ToolTracePanel.test.tsx` red first, then green
- `npm test`
- `npm run build`
- `python -m pytest -q`
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `npm audit --omit=dev`
- `git diff --check`

## Notes
This keeps the change frontend-focused and builds on the existing persisted tool-call payloads. Dedicated job progress and artifact panels remain separate Phase 5 tasks.

## Reference
Closes #104
