### PR TITLE
ML-407 / Create eval suite dashboard and gating view

### DIFF
--- a/docs/superpowers/plans/2026-07-01-eval-suite-dashboard.md
+++ b/docs/superpowers/plans/2026-07-01-eval-suite-dashboard.md
@@ -1,0 +1,154 @@
+# Eval Suite Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build ML-407, a frontend eval suite dashboard and release-gating view from existing eval suite reports and persisted tool output.
+
+**Architecture:** Keep this slice frontend-first. Add a pure parser that extracts eval suite report JSON from tool output/artifact previews, then render a focused dashboard panel in the inspector. Link report artifacts into the artifact browser rather than adding new backend file APIs.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing `ToolCallPayload` and artifact-browser infrastructure.
+
+---
+
+### Task 1: Eval dashboard extraction helper
+
+**Files:**
+- Create: `frontend/src/evalDashboard.ts`
+- Test: `frontend/src/evalDashboard.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/evalDashboard.test.ts` with a test that calls `buildEvalDashboardSummary(toolCalls)` using a tool output containing fenced eval suite JSON:
+
+```ts
+expect(summary.gateStatus).toBe('blocked');
+expect(summary.suites[0].status).toBe('failed');
+expect(summary.suites[0].fixtures).toHaveLength(2);
+expect(summary.suites[0].fixtures[1].changedFiles).toContain('src/train.py');
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- evalDashboard.test.ts` from `frontend/`.
+Expected: FAIL because `./evalDashboard` does not exist.
+
+- [ ] **Step 3: Implement minimal parser**
+
+Create `evalDashboard.ts` with:
+
+- `buildEvalDashboardSummary(toolCalls: ToolCallPayload[]): EvalDashboardSummary`
+- suite JSON parsing from fenced code blocks and raw JSON-like output
+- gate status values `healthy`, `blocked`, `unknown`
+- fixture summaries with report/workspace/artifact paths, status, score, checks, and changed files where report data includes them
+- scripted/live mode inference from fixture metadata or agent output mode
+
+- [ ] **Step 4: Run focused helper test**
+
+Run: `npm test -- evalDashboard.test.ts`.
+Expected: PASS.
+
+### Task 2: Dashboard panel UI
+
+**Files:**
+- Create: `frontend/src/components/EvalDashboardPanel.tsx`
+- Test: `frontend/src/components/EvalDashboardPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create a test that renders `EvalDashboardPanel` with failed and passing fixture data and expects:
+
+- region name `Eval suite dashboard`
+- release gate text `Release gate blocked`
+- average score, runtime, token usage, pass/fail counts
+- fixture rows with check-level failure and changed file details
+- artifact-browser link
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- EvalDashboardPanel.test.tsx`.
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement panel**
+
+Build a panel with:
+
+- gate summary header
+- suite cards
+- fixture table/list
+- check-level and changed-file details
+- report artifact links to `#artifact-browser`
+- empty state when no eval reports are present
+
+- [ ] **Step 4: Run focused component test**
+
+Run: `npm test -- EvalDashboardPanel.test.tsx`.
+Expected: PASS.
+
+### Task 3: Wire into workbench and artifact extraction
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/artifactBrowser.ts`
+- Modify: `frontend/src/artifactBrowser.test.ts`
+- Modify: `frontend/src/styles.css`
+
+- [ ] **Step 1: Write failing artifact assertion**
+
+Extend the artifact-browser test to expect `suite-report.json` and `suite-report.md` paths from eval suite output are listed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- artifactBrowser.test.ts`.
+Expected: FAIL if suite report labels are not extracted yet.
+
+- [ ] **Step 3: Implement wiring**
+
+- Import and render `EvalDashboardPanel` in the inspector stack near the artifact browser.
+- Extend artifact extraction labels to include suite/eval report paths.
+- Add `.eval-dashboard-*` styles.
+
+- [ ] **Step 4: Run focused frontend tests**
+
+Run: `npm test -- evalDashboard.test.ts EvalDashboardPanel.test.tsx artifactBrowser.test.ts`.
+Expected: PASS.
+
+### Task 4: Full verification and publish
+
+**Files:**
+- All changed files.
+
+- [ ] **Step 1: Run frontend validation**
+
+Run from `frontend/`:
+
+```bash
+npm test
+npm run build
+```
+
+- [ ] **Step 2: Run backend/regression validation**
+
+Run from repo root:
+
+```bash
+python -m pytest tests/ -q
+ruff check app/ tests/
+ruff format --check app/ tests/
+mypy app/ --ignore-missing-imports --follow-imports=skip
+git diff --check
+pre-commit run --all-files
+```
+
+- [ ] **Step 3: Commit and open PR**
+
+Stage only ML-407 files plus this plan. Commit with `ML-407: Create eval suite dashboard`, push `feature/ML-407-eval-dashboard`, and open a PR whose body contains `Closes #116`.
+
+- [ ] **Step 4: Verify PR metadata**
+
+Run:
+
+```bash
+gh pr view <pr> --json assignees,labels,closingIssuesReferences
+```
+
+Expected: assignee `Sohail-Shaikh-07`, labels `feature` and `phase5`, closing issue `#116`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from './api';
 import ApprovalDialog from './components/ApprovalDialog';
 import ArtifactBrowserPanel from './components/ArtifactBrowserPanel';
