### PR TITLE
ML-406 / Build file and artifact browser

### DIFF
--- a/docs/superpowers/plans/2026-07-01-file-artifact-browser.md
+++ b/docs/superpowers/plans/2026-07-01-file-artifact-browser.md
@@ -1,0 +1,153 @@
+# File and Artifact Browser Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build ML-406, a safe frontend file/artifact browser that surfaces generated files, provenance, and bounded previews from persisted session tool calls.
+
+**Architecture:** Keep this slice frontend-first. Add a pure artifact extraction module that derives safe file-like records from existing `ToolCallPayload` data, a focused `ArtifactBrowserPanel` component for browsing and previews, and tool-card links that deep-link into the browser. Do not add broad filesystem read APIs in this slice.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing session/tool-call API payloads.
+
+---
+
+### Task 1: Artifact extraction helper
+
+**Files:**
+- Create: `frontend/src/artifactBrowser.ts`
+- Test: `frontend/src/artifactBrowser.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/artifactBrowser.test.ts` with a test that calls `buildArtifactBrowserItems(toolCalls)` and expects:
+
+```ts
+expect(items.map((item) => item.path)).toContain('src/train.py');
+expect(items.map((item) => item.path)).toContain('.ml-copilot/reports/model-a/README.md');
+expect(items.find((item) => item.path.includes('secret'))?.safe).toBe(false);
+expect(items.find((item) => item.path.endsWith('README.md'))?.preview).toContain('# Model Card');
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- artifactBrowser.test.ts` from `frontend/`.
+Expected: FAIL because `./artifactBrowser` does not exist.
+
+- [ ] **Step 3: Implement minimal helper**
+
+Create `artifactBrowser.ts` with:
+
+- `buildArtifactBrowserItems(toolCalls: ToolCallPayload[]): ArtifactBrowserItem[]`
+- safe path filtering for absolute paths, traversal, home paths, and environment-ish secret paths
+- bounded preview extraction from tool output/error
+- classification for Markdown, JSON, Python, text, directory, and artifact records
+- deterministic de-duplication by normalized path
+
+- [ ] **Step 4: Run focused helper test**
+
+Run: `npm test -- artifactBrowser.test.ts`.
+Expected: PASS.
+
+### Task 2: Browser panel UI
+
+**Files:**
+- Create: `frontend/src/components/ArtifactBrowserPanel.tsx`
+- Test: `frontend/src/components/ArtifactBrowserPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create a test that renders `ArtifactBrowserPanel` with sandbox and publishing tool calls and expects:
+
+- region name `File and artifact browser`
+- counts for safe artifacts and blocked paths
+- type/provenance labels
+- bounded preview text
+- a blocked unsafe path warning
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- ArtifactBrowserPanel.test.tsx`.
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement panel**
+
+Build a panel with:
+
+- a summary header
+- artifact list with type, source tool, provenance, size when known, safe/blocked status
+- selected artifact preview
+- empty state when no artifacts exist
+- safe-path copy/open command affordances only for safe items
+
+- [ ] **Step 4: Run focused component test**
+
+Run: `npm test -- ArtifactBrowserPanel.test.tsx`.
+Expected: PASS.
+
+### Task 3: Wire into workbench and trace cards
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/ToolTracePanel.tsx`
+- Modify: `frontend/src/components/ToolTracePanel.test.tsx`
+- Modify: `frontend/src/styles.css`
+
+- [ ] **Step 1: Write failing trace-card expectation**
+
+Extend the tool trace test to expect relevant sandbox/publishing cards include an `Open artifact browser` link with `href="#artifact-browser"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- ToolTracePanel.test.tsx`.
+Expected: FAIL because the link is not present yet.
+
+- [ ] **Step 3: Implement wiring**
+
+- Import and render `ArtifactBrowserPanel` in the inspector stack after runtime details.
+- Add `Artifact browser` metadata link to sandbox, publishing, repository, and dataset-like tool cards.
+- Add styles for `.artifact-browser-*`.
+
+- [ ] **Step 4: Run focused frontend tests**
+
+Run: `npm test -- artifactBrowser.test.ts ArtifactBrowserPanel.test.tsx ToolTracePanel.test.tsx`.
+Expected: PASS.
+
+### Task 4: Full verification and publish
+
+**Files:**
+- All changed files.
+
+- [ ] **Step 1: Run frontend validation**
+
+Run from `frontend/`:
+
+```bash
+npm test
+npm run build
+```
+
+- [ ] **Step 2: Run backend/regression validation**
+
+Run from repo root:
+
+```bash
+python -m pytest tests/ -q
+ruff check app/ tests/
+ruff format --check app/ tests/
+mypy app/ --ignore-missing-imports --follow-imports=skip
+git diff --check
+pre-commit run --all-files
+```
+
+- [ ] **Step 3: Commit and open PR**
+
+Stage only ML-406 files plus this plan. Commit with `ML-406: Build file and artifact browser`, push `feature/ML-406-file-artifact-browser`, and open a PR whose body contains `Closes #114`.
+
+- [ ] **Step 4: Verify PR metadata**
+
+Run:
+
+```bash
+gh pr view <pr> --json assignees,labels,closingIssuesReferences
+```
+
+Expected: assignee `Sohail-Shaikh-07`, labels `feature` and `phase5`, closing issue `#114`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
   sendChatMessage,
 } from './api';
 import ApprovalDialog from './components/ApprovalDialog';
