### PR TITLE
ML-405 / Add usage and billing meter

### DIFF
--- a/docs/superpowers/plans/2026-07-01-usage-cost-meter.md
+++ b/docs/superpowers/plans/2026-07-01-usage-cost-meter.md
@@ -289,4 +289,3 @@ gh pr view <pr> --json assignees,labels,closingIssuesReferences
 ```
 
 Then watch CI and post the required `Code review` comment.
-

--- a/docs/superpowers/plans/2026-07-01-usage-cost-meter.md
+++ b/docs/superpowers/plans/2026-07-01-usage-cost-meter.md
@@ -1,0 +1,292 @@
+# Usage and Cost Meter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a product-grade usage meter that shows session tokens, estimated cost, runtime/tool usage, HF quota/credits warnings, and user budget guardrails without implying ML Copilot has its own billing system.
+
+**Architecture:** Keep ML-405 frontend-first. Derive all values from existing `SessionMetricsSummary`, persisted `ToolCallPayload` records, and ML-404 `agent_controls` metadata. Add one pure helper module for usage summarization and one React panel in the inspector so the logic is typed and testable.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing FastAPI/SQLite session metrics.
+
+---
+
+### Task 1: Pure usage summary helpers
+
+**Files:**
+- Create: `frontend/src/usageMeter.ts`
+- Test: `frontend/src/usageMeter.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/usageMeter.test.ts` with assertions for:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildUsageMeterSummary } from './usageMeter';
+import type { SessionDetail, ToolCallPayload } from './types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T00:00:00Z',
+    finished_at: '2026-07-01T00:01:30Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+const session = {
+  id: 'session-1',
+  title: 'Usage check',
+  status: 'idle',
+  model: 'zai-org/GLM-5.2:novita',
+  metadata: {
+    agent_controls: {
+      provider: 'zai',
+      reasoning_effort: 'high',
+      temperature: 0.2,
+      operating_mode: 'fast',
+      yolo_mode: true,
+      max_turns: 4,
+      spend_cap_usd: 0.05,
+    },
+  },
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:10:00Z',
+  message_count: 4,
+  event_count: 12,
+  pending_approval_count: 0,
+  pending_approvals: [],
+  tool_calls: [],
+  metrics: {
+    session_id: 'session-1',
+    turn_count: 3,
+    prompt_tokens: 1200,
+    completion_tokens: 800,
+    total_tokens: 2000,
+    estimated_cost_usd: 0.045,
+    tool_calls: 3,
+    tool_errors: 1,
+    tool_retries: 1,
+    tool_latency_ms: 90000,
+    average_tool_latency_ms: 30000,
+    error_count: 1,
+    last_updated_at: '2026-07-01T00:10:00Z',
+  },
+} satisfies SessionDetail;
+
+describe('usageMeter', () => {
+  it('summarizes usage, budget progress, runtime mix, and HF quota warnings', () => {
+    const summary = buildUsageMeterSummary(session, [
+      toolCall({ id: 'job-run', tool_name: 'manage_job', arguments: { operation: 'run' } }),
+      toolCall({ id: 'sandbox-run', tool_name: 'experiment_workspace', arguments: { operation: 'run' } }),
+      toolCall({
+        id: 'quota-error',
+        tool_name: 'manage_job',
+        status: 'failed',
+        success: false,
+        error: 'namespace has no available credits. Add credits at https://huggingface.co/settings/billing',
+      }),
+    ]);
+
+    expect(summary.costProgressPercent).toBe(90);
+    expect(summary.turnProgressPercent).toBe(75);
+    expect(summary.warningLevel).toBe('warning');
+    expect(summary.runtimeBreakdown).toEqual([
+      { label: 'HF Jobs', count: 2 },
+      { label: 'Sandbox', count: 1 },
+    ]);
+    expect(summary.hfQuotaWarning?.title).toBe('Hugging Face credits or quota needed');
+    expect(summary.copyNote).toContain('Estimates only');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- usageMeter.test.ts`
+
+Expected: FAIL because `frontend/src/usageMeter.ts` does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `frontend/src/usageMeter.ts` with:
+
+```ts
+import { readStoredAgentControls } from './sessionControls';
+import type { SessionDetail, ToolCallPayload } from './types';
+
+export type UsageWarningLevel = 'neutral' | 'warning' | 'danger';
+
+export interface UsageMeterSummary {
+  costCapUsd: number | null;
+  costProgressPercent: number | null;
+  turnCap: number | null;
+  turnProgressPercent: number | null;
+  warningLevel: UsageWarningLevel;
+  runtimeBreakdown: Array<{ label: string; count: number }>;
+  hfQuotaWarning: { title: string; body: string; href: string } | null;
+  copyNote: string;
+}
+
+export function buildUsageMeterSummary(session: SessionDetail, toolCalls: ToolCallPayload[]): UsageMeterSummary {
+  const controls = readStoredAgentControls(session.metadata);
+  const costCapUsd = controls?.spend_cap_usd ?? null;
+  const turnCap = controls?.max_turns ?? null;
+  const costProgressPercent = progress(session.metrics.estimated_cost_usd, costCapUsd);
+  const turnProgressPercent = progress(session.metrics.turn_count, turnCap);
+  const warningLevel = highestWarning(costProgressPercent, turnProgressPercent);
+  return {
+    costCapUsd,
+    costProgressPercent,
+    turnCap,
+    turnProgressPercent,
+    warningLevel,
+    runtimeBreakdown: buildRuntimeBreakdown(toolCalls),
+    hfQuotaWarning: findHfQuotaWarning(toolCalls),
+    copyNote: 'Estimates only. Actual charges happen with your configured model provider or Hugging Face account.',
+  };
+}
+```
+
+Add the `progress`, `highestWarning`, `buildRuntimeBreakdown`, and `findHfQuotaWarning` helpers in the same file. Count `manage_job` as “HF Jobs”, `experiment_workspace` as “Sandbox”, `publish_model_report` as “Publishing”, and `manage_experiment_loop` as “Experiment loop”. Detect quota warnings when output/error includes `credits`, `quota`, `billing`, `payment required`, or `402`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- usageMeter.test.ts`
+
+Expected: PASS.
+
+### Task 2: Usage meter panel
+
+**Files:**
+- Create: `frontend/src/components/UsageMeterPanel.tsx`
+- Test: `frontend/src/components/UsageMeterPanel.test.tsx`
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/styles.css`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `frontend/src/components/UsageMeterPanel.test.tsx` that renders a `UsageMeterPanel` with a session containing `estimated_cost_usd`, token counts, a spend cap, max turns, and an HF quota error tool call. Assert visible labels:
+
+```ts
+expect(screen.getByRole('region', { name: 'Usage and cost estimate' })).toBeInTheDocument();
+expect(screen.getByText('2K tokens')).toBeInTheDocument();
+expect(screen.getByText('$0.0450 est.')).toBeInTheDocument();
+expect(screen.getByText('90% of $0.05 cap')).toBeInTheDocument();
+expect(screen.getByText('3 / 4 turns')).toBeInTheDocument();
+expect(screen.getByText('HF Jobs')).toBeInTheDocument();
+expect(screen.getByText('Hugging Face credits or quota needed')).toBeInTheDocument();
+expect(screen.getByText(/Estimates only/)).toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- UsageMeterPanel.test.tsx`
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement and wire the panel**
+
+Implement `UsageMeterPanel` to accept:
+
+```ts
+interface UsageMeterPanelProps {
+  session: SessionDetail | null;
+  toolCalls: ToolCallPayload[];
+}
+```
+
+Render an empty state when no session is selected. For a selected session, render:
+
+- token split: prompt, completion, total
+- estimated cost and spend-cap progress
+- turn progress against `max_turns`
+- tool/runtime breakdown
+- tool health: errors, retries, average latency
+- HF quota warning with link only when detected
+- estimate disclaimer copy
+
+In `App.tsx`, import and place `<UsageMeterPanel session={activeSession} toolCalls={toolCalls} />` in the inspector stack near the job/runtime panels.
+
+- [ ] **Step 4: Style the panel**
+
+Add CSS classes with the project’s current glass-card style:
+
+```css
+.usage-meter-panel
+.usage-meter-grid
+.usage-meter-card
+.usage-meter-progress
+.usage-meter-progress span
+.usage-meter-warning
+.usage-meter-breakdown
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `npm test -- usageMeter.test.ts UsageMeterPanel.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Verification and publish
+
+**Files:**
+- Commit only ML-405 files and no local workflow/untracked artifacts.
+
+- [ ] **Step 1: Run full validation**
+
+Run:
+
+```bash
+npm test
+npm run build
+python -m pytest tests/ -q
+ruff check app/ tests/
+ruff format --check app/ tests/
+mypy app/ --ignore-missing-imports --follow-imports=skip
+git diff --check
+```
+
+- [ ] **Step 2: Commit and push**
+
+Stage only:
+
+```text
+docs/superpowers/plans/2026-07-01-usage-cost-meter.md
+frontend/src/usageMeter.ts
+frontend/src/usageMeter.test.ts
+frontend/src/components/UsageMeterPanel.tsx
+frontend/src/components/UsageMeterPanel.test.tsx
+frontend/src/App.tsx
+frontend/src/styles.css
+```
+
+Commit: `ML-405: Add usage and billing meter`
+
+- [ ] **Step 3: Open PR**
+
+Create PR title `ML-405 / Add usage and billing meter`; body must include:
+
+```markdown
+## Reference
+Closes #112
+```
+
+Verify assignee, labels, and closing issue reference with:
+
+```bash
+gh pr view <pr> --json assignees,labels,closingIssuesReferences
+```
+
+Then watch CI and post the required `Code review` comment.
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import {
   type SessionControlState,
 } from './sessionControls';
 import ToolTracePanel from './components/ToolTracePanel';