+import EvalDashboardPanel from './components/EvalDashboardPanel';
 import JobProgressPanel from './components/JobProgressPanel';
 import RichMessageContent from './components/RichMessageContent';
 import RuntimeDetailPanel from './components/RuntimeDetailPanel';
@@ -503,6 +504,8 @@ function App() {
             <UsageMeterPanel session={activeSession} toolCalls={toolCalls} />
 
             <RuntimeDetailPanel toolCalls={toolCalls} />
+
+            <EvalDashboardPanel toolCalls={toolCalls} />
 
             <ArtifactBrowserPanel toolCalls={toolCalls} />
 

--- a/frontend/src/artifactBrowser.test.ts
+++ b/frontend/src/artifactBrowser.test.ts
@@ -50,12 +50,16 @@ describe('buildArtifactBrowserItems', () => {
           '# Model Card',
           'This model was evaluated on a fixture dataset.',
           '```',
+          '- Suite report: .ml-copilot/evals/suites/latest/suite-report.json',
+          '- Markdown report: .ml-copilot/evals/suites/latest/suite-report.md',
         ].join('\n'),
       }),
     ]);
 
     expect(items.map((item) => item.path)).toContain('src/train.py');
     expect(items.map((item) => item.path)).toContain('.ml-copilot/reports/model-a/README.md');
+    expect(items.map((item) => item.path)).toContain('.ml-copilot/evals/suites/latest/suite-report.json');
+    expect(items.map((item) => item.path)).toContain('.ml-copilot/evals/suites/latest/suite-report.md');
     expect(items.map((item) => item.path)).toContain('../secrets.env');
 
     const readme = items.find((item) => item.path.endsWith('README.md'));

--- a/frontend/src/artifactBrowser.ts
+++ b/frontend/src/artifactBrowser.ts
@@ -128,7 +128,7 @@ function collectCandidatePaths(call: ToolCallPayload) {
       candidates.push({ path: match[1], sizeBytes: Number(match[2]) });
     }
 