+import ArtifactBrowserPanel from './components/ArtifactBrowserPanel';
 import JobProgressPanel from './components/JobProgressPanel';
 import RichMessageContent from './components/RichMessageContent';
 import RuntimeDetailPanel from './components/RuntimeDetailPanel';
@@ -502,6 +503,8 @@ function App() {
             <UsageMeterPanel session={activeSession} toolCalls={toolCalls} />
 
             <RuntimeDetailPanel toolCalls={toolCalls} />
+
+            <ArtifactBrowserPanel toolCalls={toolCalls} />
 
             <ToolTracePanel
               liveEvents={liveEvents}

--- a/frontend/src/artifactBrowser.test.ts
+++ b/frontend/src/artifactBrowser.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildArtifactBrowserItems } from './artifactBrowser';
+import type { ToolCallPayload } from './types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'experiment_workspace',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('buildArtifactBrowserItems', () => {
+  it('extracts safe artifacts with provenance, bounded previews, and blocked unsafe paths', () => {
+    const items = buildArtifactBrowserItems([
+      toolCall({
+        id: 'sandbox-write',
+        arguments: { operation: 'write', path: 'src/train.py' },
+        output: 'Wrote src/train.py (128 bytes).\n```python\nprint("train")\n```',
+      }),
+      toolCall({
+        id: 'sandbox-read',
+        arguments: { operation: 'read', path: '../secrets.env' },
+        output: '### ../secrets.env\n```text\nHF_TOKEN=should-not-open\n```',
+      }),
+      toolCall({
+        id: 'publish-report',
+        tool_name: 'publish_model_report',
+        arguments: { output_dir: '.ml-copilot/reports/model-a' },
+        output: [
+          'Prepared model publishing assets.',
+          '- README: .ml-copilot/reports/model-a/README.md',
+          '- Final report: .ml-copilot/reports/model-a/FINAL_REPORT.md',
+          '- Manifest: .ml-copilot/reports/model-a/publish_manifest.json',
+          '',
+          '### .ml-copilot/reports/model-a/README.md',
+          '```markdown',
+          '# Model Card',
+          'This model was evaluated on a fixture dataset.',
+          '```',
+        ].join('\n'),
+      }),
+    ]);
+
+    expect(items.map((item) => item.path)).toContain('src/train.py');
+    expect(items.map((item) => item.path)).toContain('.ml-copilot/reports/model-a/README.md');
+    expect(items.map((item) => item.path)).toContain('../secrets.env');
+
+    const readme = items.find((item) => item.path.endsWith('README.md'));
+    expect(readme).toMatchObject({
+      fileName: 'README.md',
+      kind: 'Markdown',
+      provenance: 'publish_model_report',
+      safe: true,
+      sizeLabel: null,
+    });
+    expect(readme?.preview).toContain('# Model Card');
+
+    const trainFile = items.find((item) => item.path === 'src/train.py');
+    expect(trainFile).toMatchObject({
+      fileName: 'train.py',
+      kind: 'Python',
+      sizeLabel: '128 B',
+      safe: true,
+    });
+
+    const unsafe = items.find((item) => item.path === '../secrets.env');
+    expect(unsafe).toMatchObject({
+      safe: false,
+      blockedReason: 'Path traversal is blocked',
+      preview: null,
+    });
+  });
+});

