### PR TITLE
ML-403 / Add sandbox job and artifact detail panels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import ApprovalDialog from './components/ApprovalDialog';
 import JobProgressPanel from './components/JobProgressPanel';
 import RichMessageContent from './components/RichMessageContent';
+import RuntimeDetailPanel from './components/RuntimeDetailPanel';
 import SessionSidebar from './components/SessionSidebar';
 import ToolTracePanel from './components/ToolTracePanel';
 import type {
@@ -488,6 +489,8 @@ function App() {
             />
 
             <JobProgressPanel toolCalls={toolCalls} />
+
+            <RuntimeDetailPanel toolCalls={toolCalls} />
 
             <ToolTracePanel
               liveEvents={liveEvents}

--- a/frontend/src/components/RuntimeDetailPanel.test.tsx
+++ b/frontend/src/components/RuntimeDetailPanel.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import RuntimeDetailPanel from './RuntimeDetailPanel';
+import type { ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'experiment_workspace',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-06-30T06:00:00Z',
+    finished_at: '2026-06-30T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('RuntimeDetailPanel', () => {
+  it('groups persisted sandbox, job, and artifact details with safe action affordances', () => {
+    render(
+      <RuntimeDetailPanel
+        toolCalls={[
+          toolCall({
+            id: 'sandbox-create',
+            arguments: { operation: 'create', hardware: 'cpu-basic' },
+            output: [
+              'Experiment workspace created.',
+              '- Space: owner/ml-copilot-sandbox-session-1',
+              '- URL: https://owner-ml-copilot-sandbox-session-1.hf.space',
+              '- Hardware: cpu-basic',
+              '- Created: 2026-06-30T06:00:00Z',
+            ].join('\n'),
+          }),
+          toolCall({
+            id: 'sandbox-write',
+            arguments: { operation: 'write', path: 'src/train.py' },
+            output: 'Wrote src/train.py (128 bytes).',
+          }),
+          toolCall({
+            id: 'sandbox-run',
+            arguments: { operation: 'run', command: 'python src/train.py', timeout_seconds: 120 },
+            status: 'failed',
+            success: false,
+            error: ['Command: python src/train.py', 'Exit code: 1', '', 'Stderr:', 'CUDA out of memory'].join('\n'),
+          }),
+          toolCall({
+            id: 'job-call',
+            tool_name: 'manage_job',
+            arguments: { operation: 'logs', job_id: 'job-123' },
+            output: ['# Logs for job-123', '', '```', 'epoch=1 loss=0.42', '```'].join('\n'),
+          }),
+          toolCall({
+            id: 'publish-call',
+            tool_name: 'publish_model_report',
+            arguments: { repo_id: 'owner/model-a', output_dir: '.ml-copilot/reports/model-a' },
+            output: [
+              'Prepared model publishing assets.',
+              '- README: D:\\work\\.ml-copilot\\reports\\model-a\\README.md',
+              '- Final report: D:\\work\\.ml-copilot\\reports\\model-a\\FINAL_REPORT.md',
+              '- Manifest: D:\\work\\.ml-copilot\\reports\\model-a\\publish_manifest.json',
+            ].join('\n'),
+          }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Runtime detail panels' });
+    expect(within(panel).getByText('1 sandbox')).toBeInTheDocument();
+    expect(within(panel).getByText('1 job reference')).toBeInTheDocument();
+    expect(within(panel).getAllByText('5 artifacts')).toHaveLength(2);
+
+    const sandbox = screen.getByTestId('runtime-sandbox-owner-ml-copilot-sandbox-session-1');
+    expect(within(sandbox).getByText('owner/ml-copilot-sandbox-session-1')).toBeInTheDocument();
+    expect(within(sandbox).getByText('cpu-basic')).toBeInTheDocument();
+    expect(within(sandbox).getByRole('link', { name: 'Open sandbox' })).toHaveAttribute(
+      'href',
+      'https://owner-ml-copilot-sandbox-session-1.hf.space',
+    );
+    expect(within(sandbox).getByText('src/train.py')).toBeInTheDocument();
+    expect(within(sandbox).getByText('python src/train.py')).toBeInTheDocument();
+    expect(within(sandbox).getByText(/CUDA out of memory/)).toBeInTheDocument();
+    expect(within(sandbox).getByText("experiment_workspace operation='status'")).toBeInTheDocument();
+    expect(within(sandbox).getByText("experiment_workspace operation='read' path='src/train.py'")).toBeInTheDocument();
+
+    const job = screen.getByTestId('runtime-job-job-123');
+    expect(within(job).getByText('job-123')).toBeInTheDocument();
+    expect(within(job).getByText(/epoch=1 loss=0\.42/)).toBeInTheDocument();
+    expect(within(job).getByText("manage_job operation='inspect' job_id='job-123'")).toBeInTheDocument();
+    expect(within(job).getByText("manage_job operation='logs' job_id='job-123'")).toBeInTheDocument();
+
+    const artifacts = screen.getByTestId('runtime-artifacts');
+    expect(within(artifacts).getByText('.ml-copilot/reports/model-a')).toBeInTheDocument();
+    expect(within(artifacts).getByText('README.md')).toBeInTheDocument();
+    expect(within(artifacts).getByText('FINAL_REPORT.md')).toBeInTheDocument();
+    expect(within(artifacts).getByText('publish_manifest.json')).toBeInTheDocument();
+    expect(within(artifacts).getByText('src/train.py')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RuntimeDetailPanel.tsx
+++ b/frontend/src/components/RuntimeDetailPanel.tsx
@@ -1,0 +1,346 @@
+import { useMemo } from 'react';
+import type { ToolCallPayload } from '../types';
+
+interface RuntimeDetailPanelProps {
+  toolCalls: ToolCallPayload[];
+}
+
+interface SandboxDetail {
+  id: string;
+  url: string | null;
+  hardware: string | null;
+  createdAt: string | null;
+  files: string[];
+  commands: Array<{ command: string; status: string; output: string | null }>;
+}
+
+interface JobDetail {
+  id: string;
+  logs: string[];
+  url: string | null;
+}
+
+interface ArtifactDetail {
+  id: string;
+  label: string;
+  kind: string;
+  source: string;
+}
+
+interface RuntimeDetails {
+  sandboxes: SandboxDetail[];
+  jobs: JobDetail[];
+  artifacts: ArtifactDetail[];
+}
+
+const ARTIFACT_FILE_RE = /\b(?:README\.md|FINAL_REPORT\.md|publish_manifest\.json|report\.json|report\.md)\b/gi;
+
+function firstNonEmptyText(...values: Array<string | null | undefined>) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function getArgText(args: Record<string, unknown>, key: string) {
+  const value = args[key];
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+}
+
+function matchLine(text: string | null | undefined, pattern: RegExp) {
+  if (!text) return null;
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(pattern);
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+  return null;
+}
+
+function firstUrl(text: string | null | undefined) {
+  return text?.match(/https?:\/\/[^\s)]+/)?.[0] ?? null;
+}
+
+function slug(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'runtime';
+}
+
+function formatCount(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function basename(path: string) {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+function addUnique(values: string[], value: string | null | undefined) {
+  const normalized = value?.trim();
+  if (!normalized) return;
+  if (!values.includes(normalized)) values.push(normalized);
+}
+
+function addArtifact(artifacts: Map<string, ArtifactDetail>, label: string | null | undefined, kind: string, source: string) {
+  const normalized = label?.trim();
+  if (!normalized) return;
+  const id = `${kind}:${normalized}`;
+  if (!artifacts.has(id)) {
+    artifacts.set(id, { id, label: normalized, kind, source });
+  }
+}
+
+function parseLogs(output: string | null | undefined) {
+  if (!output) return [];
+  const fenced = output.match(/```\s*([\s\S]*?)\s*```/);
+  const body = fenced?.[1] ?? output;
+  return body
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim() && !line.startsWith('# Logs for'))
+    .slice(-12);
+}
+
+function parseJobId(call: ToolCallPayload) {
+  const output = firstNonEmptyText(call.output, call.error);
+  return (
+    getArgText(call.arguments, 'job_id') ??
+    matchLine(output, /^### Job\s+(.+)$/i) ??
+    matchLine(output, /^# Logs for\s+([^\s(]+)/i) ??
+    matchLine(output, /^Job\s+([^\s]+)\s+has been cancelled/i)
+  );
+}
+
+function sandboxFromCall(call: ToolCallPayload, fallbackId: string): SandboxDetail {
+  const output = firstNonEmptyText(call.output, call.error);
+  const id = matchLine(output, /^- Space:\s*(.+)$/i) ?? fallbackId;
+  return {
+    id,
+    url: firstUrl(output) ?? null,
+    hardware: getArgText(call.arguments, 'hardware') ?? matchLine(output, /^- Hardware:\s*(.+)$/i),
+    createdAt: matchLine(output, /^- Created:\s*(.+)$/i),
+    files: [],
+    commands: [],
+  };
+}
+
+function collectArtifactsFromText(artifacts: Map<string, ArtifactDetail>, text: string | null | undefined, source: string) {
+  if (!text) return;
+  const pathBullets = text.matchAll(/^- (?:README|Final report|Manifest):\s*(.+)$/gim);
+  for (const match of pathBullets) {
+    const path = match[1]?.trim();
+    if (path) addArtifact(artifacts, basename(path), 'artifact', source);
+  }
+
+  for (const match of text.matchAll(ARTIFACT_FILE_RE)) {
+    addArtifact(artifacts, match[0], 'artifact', source);
+  }
+}
+
+function deriveRuntimeDetails(toolCalls: ToolCallPayload[]): RuntimeDetails {
+  const sandboxes = new Map<string, SandboxDetail>();
+  const jobs = new Map<string, JobDetail>();
+  const artifacts = new Map<string, ArtifactDetail>();
+  let activeSandboxId = 'active-sandbox';
+
+  for (const call of toolCalls) {
+    const output = firstNonEmptyText(call.output, call.error);
+    const operation = getArgText(call.arguments, 'operation');
+
+    if (call.tool_name === 'experiment_workspace') {
+      const createDetail = sandboxFromCall(call, activeSandboxId);
+      if (operation === 'create' || !sandboxes.size) {
+        activeSandboxId = createDetail.id;
+        if (!sandboxes.has(createDetail.id)) sandboxes.set(createDetail.id, createDetail);
+      }
+
+      const sandbox = sandboxes.get(activeSandboxId) ?? createDetail;
+      sandboxes.set(sandbox.id, sandbox);
+
+      const path = getArgText(call.arguments, 'path') ?? matchLine(output, /^Wrote\s+(.+?)\s+\(/i) ?? matchLine(output, /^###\s+(.+)$/i);
+      addUnique(sandbox.files, path);
+      if (path) addArtifact(artifacts, path, 'sandbox file', 'sandbox');
+
+      const command = getArgText(call.arguments, 'command') ?? matchLine(output, /^Command:\s*(.+)$/i);
+      if (command) {
+        sandbox.commands.push({
+          command,
+          status: call.success === false || call.error ? 'failed' : 'completed',
+          output: output ? output.slice(0, 700) : null,
+        });
+      }
+    }
+
+    if (call.tool_name === 'manage_job') {
+      const jobId = parseJobId(call);
+      if (jobId) {
+        const current = jobs.get(jobId) ?? { id: jobId, logs: [], url: null };
+        current.url = current.url ?? firstUrl(output);
+        const logs = parseLogs(output);
+        for (const line of logs) addUnique(current.logs, line);
+        jobs.set(jobId, current);
+      }
+    }
+
+    if (call.tool_name === 'publish_model_report') {
+      addArtifact(artifacts, getArgText(call.arguments, 'output_dir'), 'artifact directory', 'publishing');
+      collectArtifactsFromText(artifacts, output, 'publishing');
+    }
+
+    collectArtifactsFromText(artifacts, output, call.tool_name);
+  }
+
+  return {
+    sandboxes: [...sandboxes.values()],
+    jobs: [...jobs.values()],
+    artifacts: [...artifacts.values()],
+  };
+}
+
+function sandboxStatusAction() {
+  return "experiment_workspace operation='status'";
+}
+
+function sandboxReadAction(path: string) {
+  return `experiment_workspace operation='read' path='${path}'`;
+}
+
+function jobAction(operation: 'inspect' | 'logs', jobId: string) {
+  return `manage_job operation='${operation}' job_id='${jobId}'`;
+}
+
+export default function RuntimeDetailPanel({ toolCalls }: RuntimeDetailPanelProps) {
+  const details = useMemo(() => deriveRuntimeDetails(toolCalls), [toolCalls]);
+  const hasRuntimeDetails = details.sandboxes.length || details.jobs.length || details.artifacts.length;
+
+  return (
+    <section className="runtime-detail-panel" id="runtime-details" aria-label="Runtime detail panels">
+      <div className="runtime-detail-header">
+        <div>
+          <p className="panel-label">Runtime details</p>
+          <h3>Sandboxes, jobs, and artifacts</h3>
+          <p className="muted">Recovered from persisted session tool calls for current and historical sessions.</p>
+        </div>
+        <div className="runtime-detail-counts">
+          <span className="status-chip neutral">{formatCount(details.sandboxes.length, 'sandbox', 'sandboxes')}</span>
+          <span className="status-chip neutral">{formatCount(details.jobs.length, 'job reference')}</span>
+          <span className="status-chip neutral">{formatCount(details.artifacts.length, 'artifact')}</span>
+        </div>
+      </div>
+
+      {!hasRuntimeDetails ? (
+        <p className="muted">Sandbox sessions, job references, and generated artifacts will appear here after runtime tools run.</p>
+      ) : (
+        <div className="runtime-detail-stack">
+          {details.sandboxes.map((sandbox) => (
+            <article className="runtime-detail-card" data-testid={`runtime-sandbox-${slug(sandbox.id)}`} key={sandbox.id}>
+              <div className="runtime-detail-card-head">
+                <div>
+                  <span>Sandbox runtime</span>
+                  <h4>{sandbox.id}</h4>
+                </div>
+                {sandbox.url ? (
+                  <a href={sandbox.url} rel="noopener noreferrer" target="_blank">
+                    Open sandbox
+                  </a>
+                ) : null}
+              </div>
+
+              <dl className="runtime-detail-metadata">
+                {sandbox.hardware ? (
+                  <div>
+                    <dt>Hardware</dt>
+                    <dd>{sandbox.hardware}</dd>
+                  </div>
+                ) : null}
+                {sandbox.createdAt ? (
+                  <div>
+                    <dt>Created</dt>
+                    <dd>{sandbox.createdAt}</dd>
+                  </div>
+                ) : null}
+              </dl>
+
+              {sandbox.files.length ? (
+                <div className="runtime-detail-list">
+                  <strong>Files</strong>
+                  {sandbox.files.map((file) => (
+                    <span key={file}>{file}</span>
+                  ))}
+                </div>
+              ) : null}
+
+              {sandbox.commands.length ? (
+                <div className="runtime-command-list">
+                  <strong>Commands</strong>
+                  {sandbox.commands.map((command, index) => (
+                    <div className={`runtime-command ${command.status}`} key={`${command.command}-${index}`}>
+                      <span>{command.command}</span>
+                      {command.output ? <pre>{command.output}</pre> : null}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+
+              <div className="runtime-detail-actions">
+                <code>{sandboxStatusAction()}</code>
+                {sandbox.files.slice(0, 3).map((file) => (
+                  <code key={file}>{sandboxReadAction(file)}</code>
+                ))}
+              </div>
+            </article>
+          ))}
+
+          {details.jobs.map((job) => (
+            <article className="runtime-detail-card" data-testid={`runtime-job-${slug(job.id)}`} key={job.id}>
+              <div className="runtime-detail-card-head">
+                <div>
+                  <span>Job reference</span>
+                  <h4>{job.id}</h4>
+                </div>
+                {job.url ? (
+                  <a href={job.url} rel="noopener noreferrer" target="_blank">
+                    Open job
+                  </a>
+                ) : null}
+              </div>
+
+              {job.logs.length ? (
+                <div className="runtime-command-list">
+                  <strong>Latest logs</strong>
+                  <pre>{job.logs.join('\n')}</pre>
+                </div>
+              ) : null}
+
+              <div className="runtime-detail-actions">
+                <code>{jobAction('inspect', job.id)}</code>
+                <code>{jobAction('logs', job.id)}</code>
+              </div>
+            </article>
+          ))}
+
+          {details.artifacts.length ? (
+            <article className="runtime-detail-card" data-testid="runtime-artifacts">
+              <div className="runtime-detail-card-head">
+                <div>
+                  <span>Generated artifacts</span>
+                  <h4>{formatCount(details.artifacts.length, 'artifact')}</h4>
+                </div>
+              </div>
+
+              <div className="runtime-artifact-grid">
+                {details.artifacts.map((artifact) => (
+                  <div className="runtime-artifact" key={artifact.id}>
+                    <span>{artifact.kind}</span>
+                    <strong>{artifact.label}</strong>
+                    <small>{artifact.source}</small>
+                  </div>
+                ))}
+              </div>
+            </article>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ToolTracePanel.test.tsx
+++ b/frontend/src/components/ToolTracePanel.test.tsx
@@ -118,6 +118,10 @@ describe('ToolTracePanel', () => {
     const sandboxCard = screen.getByTestId('tool-card-sandbox-call');
     expect(within(sandboxCard).getByText('Sandbox runtime')).toBeInTheDocument();
     expect(within(sandboxCard).getByText('Command failed with CUDA out of memory while training.')).toBeInTheDocument();
+    expect(within(sandboxCard).getByRole('link', { name: 'Open runtime panel' })).toHaveAttribute(
+      'href',
+      '#runtime-details',
+    );
 
     const publishCard = screen.getByTestId('tool-card-publish-call');
     expect(within(publishCard).getByText('Publishing')).toBeInTheDocument();

--- a/frontend/src/components/ToolTracePanel.tsx
+++ b/frontend/src/components/ToolTracePanel.tsx
@@ -188,6 +188,15 @@ function addMetadata(items: ToolMetadataItem[], item: ToolMetadataItem | null) {
   items.push(item);
 }
 
+function addRuntimePanelLink(items: ToolMetadataItem[]) {
+  addMetadata(items, {
+    label: 'Runtime',
+    value: 'Runtime panel',
+    href: '#runtime-details',
+    linkLabel: 'Open runtime panel',
+  });
+}
+
 function buildToolProfile(call: ToolCallPayload): ToolProfile {
   const args = call.arguments;
   const output = textOutput(call);
@@ -209,6 +218,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
       if (hardware) addMetadata(metadata, { label: 'Hardware', value: hardware });
       if (jobId) addMetadata(metadata, { label: 'Job', value: jobId });
       if (url) addMetadata(metadata, { label: 'Link', value: url, href: url, linkLabel: 'Open job' });
+      addRuntimePanelLink(metadata);
 
       return {
         category: 'Job orchestration',
@@ -226,6 +236,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
       if (command) addMetadata(metadata, { label: 'Command', value: command });
       if (path) addMetadata(metadata, { label: 'Path', value: path });
       if (sandboxId) addMetadata(metadata, { label: 'Sandbox', value: sandboxId });
+      addRuntimePanelLink(metadata);
 
       return {
         category: 'Sandbox runtime',
@@ -256,6 +267,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
 
       if (outputDir) addMetadata(metadata, { label: 'Output', value: outputDir });
       if (repoId) addMetadata(metadata, { label: 'Repository', value: repoId });
+      addRuntimePanelLink(metadata);
 
       return {
         category: 'Publishing',

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1267,6 +1267,193 @@ button {
   font-size: 0.72rem;
 }
 
+.runtime-detail-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.74), rgba(2, 6, 23, 0.8));
+}
+
+.runtime-detail-header,
+.runtime-detail-card-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.runtime-detail-header h3,
+.runtime-detail-card-head h4 {
+  margin: 4px 0;
+  letter-spacing: -0.03em;
+}
+
+.runtime-detail-counts,
+.runtime-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.runtime-detail-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.runtime-detail-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 18px;
+  background: rgba(3, 7, 18, 0.72);
+}
+
+.runtime-detail-card-head span,
+.runtime-command-list strong,
+.runtime-detail-list strong {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.runtime-detail-card-head a {
+  color: var(--accent);
+  font-size: 0.82rem;
+  text-decoration: none;
+}
+
+.runtime-detail-card-head a:hover {
+  text-decoration: underline;
+}
+
+.runtime-detail-metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.runtime-detail-metadata div,
+.runtime-artifact {
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.runtime-detail-metadata dt,
+.runtime-artifact span,
+.runtime-artifact small {
+  color: var(--muted);
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.runtime-detail-metadata dd {
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-detail-list,
+.runtime-command-list {
+  display: grid;
+  gap: 8px;
+}
+
+.runtime-detail-list span {
+  width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 6px 8px;
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  border-radius: 999px;
+  background: rgba(30, 64, 175, 0.18);
+  color: #dbeafe;
+  font-family: monospace;
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+}
+
+.runtime-command {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.runtime-command.failed {
+  border-color: rgba(248, 113, 113, 0.26);
+  background: rgba(127, 29, 29, 0.18);
+}
+
+.runtime-command span {
+  color: #dbeafe;
+  font-family: monospace;
+  font-size: 0.78rem;
+}
+
+.runtime-command pre,
+.runtime-command-list pre {
+  max-height: 180px;
+  margin: 0;
+  overflow: auto;
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.9);
+  color: #dbeafe;
+  font-size: 0.76rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.runtime-detail-actions {
+  justify-content: flex-start;
+}
+
+.runtime-detail-actions code {
+  padding: 6px 8px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  color: #dbeafe;
+  font-size: 0.72rem;
+}
+
+.runtime-artifact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+}
+
+.runtime-artifact {
+  display: grid;
+  gap: 4px;
+}
+
+.runtime-artifact strong {
+  overflow: hidden;
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .tool-trace-output {
   margin-top: 10px;
   padding-top: 10px;


### PR DESCRIPTION
## Summary
- add a RuntimeDetailPanel that groups persisted sandbox sessions, job references, command output, and generated artifacts in the inspector
- derive runtime details from existing ToolCallPayload records so historical sessions and refresh recovery work without backend schema changes
- surface safe command affordances for sandbox status/read and job inspect/logs instead of adding direct destructive UI actions
- add frontend regression coverage for sandbox metadata, command failures, job logs, and publishing artifacts

## Testing
- `npm test -- RuntimeDetailPanel.test.tsx` red first, then green
- `npm test`
- `npm run build`
- `python -m pytest -q`
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `python -m mypy app/ --ignore-missing-imports --follow-imports=skip`
- `npm audit --omit=dev`
- `git diff --check`

## Notes
This is intentionally frontend-first and complements the existing job progress and tool trace panels. A deeper file browser and open/download actions remain scoped to the later artifact browser task.

## Reference
Closes #108