### PR TITLE
ML-402 / Build dedicated Hugging Face job progress UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
   sendChatMessage,
 } from './api';
 import ApprovalDialog from './components/ApprovalDialog';
+import JobProgressPanel from './components/JobProgressPanel';
 import RichMessageContent from './components/RichMessageContent';
 import SessionSidebar from './components/SessionSidebar';
 import ToolTracePanel from './components/ToolTracePanel';
@@ -485,6 +486,8 @@ function App() {
               resolving={resolvingApproval}
               onResolve={handleResolveApproval}
             />
+
+            <JobProgressPanel toolCalls={toolCalls} />
 
             <ToolTracePanel
               liveEvents={liveEvents}

--- a/frontend/src/components/JobProgressPanel.test.tsx
+++ b/frontend/src/components/JobProgressPanel.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import JobProgressPanel from './JobProgressPanel';
+import type { ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-06-30T06:00:00Z',
+    finished_at: '2026-06-30T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('JobProgressPanel', () => {
+  it('renders persisted Hugging Face job status, logs, actions, and billing hints', () => {
+    render(
+      <JobProgressPanel
+        toolCalls={[
+          toolCall({
+            id: 'run-call',
+            arguments: { operation: 'run', hardware_flavor: 'cpu-basic', timeout: '30m' },
+            output: [
+              '# Job launched',
+              '',
+              '### Job job-123',
+              '- **Status:** RUNNING',
+              '- **Message:** pulling image',
+              '- **Hardware:** cpu-basic',
+              '- **Created:** 2026-06-30T06:00:00Z',
+              '- **Command:** `python train.py`',
+              '- **URL:** https://huggingface.co/jobs/job-123',
+              '',
+              "**Next:** Use manage_job with operation 'inspect', 'logs', or 'cancel'.",
+            ].join('\n'),
+          }),
+          toolCall({
+            id: 'logs-call',
+            arguments: { operation: 'logs', job_id: 'job-123' },
+            output: ['# Logs for job-123', '', '```', 'epoch=1 loss=0.42', 'eval accuracy=0.91', '```'].join('\n'),
+          }),
+          toolCall({
+            id: 'billing-call',
+            arguments: { operation: 'run', hardware_flavor: 'a10g-small', namespace: 'team-space' },
+            status: 'failed',
+            success: false,
+            error:
+              'Error: Hugging Face rejected this run because the namespace has no available credits. Add credits at https://huggingface.co/settings/billing and re-run the job.',
+          }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Hugging Face job progress' });
+    expect(within(panel).getByText('1 active job')).toBeInTheDocument();
+
+    const jobCard = screen.getByTestId('job-progress-job-123');
+    expect(within(jobCard).getByText('RUNNING')).toBeInTheDocument();
+    expect(within(jobCard).getByText('cpu-basic')).toBeInTheDocument();
+    expect(within(jobCard).getByText('2026-06-30T06:00:00Z')).toBeInTheDocument();
+    expect(within(jobCard).getByRole('link', { name: 'Open on Hugging Face' })).toHaveAttribute(
+      'href',
+      'https://huggingface.co/jobs/job-123',
+    );
+
+    expect(within(jobCard).getByText('Launched')).toBeInTheDocument();
+    expect(within(jobCard).getByText('Logs fetched')).toBeInTheDocument();
+    expect(within(jobCard).getByText(/epoch=1 loss=0\.42/)).toBeInTheDocument();
+    expect(within(jobCard).getByText(/eval accuracy=0\.91/)).toBeInTheDocument();
+
+    expect(within(jobCard).getByText("manage_job operation='inspect' job_id='job-123'")).toBeInTheDocument();
+    expect(within(jobCard).getByText("manage_job operation='logs' job_id='job-123'")).toBeInTheDocument();
+    expect(within(jobCard).getByText("manage_job operation='cancel' job_id='job-123'")).toBeInTheDocument();
+
+    expect(within(panel).getByText('Namespace credits needed')).toBeInTheDocument();
+    expect(within(panel).getByRole('link', { name: 'Open HF billing' })).toHaveAttribute(
+      'href',
+      'https://huggingface.co/settings/billing',
+    );
+  });
+});

--- a/frontend/src/components/JobProgressPanel.tsx
+++ b/frontend/src/components/JobProgressPanel.tsx
@@ -1,0 +1,276 @@
+import { useMemo } from 'react';
+import type { ToolCallPayload } from '../types';
+
+interface JobProgressPanelProps {
+  toolCalls: ToolCallPayload[];
+}
+
+interface JobProgress {
+  id: string;
+  status: string;
+  message: string | null;
+  hardware: string | null;
+  createdAt: string | null;
+  command: string | null;
+  url: string | null;
+  logs: string[];
+  timeline: Array<{ label: string; detail: string | null }>;
+}
+
+const ACTIVE_STATUSES = new Set(['QUEUED', 'RUNNING', 'STARTING', 'PENDING']);
+const BILLING_URL = 'https://huggingface.co/settings/billing';
+
+function firstNonEmptyText(...values: Array<string | null | undefined>) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function getArgText(args: Record<string, unknown>, key: string) {
+  const value = args[key];
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+}
+
+function matchLine(text: string | null | undefined, pattern: RegExp) {
+  if (!text) return null;
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(pattern);
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+  return null;
+}
+
+function firstUrl(text: string | null | undefined) {
+  return text?.match(/https?:\/\/[^\s)]+/)?.[0] ?? null;
+}
+
+function parseJobId(call: ToolCallPayload) {
+  const output = firstNonEmptyText(call.output, call.error);
+  return (
+    getArgText(call.arguments, 'job_id') ??
+    matchLine(output, /^### Job\s+(.+)$/i) ??
+    matchLine(output, /^Job\s+([^\s]+)\s+has been cancelled/i) ??
+    matchLine(output, /^# Logs for\s+([^\s(]+)/i) ??
+    matchLine(output, /^Error (?:fetching logs|cancelling job|inspecting job)\s+([^:]+):/i)
+  );
+}
+
+function parseMarkdownBullet(text: string | null | undefined, label: string) {
+  return matchLine(text, new RegExp(`^- \\*\\*${label}:\\*\\*\\s*(.+)$`, 'i'));
+}
+
+function parseLogs(output: string | null | undefined) {
+  if (!output) return [];
+  const fenced = output.match(/```(?:\w+)?\n([\s\S]*?)```/);
+  const body = fenced?.[1] ?? output.replace(/^# Logs for[^\n]*\n*/i, '');
+  return body
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim())
+    .slice(-8);
+}
+
+function isBillingProblem(text: string | null | undefined) {
+  if (!text) return false;
+  const lowered = text.toLowerCase();
+  return (
+    lowered.includes('no available credits') ||
+    lowered.includes('billing') ||
+    lowered.includes('quota') ||
+    lowered.includes('payment required') ||
+    lowered.includes('402')
+  );
+}
+
+function upsertJob(jobs: Map<string, JobProgress>, jobId: string): JobProgress {
+  const current = jobs.get(jobId);
+  if (current) return current;
+
+  const next: JobProgress = {
+    id: jobId,
+    status: 'UNKNOWN',
+    message: null,
+    hardware: null,
+    createdAt: null,
+    command: null,
+    url: null,
+    logs: [],
+    timeline: [],
+  };
+  jobs.set(jobId, next);
+  return next;
+}
+
+function addTimeline(job: JobProgress, label: string, detail: string | null = null) {
+  if (job.timeline.some((item) => item.label === label && item.detail === detail)) return;
+  job.timeline.push({ label, detail });
+}
+
+function buildJobs(toolCalls: ToolCallPayload[]) {
+  const jobs = new Map<string, JobProgress>();
+  const billingProblems: string[] = [];
+
+  for (const call of toolCalls) {
+    if (call.tool_name !== 'manage_job') continue;
+
+    const output = firstNonEmptyText(call.output, call.error);
+    if (isBillingProblem(output)) {
+      billingProblems.push(output ?? 'Hugging Face Jobs need namespace credits before this run can continue.');
+    }
+
+    const jobId = parseJobId(call);
+    if (!jobId) continue;
+
+    const job = upsertJob(jobs, jobId);
+    const operation = getArgText(call.arguments, 'operation')?.toLowerCase();
+    const status = parseMarkdownBullet(output, 'Status');
+    const message = parseMarkdownBullet(output, 'Message');
+    const hardware = getArgText(call.arguments, 'hardware_flavor') ?? parseMarkdownBullet(output, 'Hardware');
+    const createdAt = parseMarkdownBullet(output, 'Created');
+    const command = parseMarkdownBullet(output, 'Command')?.replace(/^`|`$/g, '');
+    const url = firstUrl(output);
+
+    if (status) job.status = status.toUpperCase();
+    if (message) job.message = message;
+    if (hardware) job.hardware = hardware;
+    if (createdAt) job.createdAt = createdAt;
+    if (command) job.command = command;
+    if (url) job.url = url;
+
+    if (operation === 'run') addTimeline(job, 'Launched', call.finished_at);
+    if (operation === 'inspect') addTimeline(job, 'Inspected', call.finished_at);
+    if (operation === 'logs') {
+      addTimeline(job, 'Logs fetched', call.finished_at);
+      job.logs = parseLogs(call.output);
+    }
+    if (operation === 'cancel') {
+      job.status = 'CANCELLED';
+      addTimeline(job, 'Cancel requested', call.finished_at);
+    }
+  }
+
+  return {
+    jobs: [...jobs.values()].sort((a, b) => a.id.localeCompare(b.id)),
+    billingProblem: billingProblems[0] ?? null,
+  };
+}
+
+function statusTone(status: string) {
+  if (status === 'COMPLETED') return 'success';
+  if (status === 'FAILED' || status === 'ERROR' || status === 'CANCELLED') return 'danger';
+  if (ACTIVE_STATUSES.has(status)) return 'warning';
+  return 'neutral';
+}
+
+function actionText(operation: 'inspect' | 'logs' | 'cancel', jobId: string) {
+  return `manage_job operation='${operation}' job_id='${jobId}'`;
+}
+
+export default function JobProgressPanel({ toolCalls }: JobProgressPanelProps) {
+  const { jobs, billingProblem } = useMemo(() => buildJobs(toolCalls), [toolCalls]);
+  const activeCount = jobs.filter((job) => ACTIVE_STATUSES.has(job.status)).length;
+
+  return (
+    <section className="job-progress-panel" aria-label="Hugging Face job progress">
+      <div className="job-progress-header">
+        <div>
+          <p className="panel-label">HF Jobs</p>
+          <h3>Job progress</h3>
+          <p className="muted">Recovered from persisted manage_job calls, so job state remains visible after refresh.</p>
+        </div>
+        <span className={`status-chip ${activeCount > 0 ? 'warning' : 'neutral'}`}>
+          {activeCount} active job{activeCount === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {billingProblem ? (
+        <div className="job-billing-alert">
+          <strong>Namespace credits needed</strong>
+          <p>
+            HF Jobs use namespace credits, which are separate from HF Pro membership. Add credits, then re-run the job.
+          </p>
+          <a href={BILLING_URL} rel="noopener noreferrer" target="_blank">
+            Open HF billing
+          </a>
+        </div>
+      ) : null}
+
+      {jobs.length === 0 ? (
+        <p className="muted">Hugging Face Jobs will appear here after manage_job launches, inspects, logs, or cancels a run.</p>
+      ) : (
+        <div className="job-progress-list">
+          {jobs.map((job) => (
+            <article key={job.id} className="job-progress-card" data-testid={`job-progress-${job.id}`}>
+              <div className="job-progress-card-head">
+                <div>
+                  <span className="tool-card-category">Hugging Face job</span>
+                  <h4>{job.id}</h4>
+                  {job.message ? <p>{job.message}</p> : null}
+                </div>
+                <span className={`status-chip ${statusTone(job.status)}`}>{job.status}</span>
+              </div>
+
+              <dl className="job-progress-metadata">
+                {job.hardware ? (
+                  <div>
+                    <dt>Hardware</dt>
+                    <dd>{job.hardware}</dd>
+                  </div>
+                ) : null}
+                {job.createdAt ? (
+                  <div>
+                    <dt>Created</dt>
+                    <dd>{job.createdAt}</dd>
+                  </div>
+                ) : null}
+                {job.command ? (
+                  <div>
+                    <dt>Command</dt>
+                    <dd>{job.command}</dd>
+                  </div>
+                ) : null}
+                {job.url ? (
+                  <div>
+                    <dt>Destination</dt>
+                    <dd>
+                      <a href={job.url} rel="noopener noreferrer" target="_blank">
+                        Open on Hugging Face
+                      </a>
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+
+              <div className="job-progress-timeline" aria-label={`Timeline for ${job.id}`}>
+                {job.timeline.map((item) => (
+                  <div key={`${item.label}-${item.detail ?? ''}`}>
+                    <span aria-hidden="true" />
+                    <p>{item.label}</p>
+                    {item.detail ? <small>{item.detail}</small> : null}
+                  </div>
+                ))}
+              </div>
+
+              {job.logs.length ? (
+                <div className="job-progress-logs">
+                  <span>Latest logs</span>
+                  <pre>{job.logs.join('\n')}</pre>
+                </div>
+              ) : null}
+
+              <div className="job-progress-actions" aria-label={`Safe actions for ${job.id}`}>
+                <code>{actionText('inspect', job.id)}</code>
+                <code>{actionText('logs', job.id)}</code>
+                {ACTIVE_STATUSES.has(job.status) ? <code>{actionText('cancel', job.id)}</code> : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1093,6 +1093,180 @@ button {
   white-space: pre-wrap;
 }
 
+.job-progress-panel {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  border-radius: 20px;
+  background:
+    radial-gradient(circle at top right, rgba(96, 165, 250, 0.14), transparent 38%),
+    rgba(8, 15, 28, 0.9);
+}
+
+.job-progress-header,
+.job-progress-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.job-progress-header h3,
+.job-progress-card-head h4 {
+  margin: 4px 0;
+  letter-spacing: -0.03em;
+}
+
+.job-billing-alert {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid rgba(245, 158, 11, 0.24);
+  border-radius: 16px;
+  background: rgba(120, 53, 15, 0.2);
+}
+
+.job-billing-alert p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.job-billing-alert a,
+.job-progress-metadata a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.job-billing-alert a:hover,
+.job-progress-metadata a:hover {
+  text-decoration: underline;
+}
+
+.job-progress-list {
+  display: grid;
+  gap: 12px;
+}
+
+.job-progress-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 18px;
+  background: rgba(3, 7, 18, 0.72);
+}
+
+.job-progress-card-head p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.job-progress-metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(116px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.job-progress-metadata div {
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.job-progress-metadata dt {
+  color: var(--muted);
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.job-progress-metadata dd {
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.job-progress-timeline {
+  display: grid;
+  gap: 8px;
+}
+
+.job-progress-timeline div {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  column-gap: 8px;
+  align-items: start;
+}
+
+.job-progress-timeline span {
+  width: 9px;
+  height: 9px;
+  margin-top: 6px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.12);
+}
+
+.job-progress-timeline p {
+  margin: 0;
+  font-weight: 700;
+}
+
+.job-progress-timeline small {
+  grid-column: 2;
+  color: var(--muted);
+}
+
+.job-progress-logs {
+  display: grid;
+  gap: 6px;
+}
+
+.job-progress-logs span {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.job-progress-logs pre {
+  max-height: 180px;
+  margin: 0;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.9);
+  color: #dbeafe;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.job-progress-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.job-progress-actions code {
+  padding: 6px 8px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  color: #dbeafe;
+  font-size: 0.72rem;
+}
+
 .tool-trace-output {
   margin-top: 10px;
   padding-top: 10px;


### PR DESCRIPTION
﻿## Summary
- add a dedicated Hugging Face Jobs progress panel to the inspector, above the lower-level tool trace
- derive job cards from persisted `manage_job` tool calls so status, logs, and actions remain visible after refresh
- parse job id, status, message, hardware, created time, command, destination URL, latest logs, and timeline events from existing Jobs outputs
- surface safe inspect/logs/cancel command affordances plus plain-language namespace-credit billing guidance with an HF billing link
- add frontend regression coverage for persisted job recovery, active status, logs, actions, and billing hints

## Testing
- `npm test -- JobProgressPanel.test.tsx` red first, then green
- `npm test`
- `npm run build`
- `python -m pytest -q`
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `npm audit --omit=dev`
- `git diff --check`

## Notes
This is intentionally frontend-first and uses the existing persisted `ToolCallPayload` shape. It does not add new job-control API endpoints; the panel makes the existing inspect/logs/cancel flows clear and safe as command affordances.

## Reference
Closes #106