-    for (const match of output.matchAll(/^- (?:README|Final report|Manifest|Report|Model card|Dataset|Artifact):\s*(.+)$/gim)) {
+    for (const match of output.matchAll(/^- (?:README|Final report|Manifest|Report|Markdown report|Suite report|Model card|Dataset|Artifact):\s*(.+)$/gim)) {
       candidates.push({ path: match[1], sizeBytes: null });
     }
 

--- a/frontend/src/components/EvalDashboardPanel.test.tsx
+++ b/frontend/src/components/EvalDashboardPanel.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import EvalDashboardPanel from './EvalDashboardPanel';
+import type { ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'eval-suite-call',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_eval_suite',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('EvalDashboardPanel', () => {
+  it('shows release gate health, suite metrics, fixtures, failures, and artifact links', () => {
+    const report = {
+      status: 'failed',
+      summary: {
+        fixtures_total: 2,
+        fixtures_passed: 1,
+        fixtures_failed: 1,
+        fixtures_error: 0,
+        average_score: 0.5,
+        runtime_seconds: 9.25,
+        total_tokens: 42,
+      },
+      fixtures: [
+        {
+          fixture_id: 'fixture-pass',
+          status: 'passed',
+          score: 1,
+          markdown_path: '.ml-copilot/evals/artifacts/pass/report.md',
+          report_path: '.ml-copilot/evals/artifacts/pass/report.json',
+          report: {
+            agent_output: { mode: 'live' },
+            checks: [{ type: 'contains', passed: true, message: 'Final response contains expected text.' }],
+          },
+        },
+        {
+          fixture_id: 'fixture-fail',
+          status: 'failed',
+          score: 0,
+          markdown_path: '.ml-copilot/evals/artifacts/fail/report.md',
+          report_path: '.ml-copilot/evals/artifacts/fail/report.json',
+          workspace_path: '.ml-copilot/evals/workspaces/fail',
+          report: {
+            fixture: { metadata: { mode: 'scripted' } },
+            scoring: { file_changes: { files_changed: ['src/train.py'] } },
+            checks: [
+              {
+                type: 'file_contains',
+                passed: false,
+                path: 'src/train.py',
+                message: 'Expected metric is missing.',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    render(
+      <EvalDashboardPanel
+        toolCalls={[
+          toolCall({
+            output: ['Suite report:', '```json', JSON.stringify(report), '```'].join('\n'),
+          }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Eval suite dashboard' });
+    expect(within(panel).getByText('Release gate blocked')).toBeInTheDocument();
+    expect(within(panel).getByText('50% score')).toBeInTheDocument();
+    expect(within(panel).getByText('1 / 2 passed')).toBeInTheDocument();
+    expect(within(panel).getByText('9.25s runtime')).toBeInTheDocument();
+    expect(within(panel).getByText('42 tokens')).toBeInTheDocument();
+    expect(within(panel).getByText('fixture-fail')).toBeInTheDocument();
+    expect(within(panel).getByText('scripted')).toBeInTheDocument();
+    expect(within(panel).getByText('src/train.py')).toBeInTheDocument();
+    expect(within(panel).getByText('Expected metric is missing.')).toBeInTheDocument();
+    expect(within(panel).getByRole('link', { name: 'Open eval artifacts' })).toHaveAttribute(
+      'href',
+      '#artifact-browser',
+    );
+  });
+});

--- a/frontend/src/components/EvalDashboardPanel.tsx
+++ b/frontend/src/components/EvalDashboardPanel.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+
+import { buildEvalDashboardSummary } from '../evalDashboard';
+import type { EvalGateStatus, EvalSuiteSummary } from '../evalDashboard';
+import type { ToolCallPayload } from '../types';
+
+interface EvalDashboardPanelProps {
+  toolCalls: ToolCallPayload[];
+}
+
+function formatScore(score: number | null) {
+  if (score === null) return 'No score';
+  return `${Math.round(score * 100)}% score`;
+}
+
+function formatRuntime(seconds: number | null) {
+  if (seconds === null) return 'runtime unknown';
+  return `${seconds}s runtime`;
+}
+
+function gateLabel(status: EvalGateStatus) {
+  if (status === 'healthy') return 'Release gate healthy';
+  if (status === 'blocked') return 'Release gate blocked';
+  return 'Release gate unknown';
+}
+
+function gateTone(status: EvalGateStatus) {
+  if (status === 'healthy') return 'success';
+  if (status === 'blocked') return 'danger';
+  return 'neutral';
+}
+
+function fixtureTone(status: string) {
+  if (status === 'passed') return 'success';
+  if (status === 'failed' || status === 'error') return 'danger';
+  return 'neutral';
+}
+
+function SuiteCard({ suite }: { suite: EvalSuiteSummary }) {
+  return (
+    <article className="eval-dashboard-suite">
+      <div className="runtime-detail-card-head">
+        <div>
+          <span>Eval suite</span>
+          <h4>{suite.status}</h4>
+        </div>
+        <a href="#artifact-browser">Open eval artifacts</a>
+      </div>
+
+      <div className="eval-dashboard-metrics">
+        <span>{formatScore(suite.averageScore)}</span>
+        <span>{suite.fixturesPassed} / {suite.fixturesTotal} passed</span>
+        <span>{formatRuntime(suite.runtimeSeconds)}</span>
+        <span>{suite.totalTokens} tokens</span>
+      </div>
+
+      <div className="eval-dashboard-fixtures">
+        {suite.fixtures.map((fixture) => (
+          <article className="eval-dashboard-fixture" key={fixture.fixtureId}>
+            <div className="eval-dashboard-fixture-head">
+              <div>
+                <strong>{fixture.fixtureId}</strong>
+                <span>{fixture.mode}</span>
+              </div>
+              <span className={`status-chip ${fixtureTone(fixture.status)}`}>{fixture.status}</span>
+            </div>
+            <p className="muted">{formatScore(fixture.score)}</p>
+            {fixture.changedFiles.length ? (
+              <div className="eval-dashboard-detail-list">
+                <span>Changed files</span>
+                {fixture.changedFiles.map((file) => <code key={file}>{file}</code>)}
+              </div>
+            ) : null}
+            {fixture.checks.length ? (
+              <div className="eval-dashboard-detail-list">
+                <span>Checks</span>
+                {fixture.checks.map((check, index) => (
+                  <p key={`${check.type}-${index}`} className={check.passed ? 'muted' : 'artifact-browser-warning'}>
+                    <span>{check.type}{check.path ? ` ${check.path}` : ''}</span>
+                    {check.message}
+                  </p>
+                ))}
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export default function EvalDashboardPanel({ toolCalls }: EvalDashboardPanelProps) {
+  const summary = useMemo(() => buildEvalDashboardSummary(toolCalls), [toolCalls]);
+
+  return (
+    <section className="eval-dashboard-panel" id="eval-dashboard" aria-label="Eval suite dashboard">
+      <div className="eval-dashboard-header">
+        <div>
+          <p className="panel-label">Evals</p>
+          <h3>Eval suite dashboard</h3>
+          <p className="muted">Release gating view derived from generated eval suite reports.</p>
+        </div>
+        <span className={`status-chip ${gateTone(summary.gateStatus)}`}>{gateLabel(summary.gateStatus)}</span>
+      </div>
+
+      {!summary.latestSuite ? (
+        <p className="muted">Eval suite reports will appear here after deterministic or live eval runs generate report JSON.</p>
+      ) : (
+        <div className="eval-dashboard-stack">
+          {summary.suites.map((suite) => <SuiteCard key={suite.id} suite={suite} />)}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/evalDashboard.test.ts
+++ b/frontend/src/evalDashboard.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildEvalDashboardSummary } from './evalDashboard';
+import type { ToolCallPayload } from './types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_eval_suite',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+const suiteReport = {
+  status: 'failed',
+  summary: {
+    fixtures_total: 2,
+    fixtures_passed: 1,
+    fixtures_failed: 1,
+    fixtures_error: 0,
+    average_score: 0.5,
+    runtime_seconds: 12.4,
+    total_tokens: 321,
+  },
+  fixtures: [
+    {
+      fixture_id: 'fixture-pass',
+      status: 'passed',
+      score: 1,
+      report_path: '.ml-copilot/evals/artifacts/pass/report.json',
+      markdown_path: '.ml-copilot/evals/artifacts/pass/report.md',
+      workspace_path: '.ml-copilot/evals/workspaces/pass',
+    },
+    {
+      fixture_id: 'fixture-fail',
+      status: 'failed',
+      score: 0,
+      report_path: '.ml-copilot/evals/artifacts/fail/report.json',
+      markdown_path: '.ml-copilot/evals/artifacts/fail/report.md',
+      workspace_path: '.ml-copilot/evals/workspaces/fail',
+      report: {
+        fixture: { metadata: { mode: 'scripted' } },
+        scoring: {
+          file_changes: { files_changed: ['src/train.py'] },
+        },
+        checks: [
+          { type: 'file_contains', passed: false, path: 'src/train.py', message: 'Expected metric is missing.' },
+        ],
+      },
+    },
+  ],
+};
+
+describe('buildEvalDashboardSummary', () => {
+  it('extracts suite reports and derives release gate state with fixture details', () => {
+    const summary = buildEvalDashboardSummary([
+      toolCall({
+        output: ['Eval suite completed.', '```json', JSON.stringify(suiteReport), '```'].join('\n'),
+      }),
+    ]);
+
+    expect(summary.gateStatus).toBe('blocked');
+    expect(summary.totalSuites).toBe(1);
+    expect(summary.latestSuite?.status).toBe('failed');
+    expect(summary.latestSuite?.averageScore).toBe(0.5);
+    expect(summary.suites[0].fixtures).toHaveLength(2);
+    expect(summary.suites[0].fixtures[1]).toMatchObject({
+      fixtureId: 'fixture-fail',
+      status: 'failed',
+      mode: 'scripted',
+      changedFiles: ['src/train.py'],
+    });
+    expect(summary.suites[0].fixtures[1].checks[0]).toMatchObject({
+      type: 'file_contains',
+      passed: false,
+      message: 'Expected metric is missing.',
+    });
+  });
+});

--- a/frontend/src/evalDashboard.ts
+++ b/frontend/src/evalDashboard.ts
@@ -1,0 +1,191 @@
+import type { ToolCallPayload } from './types';
+
+export type EvalGateStatus = 'healthy' | 'blocked' | 'unknown';
+
+export interface EvalCheckSummary {
+  type: string;
+  passed: boolean;
+  message: string;
+  path: string | null;
+}
+
+export interface EvalFixtureSummary {
+  fixtureId: string;
+  status: string;
+  score: number | null;
+  mode: string;
+  reportPath: string | null;
+  markdownPath: string | null;
+  workspacePath: string | null;
+  changedFiles: string[];
+  checks: EvalCheckSummary[];
+}
+
+export interface EvalSuiteSummary {
+  id: string;
+  status: string;
+  averageScore: number | null;
+  runtimeSeconds: number | null;
+  totalTokens: number;
+  fixturesTotal: number;
+  fixturesPassed: number;
+  fixturesFailed: number;
+  fixturesError: number;
+  fixtures: EvalFixtureSummary[];
+}
+
+export interface EvalDashboardSummary {
+  gateStatus: EvalGateStatus;
+  totalSuites: number;
+  latestSuite: EvalSuiteSummary | null;
+  suites: EvalSuiteSummary[];
+}
+
+function firstNonEmptyText(...values: Array<string | null | undefined>) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function asNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() && Number.isFinite(Number(value))) return Number(value);
+  return null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function parseJsonCandidates(text: string): Record<string, unknown>[] {
+  const candidates: Record<string, unknown>[] = [];
+
+  for (const match of text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)) {
+    const parsed = parseJsonObject(match[1]);
+    if (parsed) candidates.push(parsed);
+  }
+
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    const parsed = parseJsonObject(trimmed);
+    if (parsed) candidates.push(parsed);
+  }
+
+  return candidates;
+}
+
+function parseJsonObject(value: string | undefined) {
+  if (!value) return null;
+  try {
+    return asRecord(JSON.parse(value));
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeSuiteReport(report: Record<string, unknown>) {
+  return Boolean(asRecord(report.summary) && Array.isArray(report.fixtures));
+}
+
+function inferMode(fixture: Record<string, unknown>, nestedReport: Record<string, unknown> | null) {
+  const metadata = asRecord(asRecord(nestedReport?.fixture)?.metadata);
+  const agentOutput = asRecord(nestedReport?.agent_output);
+  return asString(metadata?.mode) ?? asString(agentOutput?.mode) ?? 'live';
+}
+
+function changedFilesFromReport(report: Record<string, unknown> | null) {
+  const scoring = asRecord(report?.scoring);
+  const fileChanges = asRecord(scoring?.file_changes);
+  return asArray(fileChanges?.files_changed).map(String);
+}
+
+function checksFromReport(report: Record<string, unknown> | null): EvalCheckSummary[] {
+  return asArray(report?.checks).flatMap((raw) => {
+    const check = asRecord(raw);
+    if (!check) return [];
+    return [{
+      type: asString(check.type) ?? 'check',
+      passed: Boolean(check.passed),
+      message: asString(check.message) ?? '',
+      path: asString(check.path),
+    }];
+  });
+}
+
+function fixtureSummary(raw: unknown): EvalFixtureSummary | null {
+  const fixture = asRecord(raw);
+  if (!fixture) return null;
+  const nestedReport = asRecord(fixture.report);
+  const fixtureId = asString(fixture.fixture_id) ?? asString(asRecord(nestedReport?.fixture)?.id);
+  if (!fixtureId) return null;
+
+  return {
+    fixtureId,
+    status: asString(fixture.status) ?? asString(nestedReport?.status) ?? 'unknown',
+    score: asNumber(fixture.score ?? nestedReport?.score),
+    mode: inferMode(fixture, nestedReport),
+    reportPath: asString(fixture.report_path),
+    markdownPath: asString(fixture.markdown_path),
+    workspacePath: asString(fixture.workspace_path),
+    changedFiles: changedFilesFromReport(nestedReport),
+    checks: checksFromReport(nestedReport),
+  };
+}
+
+function suiteSummary(report: Record<string, unknown>, index: number): EvalSuiteSummary | null {
+  if (!looksLikeSuiteReport(report)) return null;
+  const summary = asRecord(report.summary) ?? {};
+  const fixtures = asArray(report.fixtures).flatMap((fixture) => {
+    const parsed = fixtureSummary(fixture);
+    return parsed ? [parsed] : [];
+  });
+
+  return {
+    id: `suite-${index + 1}`,
+    status: asString(report.status) ?? 'unknown',
+    averageScore: asNumber(summary.average_score),
+    runtimeSeconds: asNumber(summary.runtime_seconds),
+    totalTokens: asNumber(summary.total_tokens) ?? 0,
+    fixturesTotal: asNumber(summary.fixtures_total) ?? fixtures.length,
+    fixturesPassed: asNumber(summary.fixtures_passed) ?? fixtures.filter((fixture) => fixture.status === 'passed').length,
+    fixturesFailed: asNumber(summary.fixtures_failed) ?? fixtures.filter((fixture) => fixture.status === 'failed').length,
+    fixturesError: asNumber(summary.fixtures_error) ?? fixtures.filter((fixture) => fixture.status === 'error').length,
+    fixtures,
+  };
+}
+
+function gateStatusForSuite(suite: EvalSuiteSummary | null): EvalGateStatus {
+  if (!suite) return 'unknown';
+  if (suite.status === 'passed' && suite.fixturesFailed === 0 && suite.fixturesError === 0) return 'healthy';
+  return 'blocked';
+}
+
+export function buildEvalDashboardSummary(toolCalls: ToolCallPayload[]): EvalDashboardSummary {
+  const suites: EvalSuiteSummary[] = [];
+
+  for (const call of toolCalls) {
+    const text = firstNonEmptyText(call.output, call.error);
+    if (!text) continue;
+    for (const candidate of parseJsonCandidates(text)) {
+      const suite = suiteSummary(candidate, suites.length);
+      if (suite) suites.push(suite);
+    }
+  }
+
+  const latestSuite = suites.at(-1) ?? null;
+  return {
+    gateStatus: gateStatusForSuite(latestSuite),
+    totalSuites: suites.length,
+    latestSuite,
+    suites,
+  };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1718,6 +1718,92 @@ button {
   white-space: pre-wrap;
 }
 
+.eval-dashboard-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.eval-dashboard-header,
+.eval-dashboard-stack,
+.eval-dashboard-suite,
+.eval-dashboard-fixtures,
+.eval-dashboard-fixture,
+.eval-dashboard-detail-list {
+  display: grid;
+  gap: 12px;
+}
+
+.eval-dashboard-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.eval-dashboard-metrics span {
+  padding: 9px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 12px;
+  background: rgba(3, 7, 18, 0.58);
+  color: #dbeafe;
+  font-size: 0.78rem;
+}
+
+.eval-dashboard-suite,
+.eval-dashboard-fixture {
+  padding: 12px;
+  border: 1px solid rgba(96, 165, 250, 0.14);
+  border-radius: 16px;
+  background: rgba(3, 7, 18, 0.68);
+}
+
+.eval-dashboard-fixture-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.eval-dashboard-fixture-head div {
+  display: grid;
+  gap: 4px;
+}
+
+.eval-dashboard-fixture-head strong {
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.eval-dashboard-fixture-head span:not(.status-chip),
+.eval-dashboard-detail-list span {
+  color: var(--muted);
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.eval-dashboard-detail-list code {
+  width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 5px 7px;
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  border-radius: 999px;
+  background: rgba(30, 64, 175, 0.18);
+  color: #dbeafe;
+  font-family: monospace;
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+}
+
+.eval-dashboard-detail-list p {
+  margin: 0;
+  font-size: 0.78rem;
+}
+
 .tool-trace-output {
   margin-top: 10px;
   padding-top: 10px;


### PR DESCRIPTION
## Summary
- Adds an eval suite dashboard panel to the frontend inspector.
- Parses existing eval suite report JSON from persisted tool output/artifact text.
- Shows release gate health, suite status, score, runtime, token usage, fixture pass/fail counts, scripted/live mode, changed files, and check-level failure details.
- Extends artifact extraction to catch suite/Markdown report paths and links eval artifacts to the existing artifact browser.

Closes #116

## Validation
- `npm test` from `frontend/` — 12 files / 13 tests passed
- `npm run build` from `frontend/`
- `python -m pytest tests/ -q` — 246 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`
- `npm audit --omit=dev` from `frontend/`