+import UsageMeterPanel from './components/UsageMeterPanel';
 import type {
   ApprovalDecisionRequest,
   MessagePayload,
@@ -497,6 +498,8 @@ function App() {
             />
 
             <JobProgressPanel toolCalls={toolCalls} />
+
+            <UsageMeterPanel session={activeSession} toolCalls={toolCalls} />
 
             <RuntimeDetailPanel toolCalls={toolCalls} />
 

--- a/frontend/src/components/UsageMeterPanel.test.tsx
+++ b/frontend/src/components/UsageMeterPanel.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import UsageMeterPanel from './UsageMeterPanel';
+import type { SessionDetail, ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T00:00:00Z',
+    finished_at: '2026-07-01T00:01:30Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+function session(): SessionDetail {
+  return {
+    id: 'session-1',
+    title: 'Usage check',
+    status: 'idle',
+    model: 'zai-org/GLM-5.2:novita',
+    metadata: {
+      agent_controls: {
+        provider: 'zai',
+        reasoning_effort: 'high',
+        temperature: 0.2,
+        operating_mode: 'fast',
+        yolo_mode: true,
+        max_turns: 4,
+        spend_cap_usd: 0.05,
+      },
+    },
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:10:00Z',
+    message_count: 4,
+    event_count: 12,
+    pending_approval_count: 0,
+    pending_approvals: [],
+    tool_calls: [],
+    metrics: {
+      session_id: 'session-1',
+      turn_count: 3,
+      prompt_tokens: 1200,
+      completion_tokens: 800,
+      total_tokens: 2000,
+      estimated_cost_usd: 0.045,
+      tool_calls: 3,
+      tool_errors: 1,
+      tool_retries: 1,
+      tool_latency_ms: 90000,
+      average_tool_latency_ms: 30000,
+      error_count: 1,
+      last_updated_at: '2026-07-01T00:10:00Z',
+    },
+  };
+}
+
+describe('UsageMeterPanel', () => {
+  it('renders session usage estimates, budget guardrails, runtime usage, and HF quota warnings', () => {
+    render(
+      <UsageMeterPanel
+        session={session()}
+        toolCalls={[
+          toolCall({ id: 'job-run', tool_name: 'manage_job', arguments: { operation: 'run' } }),
+          toolCall({ id: 'sandbox-run', tool_name: 'experiment_workspace', arguments: { operation: 'run' } }),
+          toolCall({
+            id: 'quota-error',
+            tool_name: 'manage_job',
+            status: 'failed',
+            success: false,
+            error: 'namespace has no available credits. Add credits at https://huggingface.co/settings/billing',
+          }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Usage and cost estimate' });
+    expect(within(panel).getByText('2K tokens')).toBeInTheDocument();
+    expect(within(panel).getByText('$0.0450 est.')).toBeInTheDocument();
+    expect(within(panel).getByText('90% of $0.05 cap')).toBeInTheDocument();
+    expect(within(panel).getByText('3 / 4 turns')).toBeInTheDocument();
+    expect(within(panel).getByText('HF Jobs')).toBeInTheDocument();
+    expect(within(panel).getByText('Hugging Face credits or quota needed')).toBeInTheDocument();
+    expect(within(panel).getByText(/Estimates only/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/UsageMeterPanel.tsx
+++ b/frontend/src/components/UsageMeterPanel.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from 'react';
+import { buildUsageMeterSummary } from '../usageMeter';
+import type { SessionDetail, ToolCallPayload } from '../types';
+
+interface UsageMeterPanelProps {
+  session: SessionDetail | null;
+  toolCalls: ToolCallPayload[];
+}
+
+function formatCompact(value: number) {
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
+}
+
+function formatCurrency(value: number, maximumFractionDigits = 4, minimumFractionDigits = maximumFractionDigits) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits,
+    minimumFractionDigits,
+  }).format(value);
+}
+
+function formatLatency(value: number) {
+  if (value < 1000) return `${Math.round(value)}ms`;
+  return `${(value / 1000).toFixed(1)}s`;
+}
+
+function progressLabel(percent: number | null, fallback: string) {
+  return percent === null ? fallback : `${percent}%`;
+}
+
+export default function UsageMeterPanel({ session, toolCalls }: UsageMeterPanelProps) {
+  const summary = useMemo(
+    () => (session ? buildUsageMeterSummary(session, toolCalls) : null),
+    [session, toolCalls],
+  );
+
+  return (
+    <section className="usage-meter-panel" aria-label="Usage and cost estimate">
+      <div className="usage-meter-header">
+        <div>
+          <p className="panel-label">Usage</p>
+          <h3>Cost estimate</h3>
+          <p className="muted">Tracks tokens, estimated provider spend, runtime tools, and budget hints.</p>
+        </div>
+        <span className={`status-chip ${summary?.warningLevel ?? 'neutral'}`}>
+          {summary?.warningLevel === 'danger'
+            ? 'cap reached'
+            : summary?.warningLevel === 'warning'
+              ? 'near cap'
+              : 'estimate'}
+        </span>
+      </div>
+
+      {!session || !summary ? (
+        <p className="muted">Usage estimates will appear after you select or create a session.</p>
+      ) : (
+        <>
+          <div className="usage-meter-grid">
+            <article className="usage-meter-card">
+              <span>Tokens</span>
+              <strong>{formatCompact(session.metrics.total_tokens)} tokens</strong>
+              <p>
+                {formatCompact(session.metrics.prompt_tokens)} prompt ·{' '}
+                {formatCompact(session.metrics.completion_tokens)} completion
+              </p>
+            </article>
+
+            <article className="usage-meter-card">
+              <span>Estimated provider cost</span>
+              <strong>{formatCurrency(session.metrics.estimated_cost_usd)} est.</strong>
+              <p>
+                {summary.costProgressPercent === null || summary.costCapUsd === null
+                  ? 'No spend cap set for this session'
+                  : `${progressLabel(summary.costProgressPercent, '0%')} of ${formatCurrency(summary.costCapUsd, 2, 2)} cap`}
+              </p>
+              <div className="usage-meter-progress" aria-label="Spend cap progress">
+                <span style={{ width: `${Math.min(summary.costProgressPercent ?? 0, 100)}%` }} />
+              </div>
+            </article>
+
+            <article className="usage-meter-card">
+              <span>Turns</span>
+              <strong>
+                {summary.turnCap === null
+                  ? `${session.metrics.turn_count} turns`
+                  : `${session.metrics.turn_count} / ${summary.turnCap} turns`}
+              </strong>
+              <p>
+                {summary.turnProgressPercent === null
+                  ? 'No max-turn guardrail set'
+                  : `${summary.turnProgressPercent}% of session turn budget`}
+              </p>
+              <div className="usage-meter-progress" aria-label="Turn cap progress">
+                <span style={{ width: `${Math.min(summary.turnProgressPercent ?? 0, 100)}%` }} />
+              </div>
+            </article>
+
+            <article className="usage-meter-card">
+              <span>Tool health</span>
+              <strong>{session.metrics.tool_calls} calls</strong>
+              <p>
+                {session.metrics.tool_errors} errors · {session.metrics.tool_retries} retries · avg{' '}
+                {formatLatency(session.metrics.average_tool_latency_ms)}
+              </p>
+            </article>
+          </div>
+
+          {summary.runtimeBreakdown.length ? (
+            <div className="usage-meter-breakdown" aria-label="Runtime usage breakdown">
+              {summary.runtimeBreakdown.map((item) => (
+                <div className="usage-meter-breakdown-item" key={item.label}>
+                  <strong>{item.label}</strong>
+                  <span>{item.count}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="muted">Runtime usage appears after jobs, sandboxes, publishing, or experiment-loop tools run.</p>
+          )}
+
+          {summary.hfQuotaWarning ? (
+            <div className="usage-meter-warning">
+              <strong>{summary.hfQuotaWarning.title}</strong>
+              <p>{summary.hfQuotaWarning.body}</p>
+              <a href={summary.hfQuotaWarning.href} rel="noopener noreferrer" target="_blank">
+                Open Hugging Face billing
+              </a>
+            </div>
+          ) : null}
+
+          <p className="hint">{summary.copyNote}</p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1321,6 +1321,122 @@ button {
   font-size: 0.72rem;
 }
 
+.usage-meter-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(34, 197, 94, 0.18);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at top right, rgba(34, 197, 94, 0.1), transparent 36%),
+    rgba(8, 15, 28, 0.9);
+}
+
+.usage-meter-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.usage-meter-header h3 {
+  margin: 4px 0;
+  letter-spacing: -0.03em;
+}
+
+.usage-meter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(124px, 1fr));
+  gap: 10px;
+}
+
+.usage-meter-card {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 16px;
+  background: rgba(3, 7, 18, 0.66);
+}
+
+.usage-meter-card span,
+.usage-meter-warning span {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.usage-meter-card strong {
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.usage-meter-card p,
+.usage-meter-warning p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.usage-meter-progress {
+  overflow: hidden;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.usage-meter-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--success), var(--warning));
+}
+
+.usage-meter-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.usage-meter-breakdown-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 9px;
+  border: 1px solid rgba(34, 197, 94, 0.16);
+  border-radius: 999px;
+  background: rgba(20, 83, 45, 0.18);
+  color: #bbf7d0;
+  font-size: 0.72rem;
+}
+
+.usage-meter-breakdown-item span {
+  color: var(--text);
+  font-family: monospace;
+}
+
+.usage-meter-warning {
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+  border: 1px solid rgba(245, 158, 11, 0.24);
+  border-radius: 16px;
+  background: rgba(120, 53, 15, 0.2);
+}
+
+.usage-meter-warning a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.usage-meter-warning a:hover {
+  text-decoration: underline;
+}
+
 .runtime-detail-panel {
   display: grid;
   gap: 14px;

--- a/frontend/src/usageMeter.test.ts
+++ b/frontend/src/usageMeter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildUsageMeterSummary } from './usageMeter';
+import type { SessionDetail, ToolCallPayload } from './types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T00:00:00Z',
+    finished_at: '2026-07-01T00:01:30Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    id: 'session-1',
+    title: 'Usage check',
+    status: 'idle',
+    model: 'zai-org/GLM-5.2:novita',
+    metadata: {
+      agent_controls: {
+        provider: 'zai',
+        reasoning_effort: 'high',
+        temperature: 0.2,
+        operating_mode: 'fast',
+        yolo_mode: true,
+        max_turns: 4,
+        spend_cap_usd: 0.05,
+      },
+    },
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:10:00Z',
+    message_count: 4,
+    event_count: 12,
+    pending_approval_count: 0,
+    pending_approvals: [],
+    tool_calls: [],
+    metrics: {
+      session_id: 'session-1',
+      turn_count: 3,
+      prompt_tokens: 1200,
+      completion_tokens: 800,
+      total_tokens: 2000,
+      estimated_cost_usd: 0.045,
+      tool_calls: 3,
+      tool_errors: 1,
+      tool_retries: 1,
+      tool_latency_ms: 90000,
+      average_tool_latency_ms: 30000,
+      error_count: 1,
+      last_updated_at: '2026-07-01T00:10:00Z',
+    },
+    ...overrides,
+  };
+}
+
+describe('usageMeter', () => {
+  it('summarizes usage, budget progress, runtime mix, and HF quota warnings', () => {
+    const summary = buildUsageMeterSummary(session(), [
+      toolCall({ id: 'job-run', tool_name: 'manage_job', arguments: { operation: 'run' } }),
+      toolCall({ id: 'sandbox-run', tool_name: 'experiment_workspace', arguments: { operation: 'run' } }),
+      toolCall({
+        id: 'quota-error',
+        tool_name: 'manage_job',
+        status: 'failed',
+        success: false,
+        error: 'namespace has no available credits. Add credits at https://huggingface.co/settings/billing',
+      }),
+    ]);
+
+    expect(summary.costProgressPercent).toBe(90);
+    expect(summary.turnProgressPercent).toBe(75);
+    expect(summary.warningLevel).toBe('warning');
+    expect(summary.runtimeBreakdown).toEqual([
+      { label: 'HF Jobs', count: 2 },
+      { label: 'Sandbox', count: 1 },
+    ]);
+    expect(summary.hfQuotaWarning?.title).toBe('Hugging Face credits or quota needed');
+    expect(summary.copyNote).toContain('Estimates only');
+  });
+});

--- a/frontend/src/usageMeter.ts
+++ b/frontend/src/usageMeter.ts
@@ -1,0 +1,89 @@
+import { readStoredAgentControls } from './sessionControls';
+import type { SessionDetail, ToolCallPayload } from './types';
+
+export type UsageWarningLevel = 'neutral' | 'warning' | 'danger';
+
+export interface UsageMeterSummary {
+  costCapUsd: number | null;
+  costProgressPercent: number | null;
+  turnCap: number | null;
+  turnProgressPercent: number | null;
+  warningLevel: UsageWarningLevel;
+  runtimeBreakdown: Array<{ label: string; count: number }>;
+  hfQuotaWarning: { title: string; body: string; href: string } | null;
+  copyNote: string;
+}
+
+const HF_BILLING_URL = 'https://huggingface.co/settings/billing';
+const QUOTA_PATTERNS = ['credits', 'quota', 'billing', 'payment required', '402'];
+const RUNTIME_LABELS: Record<string, string> = {
+  manage_job: 'HF Jobs',
+  experiment_workspace: 'Sandbox',
+  publish_model_report: 'Publishing',
+  manage_experiment_loop: 'Experiment loop',
+};
+
+export function buildUsageMeterSummary(session: SessionDetail, toolCalls: ToolCallPayload[]): UsageMeterSummary {
+  const controls = readStoredAgentControls(session.metadata);
+  const costCapUsd = controls?.spend_cap_usd ?? null;
+  const turnCap = controls?.max_turns ?? null;
+  const costProgressPercent = progress(session.metrics.estimated_cost_usd, costCapUsd);
+  const turnProgressPercent = progress(session.metrics.turn_count, turnCap);
+
+  return {
+    costCapUsd,
+    costProgressPercent,
+    turnCap,
+    turnProgressPercent,
+    warningLevel: highestWarning(costProgressPercent, turnProgressPercent),
+    runtimeBreakdown: buildRuntimeBreakdown(toolCalls),
+    hfQuotaWarning: findHfQuotaWarning(toolCalls),
+    copyNote: 'Estimates only. Actual charges happen with your configured model provider or Hugging Face account.',
+  };
+}
+
+function progress(value: number, cap: number | null): number | null {
+  if (cap === null || cap <= 0) return null;
+  return Math.round((Math.max(0, value) / cap) * 100);
+}
+
+function highestWarning(...progressValues: Array<number | null>): UsageWarningLevel {
+  if (progressValues.some((value) => value !== null && value >= 100)) return 'danger';
+  if (progressValues.some((value) => value !== null && value >= 80)) return 'warning';
+  return 'neutral';
+}
+
+function buildRuntimeBreakdown(toolCalls: ToolCallPayload[]) {
+  const counts = new Map<string, number>();
+
+  for (const call of toolCalls) {
+    const label = RUNTIME_LABELS[call.tool_name];
+    if (!label) continue;
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+function findHfQuotaWarning(toolCalls: ToolCallPayload[]) {
+  const call = toolCalls.find((item) => hasQuotaText(item.output) || hasQuotaText(item.error));
+  if (!call) return null;
+
+  return {
+    title: 'Hugging Face credits or quota needed',
+    body: 'A Hugging Face Jobs or Sandbox action reported a credits, quota, or billing problem. Add credits or adjust the run in your HF account, then retry.',
+    href: firstUrl(call.output) ?? firstUrl(call.error) ?? HF_BILLING_URL,
+  };
+}
+
+function hasQuotaText(value: string | null | undefined) {
+  if (!value) return false;
+  const lowered = value.toLowerCase();
+  return QUOTA_PATTERNS.some((pattern) => lowered.includes(pattern));
+}
+
+function firstUrl(text: string | null | undefined) {
+  return text?.match(/https?:\/\/[^\s)]+/)?.[0] ?? null;
+}


### PR DESCRIPTION
## Summary
- Add a dedicated usage and cost estimate panel to the inspector, backed by existing session metrics and persisted tool calls.
- Summarize tokens, estimated provider cost, turn/spend-cap progress, tool health, runtime mix, and HF credits/quota warnings.
- Keep copy explicit that values are estimates for the user's configured provider or Hugging Face account, not ML Copilot platform billing.
- Add typed summary helpers plus Vitest/Testing Library coverage for budget progress and quota-warning behavior.

## Testing
- npm test
- npm run build
- npm audit --omit=dev
- python -m pytest tests/ -q
- ruff check app/ tests/
- ruff format --check app/ tests/
- mypy app/ --ignore-missing-imports --follow-imports=skip
- git diff --check

## Notes
This slice intentionally uses existing persisted metrics, metadata budget hints, and tool output. Real HF account billing API totals should be added later behind a dedicated backend endpoint if needed.

## Reference
Closes #112