--- a/frontend/src/artifactBrowser.ts
+++ b/frontend/src/artifactBrowser.ts
@@ -1,0 +1,180 @@
+import type { ToolCallPayload } from './types';
+
+export interface ArtifactBrowserItem {
+  id: string;
+  path: string;
+  fileName: string;
+  kind: string;
+  provenance: string;
+  sourceCallId: string;
+  safe: boolean;
+  blockedReason: string | null;
+  sizeLabel: string | null;
+  preview: string | null;
+}
+
+const PREVIEW_LIMIT = 1200;
+const PATH_KEYS = ['path', 'file_path', 'workspace_path', 'output_path', 'report_path', 'manifest_path'];
+const FILE_EXTENSIONS = ['md', 'markdown', 'json', 'py', 'txt', 'csv', 'yaml', 'yml', 'log', 'html', 'env'];
+const PATH_RE = /(?:[A-Za-z]:[\\/]|\.{1,2}[\\/]|~[\\/])?(?:[A-Za-z0-9_.-]+[\\/])+[A-Za-z0-9_.-]+\.(?:md|markdown|json|py|txt|csv|ya?ml|log|html|env)\b/g;
+
+function firstNonEmptyText(...values: Array<string | null | undefined>) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function getArgText(args: Record<string, unknown>, key: string) {
+  const value = args[key];
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+}
+
+function normalizePath(path: string) {
+  return path.trim().replace(/^['"`]|['"`]$/g, '').replace(/\\/g, '/');
+}
+
+function displayPath(path: string) {
+  return path.trim().replace(/^['"`]|['"`]$/g, '');
+}
+
+function fileName(path: string) {
+  return normalizePath(path).split('/').filter(Boolean).pop() ?? path;
+}
+
+function extension(path: string) {
+  const name = fileName(path).toLowerCase();
+  return name.includes('.') ? name.split('.').pop() ?? '' : '';
+}
+
+function classify(path: string) {
+  const ext = extension(path);
+  if (ext === 'md' || ext === 'markdown') return 'Markdown';
+  if (ext === 'json') return 'JSON';
+  if (ext === 'py') return 'Python';
+  if (ext === 'csv') return 'CSV';
+  if (ext === 'yaml' || ext === 'yml') return 'YAML';
+  if (ext === 'log') return 'Log';
+  if (ext === 'html') return 'HTML';
+  return 'Text';
+}
+
+function formatSize(bytes: number | null) {
+  if (bytes === null) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(kb >= 10 ? 0 : 1)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(mb >= 10 ? 0 : 1)} MB`;
+}
+
+function safetyForPath(path: string): { safe: boolean; blockedReason: string | null } {
+  const normalized = normalizePath(path);
+  if (/^[A-Za-z]:\//.test(normalized) || normalized.startsWith('/') || normalized.startsWith('~/')) {
+    return { safe: false, blockedReason: 'Unsafe absolute path is blocked' };
+  }
+  if (normalized.split('/').includes('..')) {
+    return { safe: false, blockedReason: 'Path traversal is blocked' };
+  }
+  if (/(^|\/)(\.env|.*secret.*|.*token.*)$/i.test(normalized)) {
+    return { safe: false, blockedReason: 'Sensitive-looking path is blocked' };
+  }
+  return { safe: true, blockedReason: null };
+}
+
+function boundedPreview(value: string | null) {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.length <= PREVIEW_LIMIT) return trimmed;
+  return `${trimmed.slice(0, PREVIEW_LIMIT).trimEnd()}\n...`;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function previewForPath(path: string, output: string | null | undefined) {
+  if (!output) return null;
+  const normalized = normalizePath(path);
+  const display = displayPath(path);
+  const headingPatterns = [normalized, display, fileName(path)].map(escapeRegExp);
+
+  for (const pattern of headingPatterns) {
+    const heading = new RegExp(`^#{1,4}\\s+${pattern}\\s*\\r?\\n\`\`\`\\w*\\s*\\r?\\n([\\s\\S]*?)\\r?\\n\`\`\``, 'im');
+    const match = output.match(heading);
+    if (match?.[1]) return boundedPreview(match[1]);
+  }
+
+  const fenced = output.match(/```\w*\s*\r?\n([\s\S]*?)\r?\n```/);
+  if (fenced?.[1]) return boundedPreview(fenced[1]);
+
+  return null;
+}
+
+function collectCandidatePaths(call: ToolCallPayload) {
+  const output = firstNonEmptyText(call.output, call.error);
+  const candidates: Array<{ path: string; sizeBytes: number | null }> = [];
+
+  for (const key of PATH_KEYS) {
+    const value = getArgText(call.arguments, key);
+    if (value) candidates.push({ path: value, sizeBytes: null });
+  }
+
+  if (output) {
+    for (const match of output.matchAll(/^Wrote\s+(.+?)\s+\((\d+)\s+bytes\)\.?$/gim)) {
+      candidates.push({ path: match[1], sizeBytes: Number(match[2]) });
+    }
+
+    for (const match of output.matchAll(/^- (?:README|Final report|Manifest|Report|Model card|Dataset|Artifact):\s*(.+)$/gim)) {
+      candidates.push({ path: match[1], sizeBytes: null });
+    }
+
+    for (const match of output.matchAll(PATH_RE)) {
+      candidates.push({ path: match[0], sizeBytes: null });
+    }
+  }
+
+  return candidates;
+}
+
+export function buildArtifactBrowserItems(toolCalls: ToolCallPayload[]): ArtifactBrowserItem[] {
+  const items = new Map<string, ArtifactBrowserItem>();
+
+  for (const call of toolCalls) {
+    const output = firstNonEmptyText(call.output, call.error);
+    for (const candidate of collectCandidatePaths(call)) {
+      const path = displayPath(candidate.path);
+      const normalized = normalizePath(path);
+      if (!path || !FILE_EXTENSIONS.includes(extension(path))) continue;
+      const safety = safetyForPath(path);
+      const id = normalized.toLowerCase();
+      const existing = items.get(id);
+      const preview = safety.safe ? previewForPath(path, output) : null;
+
+      items.set(id, {
+        id,
+        path,
+        fileName: fileName(path),
+        kind: classify(path),
+        provenance: existing?.provenance ?? call.tool_name,
+        sourceCallId: existing?.sourceCallId ?? call.id,
+        safe: safety.safe,
+        blockedReason: safety.blockedReason,
+        sizeLabel: existing?.sizeLabel ?? formatSize(candidate.sizeBytes),
+        preview: existing?.preview ?? preview,
+      });
+    }
+  }
+
+  return [...items.values()].sort((a, b) => {
+    if (a.safe !== b.safe) return a.safe ? -1 : 1;
+    return a.path.localeCompare(b.path);
+  });
+}
+
+export function artifactReadAction(path: string) {
+  return `experiment_workspace operation='read' path='${path}'`;
+}

--- a/frontend/src/components/ArtifactBrowserPanel.test.tsx
+++ b/frontend/src/components/ArtifactBrowserPanel.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import ArtifactBrowserPanel from './ArtifactBrowserPanel';
+import type { ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'experiment_workspace',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('ArtifactBrowserPanel', () => {
+  it('lists artifacts, blocks unsafe paths, and shows bounded previews for selected files', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ArtifactBrowserPanel
+        toolCalls={[
+          toolCall({
+            id: 'sandbox-write',
+            arguments: { operation: 'write', path: 'src/train.py' },
+            output: 'Wrote src/train.py (128 bytes).\n```python\nprint("train")\n```',
+          }),
+          toolCall({
+            id: 'unsafe-read',
+            arguments: { operation: 'read', path: 'C:\\Users\\sohai\\.env' },
+            output: '### C:\\Users\\sohai\\.env\n```text\nTOKEN=hidden\n```',
+          }),
+          toolCall({
+            id: 'publish-report',
+            tool_name: 'publish_model_report',
+            arguments: { output_dir: '.ml-copilot/reports/model-a' },
+            output: [
+              '- README: .ml-copilot/reports/model-a/README.md',
+              '- Manifest: .ml-copilot/reports/model-a/publish_manifest.json',
+              '',
+              '### .ml-copilot/reports/model-a/README.md',
+              '```markdown',
+              '# Model Card',
+              'Evaluation summary and card metadata.',
+              '```',
+            ].join('\n'),
+          }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'File and artifact browser' });
+    expect(within(panel).getByText('3 safe files')).toBeInTheDocument();
+    expect(within(panel).getByText('1 blocked path')).toBeInTheDocument();
+    expect(within(panel).getByText('README.md')).toBeInTheDocument();
+    expect(within(panel).getAllByText('publish_model_report').length).toBeGreaterThan(0);
+    expect(within(panel).getByText('C:\\Users\\sohai\\.env')).toBeInTheDocument();
+    expect(within(panel).getByText('Unsafe absolute path is blocked')).toBeInTheDocument();
+
+    await user.click(within(panel).getByRole('button', { name: 'Preview README.md' }));
+
+    const preview = within(panel).getByTestId('artifact-preview');
+    expect(within(preview).getByText('.ml-copilot/reports/model-a/README.md')).toBeInTheDocument();
+    expect(within(preview).getByText('Markdown')).toBeInTheDocument();
+    expect(within(preview).getByText(/# Model Card/)).toBeInTheDocument();
+    expect(within(preview).getByText("experiment_workspace operation='read' path='.ml-copilot/reports/model-a/README.md'")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ArtifactBrowserPanel.tsx
+++ b/frontend/src/components/ArtifactBrowserPanel.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+
+import { artifactReadAction, buildArtifactBrowserItems } from '../artifactBrowser';
+import type { ArtifactBrowserItem } from '../artifactBrowser';
+import type { ToolCallPayload } from '../types';
+
+interface ArtifactBrowserPanelProps {
+  toolCalls: ToolCallPayload[];
+}
+
+function formatCount(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function statusClass(item: ArtifactBrowserItem) {
+  return item.safe ? 'success' : 'warning';
+}
+
+export default function ArtifactBrowserPanel({ toolCalls }: ArtifactBrowserPanelProps) {
+  const items = useMemo(() => buildArtifactBrowserItems(toolCalls), [toolCalls]);
+  const safeItems = items.filter((item) => item.safe);
+  const blockedItems = items.filter((item) => !item.safe);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = items.find((item) => item.id === selectedId) ?? safeItems[0] ?? items[0] ?? null;
+
+  return (
+    <section className="artifact-browser-panel" id="artifact-browser" aria-label="File and artifact browser">
+      <div className="artifact-browser-header">
+        <div>
+          <p className="panel-label">Artifacts</p>
+          <h3>File and artifact browser</h3>
+          <p className="muted">Safe, bounded previews recovered from persisted session tool output.</p>
+        </div>
+        <div className="runtime-detail-counts">
+          <span className="status-chip success">{formatCount(safeItems.length, 'safe file')}</span>
+          <span className="status-chip warning">{formatCount(blockedItems.length, 'blocked path')}</span>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="muted">Generated artifacts, reports, manifests, and sandbox files will appear here after tools produce them.</p>
+      ) : (
+        <div className="artifact-browser-layout">
+          <div className="artifact-browser-list">
+            {items.map((item) => (
+              <article className={`artifact-browser-item ${item.safe ? '' : 'blocked'}`} key={item.id}>
+                <div>
+                  <span className={`status-chip ${statusClass(item)}`}>{item.safe ? item.kind : 'Blocked'}</span>
+                  <strong>{item.fileName}</strong>
+                  <code>{item.path}</code>
+                </div>
+                <dl>
+                  <div>
+                    <dt>Source</dt>
+                    <dd>{item.provenance}</dd>
+                  </div>
+                  {item.sizeLabel ? (
+                    <div>
+                      <dt>Size</dt>
+                      <dd>{item.sizeLabel}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+                {item.blockedReason ? <p className="artifact-browser-warning">{item.blockedReason}</p> : null}
+                <button
+                  className="ghost-button"
+                  type="button"
+                  disabled={!item.safe}
+                  onClick={() => setSelectedId(item.id)}
+                  aria-label={`Preview ${item.fileName}`}
+                >
+                  {item.safe ? 'Preview' : 'Blocked'}
+                </button>
+              </article>
+            ))}
+          </div>
+
+          {selected ? (
+            <article className="artifact-browser-preview" data-testid="artifact-preview">
+              <div className="runtime-detail-card-head">
+                <div>
+                  <span>{selected.kind}</span>
+                  <h4>{selected.fileName}</h4>
+                </div>
+                <span className={`status-chip ${statusClass(selected)}`}>{selected.safe ? 'safe' : 'blocked'}</span>
+              </div>
+              <code>{selected.path}</code>
+              <p className="muted">Provenance: {selected.provenance}</p>
+              {selected.safe ? (
+                <>
+                  <pre>{selected.preview ?? 'No text preview was captured for this artifact yet.'}</pre>
+                  <div className="runtime-detail-actions">
+                    <code>{artifactReadAction(selected.path)}</code>
+                  </div>
+                </>
+              ) : (
+                <p className="artifact-browser-warning">{selected.blockedReason}</p>
+              )}
+            </article>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ToolTracePanel.test.tsx
+++ b/frontend/src/components/ToolTracePanel.test.tsx
@@ -122,9 +122,17 @@ describe('ToolTracePanel', () => {
       'href',
       '#runtime-details',
     );
+    expect(within(sandboxCard).getByRole('link', { name: 'Open artifact browser' })).toHaveAttribute(
+      'href',
+      '#artifact-browser',
+    );
 
     const publishCard = screen.getByTestId('tool-card-publish-call');
     expect(within(publishCard).getByText('Publishing')).toBeInTheDocument();
     expect(within(publishCard).getByText('.ml-copilot/reports/model-a')).toBeInTheDocument();
+    expect(within(publishCard).getByRole('link', { name: 'Open artifact browser' })).toHaveAttribute(
+      'href',
+      '#artifact-browser',
+    );
   });
 });

--- a/frontend/src/components/ToolTracePanel.tsx
+++ b/frontend/src/components/ToolTracePanel.tsx
@@ -197,6 +197,15 @@ function addRuntimePanelLink(items: ToolMetadataItem[]) {
   });
 }
 
+function addArtifactBrowserLink(items: ToolMetadataItem[]) {
+  addMetadata(items, {
+    label: 'Artifacts',
+    value: 'Artifact browser',
+    href: '#artifact-browser',
+    linkLabel: 'Open artifact browser',
+  });
+}
+
 function buildToolProfile(call: ToolCallPayload): ToolProfile {
   const args = call.arguments;
   const output = textOutput(call);
@@ -237,6 +246,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
       if (path) addMetadata(metadata, { label: 'Path', value: path });
       if (sandboxId) addMetadata(metadata, { label: 'Sandbox', value: sandboxId });
       addRuntimePanelLink(metadata);
+      addArtifactBrowserLink(metadata);
 
       return {
         category: 'Sandbox runtime',
@@ -268,6 +278,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
       if (outputDir) addMetadata(metadata, { label: 'Output', value: outputDir });
       if (repoId) addMetadata(metadata, { label: 'Repository', value: repoId });
       addRuntimePanelLink(metadata);
+      addArtifactBrowserLink(metadata);
 
       return {
         category: 'Publishing',
@@ -304,6 +315,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
         label: 'Resource',
         value: getArgText(args, 'dataset') ?? getArgText(args, 'repo_id') ?? getArgText(args, 'query') ?? '',
       });
+      addArtifactBrowserLink(metadata);
       return {
         category: 'Hub operation',
         title: sentenceCase(call.tool_name),
@@ -313,6 +325,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
       };
     case 'analyze_repository':
       addMetadata(metadata, { label: 'Path', value: getArgText(args, 'path') ?? '' });
+      addArtifactBrowserLink(metadata);
       return {
         category: 'Repository analysis',
         title: 'Repository analyzer',

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1624,6 +1624,100 @@ button {
   white-space: nowrap;
 }
 
+.artifact-browser-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.artifact-browser-header,
+.artifact-browser-layout {
+  display: grid;
+  gap: 14px;
+}
+
+.artifact-browser-list {
+  display: grid;
+  gap: 10px;
+}
+
+.artifact-browser-item,
+.artifact-browser-preview {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(96, 165, 250, 0.14);
+  border-radius: 16px;
+  background: rgba(3, 7, 18, 0.7);
+}
+
+.artifact-browser-item.blocked {
+  border-color: rgba(251, 191, 36, 0.22);
+  background: rgba(120, 53, 15, 0.16);
+}
+
+.artifact-browser-item strong {
+  display: block;
+  margin-top: 6px;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.artifact-browser-item code,
+.artifact-browser-preview > code {
+  overflow: hidden;
+  color: #dbeafe;
+  font-family: monospace;
+  font-size: 0.74rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-browser-item dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.artifact-browser-item dt {
+  color: var(--muted);
+  font-size: 0.64rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.artifact-browser-item dd {
+  margin: 3px 0 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-browser-warning {
+  margin: 0;
+  color: #fcd34d;
+  font-size: 0.78rem;
+}
+
+.artifact-browser-preview pre {
+  max-height: 260px;
+  margin: 0;
+  overflow: auto;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.92);
+  color: #dbeafe;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
 .tool-trace-output {
   margin-top: 10px;
   padding-top: 10px;


### PR DESCRIPTION
## Summary
- Adds a frontend File and artifact browser panel for persisted session tool-call artifacts.
- Extracts safe file references from sandbox, publishing, repository, and Hub-style tool output with provenance, type, size when known, and bounded previews.
- Blocks unsafe absolute, traversal, and sensitive-looking paths instead of surfacing them as readable/openable files.
- Adds `Open artifact browser` links from relevant tool trace cards.

Closes #114

## Validation
- `npm test` from `frontend/` — 10 files / 11 tests passed
- `npm run build` from `frontend/`
- `python -m pytest tests/ -q` — 246 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`
- `npm audit --omit=dev` from `frontend/`