### PR TITLE
ML-404 / Add model selector and provider controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,11 @@ import JobProgressPanel from './components/JobProgressPanel';
 import RichMessageContent from './components/RichMessageContent';
 import RuntimeDetailPanel from './components/RuntimeDetailPanel';
 import SessionSidebar from './components/SessionSidebar';
+import {
+  DEFAULT_SESSION_CONTROLS,
+  buildSessionMetadata,
+  type SessionControlState,
+} from './sessionControls';
 import ToolTracePanel from './components/ToolTracePanel';
 import type {
   ApprovalDecisionRequest,
@@ -28,7 +33,7 @@ import type {
 type LoadState = 'idle' | 'loading' | 'ready' | 'error';
 type StreamState = 'idle' | 'connecting' | 'streaming' | 'closed' | 'error';
 
-const seedMetadata = { source: 'frontend-shell' };
+const sessionMetadataSource = 'frontend-shell';
 const terminalEventTypes = new Set(['turn_complete', 'approval_required', 'error', 'interrupted']);
 
 function formatTimestamp(value: string) {
@@ -97,6 +102,7 @@ function App() {
   const [resolvingApproval, setResolvingApproval] = useState(false);
   const [draftTitle, setDraftTitle] = useState('');
   const [draftModel, setDraftModel] = useState('');
+  const [draftControls, setDraftControls] = useState<SessionControlState>(DEFAULT_SESSION_CONTROLS);
   const [draftHfToken, setDraftHfToken] = useState('');
   const [draftPrompt, setDraftPrompt] = useState('');
 
@@ -219,7 +225,7 @@ function App() {
       const created = await createSession({
         title: draftTitle.trim() || null,
         model: draftModel.trim() || null,
-        metadata: seedMetadata,
+        metadata: buildSessionMetadata(sessionMetadataSource, draftControls),
       }, draftHfToken.trim() || null);
       setSessions((current) => [created, ...current.filter((session) => session.id !== created.id)]);
       setSelectedSessionId(created.id);
@@ -363,6 +369,7 @@ function App() {
           <SessionSidebar
             activeSession={activeSession}
             creating={creating}
+            draftControls={draftControls}
             draftModel={draftModel}
             draftHfToken={draftHfToken}
             draftTitle={draftTitle}
@@ -372,6 +379,7 @@ function App() {
             onSelectSession={setSelectedSessionId}
             selectedSessionId={selectedSessionId}
             sessions={sessions}
+            setDraftControls={setDraftControls}
             setDraftModel={setDraftModel}
             setDraftHfToken={setDraftHfToken}
             setDraftTitle={setDraftTitle}

--- a/frontend/src/components/SessionSidebar.test.tsx
+++ b/frontend/src/components/SessionSidebar.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import SessionSidebar from './SessionSidebar';
+import { DEFAULT_SESSION_CONTROLS, type SessionControlState } from '../sessionControls';
+import type { MessagePayload, SessionDetail, SessionSummary } from '../types';
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'session-1',
+    title: 'Train classifier',
+    status: 'idle',
+    model: 'zai-org/GLM-5.2:novita',
+    metadata: {},
+    created_at: '2026-06-30T06:00:00Z',
+    updated_at: '2026-06-30T06:30:00Z',
+    message_count: 3,
+    event_count: 9,
+    pending_approval_count: 0,
+    metrics: {
+      session_id: 'session-1',
+      turn_count: 2,
+      prompt_tokens: 1000,
+      completion_tokens: 500,
+      total_tokens: 1500,
+      estimated_cost_usd: 0.012,
+      tool_calls: 4,
+      tool_errors: 0,
+      tool_retries: 0,
+      tool_latency_ms: 1200,
+      average_tool_latency_ms: 300,
+      error_count: 0,
+      last_updated_at: '2026-06-30T06:30:00Z',
+    },
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<MessagePayload> = {}): MessagePayload {
+  return {
+    id: 'message-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    role: 'assistant',
+    content: 'Ready.',
+    tool_call_id: null,
+    name: null,
+    raw: {},
+    sequence: 1,
+    created_at: '2026-06-30T06:01:00Z',
+    ...overrides,
+  };
+}
+
+describe('SessionSidebar model/provider controls', () => {
+  it('renders provider controls and saved session preferences', async () => {
+    const user = userEvent.setup();
+    const setDraftControls = vi.fn();
+    const draftControls: SessionControlState = {
+      ...DEFAULT_SESSION_CONTROLS,
+      provider: 'zai',
+      reasoningEffort: 'high',
+      temperature: '0.2',
+      operatingMode: 'careful',
+      maxTurns: '120',
+      spendCapUsd: '3.50',
+    };
+    const activeSession = session({
+      metadata: {
+        agent_controls: {
+          provider: 'zai',
+          reasoning_effort: 'high',
+          temperature: 0.2,
+          operating_mode: 'careful',
+          yolo_mode: false,
+          max_turns: 120,
+          spend_cap_usd: 3.5,
+        },
+      },
+    }) as SessionDetail;
+
+    render(
+      <SessionSidebar
+        activeSession={{ ...activeSession, pending_approvals: [], tool_calls: [] }}
+        creating={false}
+        draftControls={draftControls}
+        draftHfToken=""
+        draftModel="zai-org/GLM-5.2:novita"
+        draftTitle=""
+        messages={[message()]}
+        onCreateSession={vi.fn()}
+        onRefreshSessions={vi.fn()}
+        onSelectSession={vi.fn()}
+        selectedSessionId="session-1"
+        sessions={[activeSession]}
+        setDraftControls={setDraftControls}
+        setDraftHfToken={vi.fn()}
+        setDraftModel={vi.fn()}
+        setDraftTitle={vi.fn()}
+      />,
+    );
+
+    const controls = screen.getByRole('region', { name: 'Model and provider controls' });
+    expect(within(controls).getByLabelText('Provider')).toHaveValue('zai');
+    expect(within(controls).getByLabelText('Reasoning effort')).toHaveValue('high');
+    expect(within(controls).getByLabelText('Operating mode')).toHaveValue('careful');
+    expect(within(controls).getByLabelText('Temperature')).toHaveValue(0.2);
+    expect(within(controls).getByLabelText('Max turns')).toHaveValue(120);
+    expect(within(controls).getByLabelText('Spend cap')).toHaveValue(3.5);
+    expect(within(controls).getByRole('button', { name: 'Use GLM 5.2' })).toBeInTheDocument();
+
+    await user.selectOptions(within(controls).getByLabelText('Provider'), 'anthropic');
+
+    expect(setDraftControls).toHaveBeenCalledWith(expect.objectContaining({ provider: 'anthropic' }));
+
+    const summary = screen.getByTestId('selected-session-controls');
+    expect(within(summary).getByText('Provider: Z.ai')).toBeInTheDocument();
+    expect(within(summary).getByText('Effort: high')).toBeInTheDocument();
+    expect(within(summary).getByText('Mode: careful')).toBeInTheDocument();
+    expect(within(summary).getByText('Spend cap: $3.50')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar.tsx
@@ -1,10 +1,24 @@
 import { useState, type FormEvent } from 'react';
 import { uploadDataset } from '../api';
+import {
+  EFFORT_OPTIONS,
+  OPERATING_MODE_OPTIONS,
+  PROVIDER_OPTIONS,
+  providerLabel,
+  readStoredAgentControls,
+  suggestedModelForProvider,
+  suggestedModelLabelForProvider,
+  type OperatingMode,
+  type ProviderId,
+  type ReasoningEffort,
+  type SessionControlState,
+} from '../sessionControls';
 import type { MessagePayload, SessionDetail, SessionSummary } from '../types';
 
 interface SessionSidebarProps {
   activeSession: SessionDetail | null;
   creating: boolean;
+  draftControls: SessionControlState;
   draftHfToken: string;
   draftModel: string;
   draftTitle: string;
@@ -14,6 +28,7 @@ interface SessionSidebarProps {
   onSelectSession: (sessionId: string) => void;
   selectedSessionId: string | null;
   sessions: SessionSummary[];
+  setDraftControls: (value: SessionControlState) => void;
   setDraftHfToken: (value: string) => void;
   setDraftModel: (value: string) => void;
   setDraftTitle: (value: string) => void;
@@ -62,6 +77,7 @@ function roleLabel(role: string) {
 export default function SessionSidebar({
   activeSession,
   creating,
+  draftControls,
   draftHfToken,
   draftModel,
   draftTitle,
@@ -71,6 +87,7 @@ export default function SessionSidebar({
   onSelectSession,
   selectedSessionId,
   sessions,
+  setDraftControls,
   setDraftHfToken,
   setDraftModel,
   setDraftTitle,
@@ -81,6 +98,11 @@ export default function SessionSidebar({
   const isCurrentSession = Boolean(activeSession && activeSession.id === selectedSessionId);
   const currentSession = isCurrentSession ? activeSession : null;
   const recentMessages = isCurrentSession ? [...messages].slice(-3) : [];
+  const selectedControls = currentSession ? readStoredAgentControls(currentSession.metadata) : null;
+
+  function updateDraftControls(patch: Partial<SessionControlState>) {
+    setDraftControls({ ...draftControls, ...patch });
+  }
 
   async function handleDatasetUpload() {
     if (!datasetFile) return;
@@ -118,14 +140,113 @@ export default function SessionSidebar({
             placeholder="Plan a dataset audit"
           />
         </label>
-        <label>
-          Model
-          <input
-            value={draftModel}
-            onChange={(event) => setDraftModel(event.target.value)}
-            placeholder="gpt-5.4"
-          />
-        </label>
+        <section className="model-control-card" aria-label="Model and provider controls">
+          <div>
+            <p className="panel-label">Agent controls</p>
+            <strong>Model and provider</strong>
+            <p className="hint">
+              Saved with the session so runs reopen with predictable provider, effort, and budget preferences.
+            </p>
+          </div>
+          <div className="model-control-grid">
+            <label>
+              Provider
+              <select
+                value={draftControls.provider}
+                onChange={(event) => updateDraftControls({ provider: event.target.value as ProviderId })}
+              >
+                {PROVIDER_OPTIONS.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Model
+              <input
+                value={draftModel}
+                onChange={(event) => setDraftModel(event.target.value)}
+                placeholder={suggestedModelForProvider(draftControls.provider)}
+              />
+            </label>
+          </div>
+          <div className="model-preset-row">
+            <button
+              className="ghost-button"
+              type="button"
+              onClick={() => setDraftModel(suggestedModelForProvider(draftControls.provider))}
+            >
+              Use {suggestedModelLabelForProvider(draftControls.provider)}
+            </button>
+            <span className="hint">Custom model IDs stay editable for OpenAI-compatible and routed providers.</span>
+          </div>
+          <div className="model-control-grid">
+            <label>
+              Reasoning effort
+              <select
+                value={draftControls.reasoningEffort}
+                onChange={(event) => updateDraftControls({ reasoningEffort: event.target.value as ReasoningEffort })}
+              >
+                {EFFORT_OPTIONS.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Operating mode
+              <select
+                value={draftControls.operatingMode}
+                onChange={(event) => updateDraftControls({ operatingMode: event.target.value as OperatingMode })}
+              >
+                {OPERATING_MODE_OPTIONS.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Temperature
+              <input
+                type="number"
+                min="0"
+                max="2"
+                step="0.1"
+                value={draftControls.temperature}
+                onChange={(event) => updateDraftControls({ temperature: event.target.value })}
+                placeholder="0.2"
+              />
+            </label>
+            <label>
+              Max turns
+              <input
+                type="number"
+                min="1"
+                step="1"
+                value={draftControls.maxTurns}
+                onChange={(event) => updateDraftControls({ maxTurns: event.target.value })}
+                placeholder="120"
+              />
+            </label>
+            <label>
+              Spend cap
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={draftControls.spendCapUsd}
+                onChange={(event) => updateDraftControls({ spendCapUsd: event.target.value })}
+                placeholder="3.50"
+              />
+            </label>
+          </div>
+          <p className="hint">
+            Unsupported backend controls are treated as transparent preferences in this slice, not hidden enforcement.
+          </p>
+        </section>
         <label>
           Hugging Face token
           <input
@@ -212,6 +333,16 @@ export default function SessionSidebar({
                 <span>{shortId(currentSession.id)}</span>
               </div>
               <p>{currentSession.model}</p>
+              {selectedControls ? (
+                <div className="session-control-summary" data-testid="selected-session-controls">
+                  <span>Provider: {providerLabel(selectedControls.provider)}</span>
+                  <span>Effort: {selectedControls.reasoning_effort}</span>
+                  <span>Mode: {selectedControls.operating_mode}</span>
+                  {selectedControls.spend_cap_usd !== null ? (
+                    <span>Spend cap: {formatCurrency(selectedControls.spend_cap_usd)}</span>
+                  ) : null}
+                </div>
+              ) : null}
               <div className="session-card-meta">
                 <span>{currentSession.message_count} messages</span>
                 <span>{currentSession.event_count} events</span>

--- a/frontend/src/sessionControls.test.ts
+++ b/frontend/src/sessionControls.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SESSION_CONTROLS,
+  buildSessionMetadata,
+  suggestedModelForProvider,
+} from './sessionControls';
+
+describe('sessionControls', () => {
+  it('builds sanitized session metadata for provider, model, effort, mode, and budget controls', () => {
+    const metadata = buildSessionMetadata('frontend-shell', {
+      ...DEFAULT_SESSION_CONTROLS,
+      provider: 'zai',
+      reasoningEffort: 'high',
+      temperature: '0.2',
+      operatingMode: 'careful',
+      maxTurns: '120',
+      spendCapUsd: '3.50',
+    });
+
+    expect(metadata).toEqual({
+      source: 'frontend-shell',
+      agent_controls: {
+        provider: 'zai',
+        reasoning_effort: 'high',
+        temperature: 0.2,
+        operating_mode: 'careful',
+        yolo_mode: false,
+        max_turns: 120,
+        spend_cap_usd: 3.5,
+      },
+    });
+  });
+
+  it('keeps custom model ids while offering provider-specific suggested defaults', () => {
+    expect(suggestedModelForProvider('anthropic')).toBe('claude-opus-4-8');
+    expect(suggestedModelForProvider('zai')).toBe('zai-org/GLM-5.2:novita');
+    expect(suggestedModelForProvider('openai_compatible')).toBe('gpt-5.4');
+  });
+});

--- a/frontend/src/sessionControls.ts
+++ b/frontend/src/sessionControls.ts
@@ -1,0 +1,157 @@
+export type ProviderId =
+  | 'openai_compatible'
+  | 'anthropic'
+  | 'gemini'
+  | 'xai'
+  | 'zai'
+  | 'kimi'
+  | 'minimax';
+
+export type ReasoningEffort = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export type OperatingMode = 'normal' | 'careful' | 'fast';
+
+export interface SessionControlState {
+  provider: ProviderId;
+  reasoningEffort: ReasoningEffort;
+  temperature: string;
+  operatingMode: OperatingMode;
+  maxTurns: string;
+  spendCapUsd: string;
+}
+
+export interface StoredAgentControls {
+  provider: ProviderId;
+  reasoning_effort: ReasoningEffort;
+  temperature: number | null;
+  operating_mode: OperatingMode;
+  yolo_mode: boolean;
+  max_turns: number | null;
+  spend_cap_usd: number | null;
+}
+
+export const DEFAULT_SESSION_CONTROLS: SessionControlState = {
+  provider: 'openai_compatible',
+  reasoningEffort: 'off',
+  temperature: '',
+  operatingMode: 'normal',
+  maxTurns: '',
+  spendCapUsd: '',
+};
+
+export const PROVIDER_OPTIONS: Array<{ id: ProviderId; label: string; suggestedModel: string; suggestedLabel: string }> = [
+  {
+    id: 'openai_compatible',
+    label: 'OpenAI-compatible',
+    suggestedModel: 'gpt-5.4',
+    suggestedLabel: 'GPT-5.4',
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    suggestedModel: 'claude-opus-4-8',
+    suggestedLabel: 'Claude Opus 4.8',
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini',
+    suggestedModel: 'gemini-2.5-pro',
+    suggestedLabel: 'Gemini 2.5 Pro',
+  },
+  {
+    id: 'xai',
+    label: 'xAI',
+    suggestedModel: 'grok-4',
+    suggestedLabel: 'Grok 4',
+  },
+  {
+    id: 'zai',
+    label: 'Z.ai',
+    suggestedModel: 'zai-org/GLM-5.2:novita',
+    suggestedLabel: 'GLM 5.2',
+  },
+  {
+    id: 'kimi',
+    label: 'Kimi',
+    suggestedModel: 'moonshotai/Kimi-K2.7-Code:novita',
+    suggestedLabel: 'Kimi K2.7 Code',
+  },
+  {
+    id: 'minimax',
+    label: 'MiniMax',
+    suggestedModel: 'MiniMaxAI/MiniMax-M3:novita',
+    suggestedLabel: 'MiniMax M3',
+  },
+];
+
+export const EFFORT_OPTIONS: Array<{ id: ReasoningEffort; label: string }> = [
+  { id: 'off', label: 'Off' },
+  { id: 'minimal', label: 'Minimal' },
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Extra high' },
+  { id: 'max', label: 'Max' },
+];
+
+export const OPERATING_MODE_OPTIONS: Array<{ id: OperatingMode; label: string; description: string }> = [
+  { id: 'normal', label: 'Normal', description: 'Balanced approvals and autonomy.' },
+  { id: 'careful', label: 'Careful', description: 'Prefer extra safety and confirmation.' },
+  { id: 'fast', label: 'Fast / YOLO-style', description: 'Persisted as a fast-mode preference only.' },
+];
+
+const providerLabels = new Map(PROVIDER_OPTIONS.map((option) => [option.id, option.label]));
+
+export function providerLabel(provider: ProviderId | string | null | undefined) {
+  return providerLabels.get(provider as ProviderId) ?? 'Unknown provider';
+}
+
+export function suggestedModelForProvider(provider: ProviderId) {
+  return PROVIDER_OPTIONS.find((option) => option.id === provider)?.suggestedModel ?? 'gpt-5.4';
+}
+
+export function suggestedModelLabelForProvider(provider: ProviderId) {
+  return PROVIDER_OPTIONS.find((option) => option.id === provider)?.suggestedLabel ?? 'GPT-5.4';
+}
+
+function nullableNumber(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function nullablePositiveInt(value: string): number | null {
+  const parsed = nullableNumber(value);
+  if (parsed === null) return null;
+  return Math.max(1, Math.round(parsed));
+}
+
+export function buildSessionMetadata(source: string, controls: SessionControlState): Record<string, unknown> {
+  return {
+    source,
+    agent_controls: {
+      provider: controls.provider,
+      reasoning_effort: controls.reasoningEffort,
+      temperature: nullableNumber(controls.temperature),
+      operating_mode: controls.operatingMode,
+      yolo_mode: controls.operatingMode === 'fast',
+      max_turns: nullablePositiveInt(controls.maxTurns),
+      spend_cap_usd: nullableNumber(controls.spendCapUsd),
+    },
+  };
+}
+
+export function readStoredAgentControls(metadata: Record<string, unknown>): StoredAgentControls | null {
+  const raw = metadata.agent_controls;
+  if (!raw || typeof raw !== 'object') return null;
+  const controls = raw as Record<string, unknown>;
+  return {
+    provider: String(controls.provider || 'openai_compatible') as ProviderId,
+    reasoning_effort: String(controls.reasoning_effort || 'off') as ReasoningEffort,
+    temperature: typeof controls.temperature === 'number' ? controls.temperature : null,
+    operating_mode: String(controls.operating_mode || 'normal') as OperatingMode,
+    yolo_mode: Boolean(controls.yolo_mode),
+    max_turns: typeof controls.max_turns === 'number' ? controls.max_turns : null,
+    spend_cap_usd: typeof controls.spend_cap_usd === 'number' ? controls.spend_cap_usd : null,
+  };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -38,6 +38,7 @@ body {
 
 button,
 input,
+select,
 textarea {
   font: inherit;
 }
@@ -306,6 +307,7 @@ button {
 }
 
 .composer-card input,
+.composer-card select,
 .composer-shell textarea {
   width: 100%;
   border-radius: 14px;
@@ -317,9 +319,44 @@ button {
 }
 
 .composer-card input:focus,
+.composer-card select:focus,
 .composer-shell textarea:focus {
   border-color: rgba(56, 189, 248, 0.45);
   box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.14);
+}
+
+.model-control-card {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid rgba(56, 189, 248, 0.16);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.12), transparent 36%),
+    rgba(3, 7, 18, 0.58);
+}
+
+.model-control-card strong {
+  display: block;
+  margin-top: 4px;
+  letter-spacing: -0.02em;
+}
+
+.model-control-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 10px;
+}
+
+.model-preset-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.model-preset-row .ghost-button {
+  white-space: nowrap;
 }
 
 .session-list,
@@ -381,6 +418,23 @@ button {
   font-size: 0.76rem;
   color: var(--muted);
   flex-wrap: wrap;
+}
+
+.session-control-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.session-control-summary span {
+  display: inline-flex;
+  padding: 6px 8px;
+  border: 1px solid rgba(56, 189, 248, 0.14);
+  border-radius: 999px;
+  background: rgba(14, 116, 144, 0.12);
+  color: #bfdbfe;
+  font-size: 0.72rem;
 }
 
 .session-history-card {


### PR DESCRIPTION
## Summary
- Add typed frontend provider/model/effort/mode/budget controls to the session composer.
- Persist agent control preferences in session metadata while keeping the model field as the actual model id.
- Show saved provider/effort/mode/spend-cap preferences in selected session history.
- Cover metadata serialization and sidebar behavior with Vitest tests.

## Validation
- npm test
- npm run build
- python -m pytest tests/ -q
- ruff check app/ tests/
- ruff format --check app/ tests/
- mypy app/ --ignore-missing-imports --follow-imports=skip
- git diff --check

## Reference
Closes #110