### PR TITLE
ML-408 / Add final report and publishing UI

### DIFF
--- a/docs/superpowers/plans/2026-07-01-report-publishing-ui.md
+++ b/docs/superpowers/plans/2026-07-01-report-publishing-ui.md
@@ -1,0 +1,245 @@
+# Report Publishing UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a frontend final-report/publishing panel that makes `publish_model_report` outputs inspectable, previewable, provenance-aware, and safe around Hub publishing.
+
+**Architecture:** Keep this slice frontend-first. Add pure parser helpers that derive publishing summaries from persisted `ToolCallPayload` records, then render them in a focused inspector panel wired into `App.tsx`. Reuse existing artifact-browser links instead of adding backend file-read or remote-publish behavior.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Testing Library, existing persisted session API/tool-call payloads.
+
+---
+
+### Task 1: Publishing summary parser
+
+**Files:**
+- Create: `frontend/src/publishingDashboard.test.ts`
+- Create: `frontend/src/publishingDashboard.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/publishingDashboard.test.ts` with a test that imports `buildPublishingDashboardSummary` from `./publishingDashboard`, feeds one `publish_model_report` call, and expects:
+
+```ts
+expect(summary.reports).toHaveLength(1);
+expect(summary.reports[0].repoId).toBe('sohail/demo-model');
+expect(summary.reports[0].publishState).toBe('local-only');
+expect(summary.reports[0].artifacts.map((artifact) => artifact.fileName)).toEqual([
+  'README.md',
+  'FINAL_REPORT.md',
+  'publish_manifest.json',
+]);
+expect(summary.reports[0].previewBlocks.map((block) => block.title)).toEqual([
+  'README.md',
+  'FINAL_REPORT.md',
+  'publish_manifest.json',
+]);
+expect(summary.reports[0].provenance.datasets).toContain('imdb');
+expect(summary.reports[0].provenance.jobs).toContain('train-job-1');
+expect(summary.needsTokenWarning).toBe(false);
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cd frontend
+npm test -- publishingDashboard.test.ts
+```
+
+Expected: FAIL because `frontend/src/publishingDashboard.ts` does not exist yet.
+
+- [ ] **Step 3: Implement minimal parser**
+
+Create `frontend/src/publishingDashboard.ts` with:
+
+```ts
+import type { ToolCallPayload } from './types';
+
+export type PublishState = 'local-only' | 'dry-run' | 'uploaded' | 'token-required' | 'error';
+
+export interface PublishingArtifact {
+  path: string;
+  fileName: string;
+  kind: string;
+}
+
+export interface PublishingPreviewBlock {
+  title: string;
+  content: string;
+}
+
+export interface PublishingProvenance {
+  datasets: string[];
+  papers: string[];
+  jobs: string[];
+  evals: string[];
+}
+
+export interface PublishingReportSummary {
+  id: string;
+  repoId: string | null;
+  modelName: string | null;
+  task: string | null;
+  publishState: PublishState;
+  outputDir: string | null;
+  artifacts: PublishingArtifact[];
+  previewBlocks: PublishingPreviewBlock[];
+  provenance: PublishingProvenance;
+  recommendation: string | null;
+  warning: string | null;
+}
+
+export interface PublishingDashboardSummary {
+  reports: PublishingReportSummary[];
+  latestReport: PublishingReportSummary | null;
+  needsTokenWarning: boolean;
+}
+```
+
+Then implement helper functions for string/list coercion, artifact extraction from `- README:`, `- Final report:`, `- Manifest:`, fenced preview extraction under `### README.md`, `### FINAL_REPORT.md`, and `### publish_manifest.json`, JSON manifest parsing, and publish-state inference from output text and args.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cd frontend
+npm test -- publishingDashboard.test.ts
+```
+
+Expected: PASS.
+
+### Task 2: Publishing panel component
+
+**Files:**
+- Create: `frontend/src/components/PublishingPanel.test.tsx`
+- Create: `frontend/src/components/PublishingPanel.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `frontend/src/components/PublishingPanel.test.tsx` rendering `<PublishingPanel toolCalls={calls} />` with a publishing call that includes README/final-report/manifest previews. Assert the panel exposes:
+
+```ts
+expect(screen.getByRole('region', { name: 'Final report and publishing UI' })).toBeInTheDocument();
+expect(screen.getByText('sohail/demo-model')).toBeInTheDocument();
+expect(screen.getByText('Local assets prepared')).toBeInTheDocument();
+expect(screen.getByRole('link', { name: 'Open publishing artifacts' })).toHaveAttribute('href', '#artifact-browser');
+expect(screen.getByText('README.md')).toBeInTheDocument();
+expect(screen.getByText('FINAL_REPORT.md')).toBeInTheDocument();
+expect(screen.getByText('publish_manifest.json')).toBeInTheDocument();
+expect(screen.getByText('imdb')).toBeInTheDocument();
+expect(screen.getByText('train-job-1')).toBeInTheDocument();
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cd frontend
+npm test -- PublishingPanel.test.tsx
+```
+
+Expected: FAIL because the component does not exist yet.
+
+- [ ] **Step 3: Implement minimal component**
+
+Create `frontend/src/components/PublishingPanel.tsx` that uses `useMemo(buildPublishingDashboardSummary(toolCalls))`, renders an empty state when no reports exist, shows the latest/all reports, status chip, repo/model metadata, warnings, provenance chips, artifact links to `#artifact-browser`, and bounded previews.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cd frontend
+npm test -- PublishingPanel.test.tsx
+```
+
+Expected: PASS.
+
+### Task 3: Wire panel into inspector and tool cards
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/ToolTracePanel.tsx`
+- Modify: `frontend/src/components/ToolTracePanel.test.tsx`
+- Modify: `frontend/src/styles.css`
+
+- [ ] **Step 1: Write failing wiring test**
+
+Update `frontend/src/components/ToolTracePanel.test.tsx` so the `publish_model_report` card is expected to include a link named `Open publishing panel` with `href="#publishing-panel"`.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cd frontend
+npm test -- ToolTracePanel.test.tsx
+```
+
+Expected: FAIL because only runtime/artifact links exist.
+
+- [ ] **Step 3: Implement wiring**
+
+Import `PublishingPanel` in `frontend/src/App.tsx` and render it between `RuntimeDetailPanel` and `EvalDashboardPanel`. Add a publishing-panel metadata link helper in `ToolTracePanel.tsx` and call it for `publish_model_report`.
+
+- [ ] **Step 4: Add styles**
+
+Add focused `.publishing-panel`, `.publishing-report-card`, `.publishing-artifact-grid`, `.publishing-preview`, and `.publishing-provenance` styles in `frontend/src/styles.css`, following existing inspector card patterns.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```bash
+cd frontend
+npm test -- ToolTracePanel.test.tsx PublishingPanel.test.tsx publishingDashboard.test.ts
+```
+
+Expected: PASS.
+
+### Task 4: Full validation and handoff
+
+**Files:**
+- Modify: `ML-COPILOT-WORKFLOW.md` outside the repo root only
+- Update: Notion ML-408 page
+
+- [ ] **Step 1: Run frontend and backend validation**
+
+Run:
+
+```bash
+cd frontend
+npm test
+npm run build
+cd ..
+python -m pytest tests/ -q
+mypy app/ --ignore-missing-imports --follow-imports=skip
+ruff check app/ tests/
+ruff format --check app/ tests/
+git diff --check
+pre-commit run --all-files
+cd frontend
+npm audit --omit=dev
+```
+
+- [ ] **Step 2: Create PR with the established template**
+
+Use title `ML-408 / Add final report and publishing UI`, labels `feature` and `phase5`, assignee `Sohail-Shaikh-07`, and a PR body with exactly `## Summary`, `Closes #118`, and `## Validation`.
+
+- [ ] **Step 3: Verify metadata**
+
+Run:
+
+```bash
+gh pr view --json number,title,labels,assignees,body,url
+```
+
+Expected: PR has both labels, self-assignee, and `Closes #118`.
+
+- [ ] **Step 4: Update tracking**
+
+Update Notion ML-408 to mention PR URL, validation, and auto-close linkage. Update local-only `D:\My work\Github Repository\ml-engineer\ML-COPILOT-WORKFLOW.md` without committing it.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import ApprovalDialog from './components/ApprovalDialog';
 import ArtifactBrowserPanel from './components/ArtifactBrowserPanel';
 import EvalDashboardPanel from './components/EvalDashboardPanel';
 import JobProgressPanel from './components/JobProgressPanel';
+import PublishingPanel from './components/PublishingPanel';
 import RichMessageContent from './components/RichMessageContent';
 import RuntimeDetailPanel from './components/RuntimeDetailPanel';
 import SessionSidebar from './components/SessionSidebar';
@@ -504,6 +505,8 @@ function App() {
             <UsageMeterPanel session={activeSession} toolCalls={toolCalls} />
 
             <RuntimeDetailPanel toolCalls={toolCalls} />
+
+            <PublishingPanel toolCalls={toolCalls} />
 
             <EvalDashboardPanel toolCalls={toolCalls} />
 

--- a/frontend/src/components/PublishingPanel.test.tsx
+++ b/frontend/src/components/PublishingPanel.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import PublishingPanel from './PublishingPanel';
+import type { ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'publish-call',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'publish_model_report',
+    arguments: {
+      repo_id: 'sohail/demo-model',
+      model_name: 'Demo Model',
+      task: 'text-classification',
+      datasets: ['imdb'],
+      jobs: ['train-job-1'],
+      publish: false,
+    },
+    status: 'completed',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T04:00:00Z',
+    finished_at: '2026-07-01T04:00:03Z',
+    output: [
+      'Prepared model publishing assets.',
+      '- README: reports/model-publishing/demo-model/README.md',
+      '- Final report: reports/model-publishing/demo-model/FINAL_REPORT.md',
+      '- Manifest: reports/model-publishing/demo-model/publish_manifest.json',
+      'Set publish=true to upload these assets to the Hugging Face Hub.',
+      '',
+      '### README.md',
+      '```markdown',
+      '# Demo Model',
+      'Generated model card content.',
+      '```',
+      '',
+      '### FINAL_REPORT.md',
+      '```markdown',
+      '# Final Report: Demo Model',
+      'Recommendation: Ship this model after one more eval pass.',
+      '```',
+      '',
+      '### publish_manifest.json',
+      '```json',
+      '{',
+      '  "repo_id": "sohail/demo-model",',
+      '  "model_name": "Demo Model",',
+      '  "task": "text-classification",',
+      '  "datasets": ["imdb"],',
+      '  "jobs": ["train-job-1"],',
+      '  "papers": ["paper-123"],',
+      '  "recommendation": "Ship this model after one more eval pass."',
+      '}',
+      '```',
+    ].join('\n'),
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('PublishingPanel', () => {
+  afterEach(() => cleanup());
+
+  it('renders publishing status, artifacts, previews, and provenance', () => {
+    render(<PublishingPanel toolCalls={[toolCall({})]} />);
+
+    const panel = screen.getByRole('region', { name: 'Final report and publishing UI' });
+    expect(within(panel).getByText('sohail/demo-model')).toBeInTheDocument();
+    expect(within(panel).getByText('Demo Model')).toBeInTheDocument();
+    expect(within(panel).getByText('Local assets prepared')).toBeInTheDocument();
+    expect(within(panel).getByRole('link', { name: 'Open publishing artifacts' })).toHaveAttribute('href', '#artifact-browser');
+    expect(within(panel).getAllByText('README.md').length).toBeGreaterThan(0);
+    expect(within(panel).getAllByText('FINAL_REPORT.md').length).toBeGreaterThan(0);
+    expect(within(panel).getAllByText('publish_manifest.json').length).toBeGreaterThan(0);
+    expect(within(panel).getByText('imdb')).toBeInTheDocument();
+    expect(within(panel).getByText('train-job-1')).toBeInTheDocument();
+    expect(within(panel).getByText('paper-123')).toBeInTheDocument();
+    expect(within(panel).getByText(/# Final Report: Demo Model/)).toBeInTheDocument();
+  });
+
+  it('shows token-aware warning for failed Hub publish attempts', () => {
+    render(
+      <PublishingPanel
+        toolCalls={[
+          toolCall({
+            arguments: { repo_id: 'sohail/demo-model', publish: true },
+            output: 'Error: A Hugging Face token is required when publish=true.',
+            success: false,
+            error: 'Error: A Hugging Face token is required when publish=true.',
+          }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Final report and publishing UI' });
+    expect(within(panel).getByText('Token required')).toBeInTheDocument();
+    expect(within(panel).getByText(/Hugging Face token is required/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PublishingPanel.tsx
+++ b/frontend/src/components/PublishingPanel.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+
+import { buildPublishingDashboardSummary } from '../publishingDashboard';
+import type { PublishingReportSummary, PublishState } from '../publishingDashboard';
+import type { ToolCallPayload } from '../types';
+
+interface PublishingPanelProps {
+  toolCalls: ToolCallPayload[];
+}
+
+function stateLabel(state: PublishState) {
+  if (state === 'local-only') return 'Local assets prepared';
+  if (state === 'dry-run') return 'Publish requested';
+  if (state === 'uploaded') return 'Uploaded to Hub';
+  if (state === 'token-required') return 'Token required';
+  return 'Publish failed';
+}
+
+function stateTone(state: PublishState) {
+  if (state === 'local-only' || state === 'uploaded') return 'success';
+  if (state === 'dry-run' || state === 'token-required') return 'warning';
+  return 'danger';
+}
+
+function ProvenanceGroup({ label, values }: { label: string; values: string[] }) {
+  if (!values.length) return null;
+  return (
+    <div>
+      <span>{label}</span>
+      <div className="publishing-chip-row">
+        {values.map((value) => <code key={value}>{value}</code>)}
+      </div>
+    </div>
+  );
+}
+
+function ReportCard({ report }: { report: PublishingReportSummary }) {
+  const hasProvenance = Boolean(
+    report.provenance.datasets.length ||
+    report.provenance.papers.length ||
+    report.provenance.jobs.length ||
+    report.provenance.evals.length,
+  );
+
+  return (
+    <article className="publishing-report-card">
+      <div className="runtime-detail-card-head">
+        <div>
+          <span>Publishing report</span>
+          <h4>{report.repoId ?? 'Repository pending'}</h4>
+        </div>
+        <a href="#artifact-browser">Open publishing artifacts</a>
+      </div>
+
+      <div className="publishing-status-row">
+        <span className={`status-chip ${stateTone(report.publishState)}`}>{stateLabel(report.publishState)}</span>
+        {report.modelName ? <strong>{report.modelName}</strong> : null}
+        {report.task ? <span>{report.task}</span> : null}
+      </div>
+
+      {report.warning ? <p className="artifact-browser-warning">{report.warning}</p> : null}
+      {report.outputDir ? <p className="muted">Output directory: {report.outputDir}</p> : null}
+      {report.recommendation ? <p>{report.recommendation}</p> : null}
+
+      {report.artifacts.length ? (
+        <div className="publishing-artifact-grid">
+          {report.artifacts.map((artifact) => (
+            <div className="runtime-artifact" key={artifact.path}>
+              <span>{artifact.kind}</span>
+              <strong>{artifact.fileName}</strong>
+              <small>{artifact.path}</small>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {hasProvenance ? (
+        <div className="publishing-provenance">
+          <strong>Provenance</strong>
+          <ProvenanceGroup label="Datasets" values={report.provenance.datasets} />
+          <ProvenanceGroup label="Papers" values={report.provenance.papers} />
+          <ProvenanceGroup label="Jobs" values={report.provenance.jobs} />
+          <ProvenanceGroup label="Evals" values={report.provenance.evals} />
+        </div>
+      ) : null}
+
+      {report.previewBlocks.length ? (
+        <div className="publishing-preview-stack">
+          {report.previewBlocks.map((block) => (
+            <div className="publishing-preview" key={block.title}>
+              <span>{block.title}</span>
+              <pre>{block.content}</pre>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export default function PublishingPanel({ toolCalls }: PublishingPanelProps) {
+  const summary = useMemo(() => buildPublishingDashboardSummary(toolCalls), [toolCalls]);
+
+  return (
+    <section className="publishing-panel" id="publishing-panel" aria-label="Final report and publishing UI">
+      <div className="runtime-detail-header">
+        <div>
+          <p className="panel-label">Publishing</p>
+          <h3>Final report and publishing</h3>
+          <p className="muted">Preview generated model cards, final reports, manifests, and Hub publishing state.</p>
+        </div>
+        <span className={`status-chip ${summary.needsTokenWarning ? 'warning' : 'neutral'}`}>
+          {summary.reports.length} report{summary.reports.length === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {!summary.latestReport ? (
+        <p className="muted">Publishing artifacts will appear here after `publish_model_report` prepares local report assets.</p>
+      ) : (
+        <div className="publishing-report-stack">
+          {summary.reports.map((report) => <ReportCard key={report.id} report={report} />)}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ToolTracePanel.test.tsx
+++ b/frontend/src/components/ToolTracePanel.test.tsx
@@ -128,8 +128,12 @@ describe('ToolTracePanel', () => {
     );
 
     const publishCard = screen.getByTestId('tool-card-publish-call');
-    expect(within(publishCard).getByText('Publishing')).toBeInTheDocument();
+    expect(within(publishCard).getAllByText('Publishing').length).toBeGreaterThan(0);
     expect(within(publishCard).getByText('.ml-copilot/reports/model-a')).toBeInTheDocument();
+    expect(within(publishCard).getByRole('link', { name: 'Open publishing panel' })).toHaveAttribute(
+      'href',
+      '#publishing-panel',
+    );
     expect(within(publishCard).getByRole('link', { name: 'Open artifact browser' })).toHaveAttribute(
       'href',
       '#artifact-browser',

--- a/frontend/src/components/ToolTracePanel.tsx
+++ b/frontend/src/components/ToolTracePanel.tsx
@@ -206,6 +206,15 @@ function addArtifactBrowserLink(items: ToolMetadataItem[]) {
   });
 }
 
+function addPublishingPanelLink(items: ToolMetadataItem[]) {
+  addMetadata(items, {
+    label: 'Publishing',
+    value: 'Final report panel',
+    href: '#publishing-panel',
+    linkLabel: 'Open publishing panel',
+  });
+}
+
 function buildToolProfile(call: ToolCallPayload): ToolProfile {
   const args = call.arguments;
   const output = textOutput(call);
@@ -278,6 +287,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
       if (outputDir) addMetadata(metadata, { label: 'Output', value: outputDir });
       if (repoId) addMetadata(metadata, { label: 'Repository', value: repoId });
       addRuntimePanelLink(metadata);
+      addPublishingPanelLink(metadata);
       addArtifactBrowserLink(metadata);
 
       return {

--- a/frontend/src/publishingDashboard.test.ts
+++ b/frontend/src/publishingDashboard.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPublishingDashboardSummary } from './publishingDashboard';
+import type { ToolCallPayload } from './types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-publish-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'publish_model_report',
+    arguments: {
+      repo_id: 'sohail/demo-model',
+      model_name: 'Demo Model',
+      task: 'text-classification',
+      datasets: ['imdb'],
+      jobs: ['train-job-1'],
+      recommendation: 'Ship this model after one more eval pass.',
+      publish: false,
+    },
+    status: 'completed',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T04:00:00Z',
+    finished_at: '2026-07-01T04:00:03Z',
+    output: [
+      'Prepared model publishing assets.',
+      '- README: reports/model-publishing/demo-model/README.md',
+      '- Final report: reports/model-publishing/demo-model/FINAL_REPORT.md',
+      '- Manifest: reports/model-publishing/demo-model/publish_manifest.json',
+      'Set publish=true to upload these assets to the Hugging Face Hub.',
+      '',
+      '### README.md',
+      '```markdown',
+      '# Demo Model',
+      'Generated model card content.',
+      '```',
+      '',
+      '### FINAL_REPORT.md',
+      '```markdown',
+      '# Final Report: Demo Model',
+      'Recommendation: Ship this model after one more eval pass.',
+      '```',
+      '',
+      '### publish_manifest.json',
+      '```json',
+      '{',
+      '  "repo_id": "sohail/demo-model",',
+      '  "model_name": "Demo Model",',
+      '  "task": "text-classification",',
+      '  "datasets": ["imdb"],',
+      '  "jobs": ["train-job-1"],',
+      '  "papers": ["paper-123"],',
+      '  "metrics": {"accuracy": 0.93},',
+      '  "recommendation": "Ship this model after one more eval pass."',
+      '}',
+      '```',
+    ].join('\n'),
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('buildPublishingDashboardSummary', () => {
+  it('summarizes local publishing artifacts, previews, and provenance', () => {
+    const summary = buildPublishingDashboardSummary([toolCall({})]);
+
+    expect(summary.reports).toHaveLength(1);
+    expect(summary.latestReport?.repoId).toBe('sohail/demo-model');
+    expect(summary.latestReport?.modelName).toBe('Demo Model');
+    expect(summary.latestReport?.task).toBe('text-classification');
+    expect(summary.latestReport?.publishState).toBe('local-only');
+    expect(summary.latestReport?.artifacts.map((artifact) => artifact.fileName)).toEqual([
+      'README.md',
+      'FINAL_REPORT.md',
+      'publish_manifest.json',
+    ]);
+    expect(summary.latestReport?.previewBlocks.map((block) => block.title)).toEqual([
+      'README.md',
+      'FINAL_REPORT.md',
+      'publish_manifest.json',
+    ]);
+    expect(summary.latestReport?.provenance.datasets).toContain('imdb');
+    expect(summary.latestReport?.provenance.jobs).toContain('train-job-1');
+    expect(summary.latestReport?.provenance.papers).toContain('paper-123');
+    expect(summary.latestReport?.recommendation).toBe('Ship this model after one more eval pass.');
+    expect(summary.needsTokenWarning).toBe(false);
+  });
+
+  it('warns when a publish request needs a Hugging Face token', () => {
+    const summary = buildPublishingDashboardSummary([
+      toolCall({
+        arguments: { repo_id: 'sohail/demo-model', publish: true },
+        output: 'Error: A Hugging Face token is required when publish=true.',
+        success: false,
+        error: 'Error: A Hugging Face token is required when publish=true.',
+      }),
+    ]);
+
+    expect(summary.latestReport?.publishState).toBe('token-required');
+    expect(summary.latestReport?.warning).toContain('token');
+    expect(summary.needsTokenWarning).toBe(true);
+  });
+});

--- a/frontend/src/publishingDashboard.ts
+++ b/frontend/src/publishingDashboard.ts
@@ -1,0 +1,204 @@
+import type { ToolCallPayload } from './types';
+
+export type PublishState = 'local-only' | 'dry-run' | 'uploaded' | 'token-required' | 'error';
+
+export interface PublishingArtifact {
+  path: string;
+  fileName: string;
+  kind: string;
+}
+
+export interface PublishingPreviewBlock {
+  title: string;
+  content: string;
+}
+
+export interface PublishingProvenance {
+  datasets: string[];
+  papers: string[];
+  jobs: string[];
+  evals: string[];
+}
+
+export interface PublishingReportSummary {
+  id: string;
+  repoId: string | null;
+  modelName: string | null;
+  task: string | null;
+  publishState: PublishState;
+  outputDir: string | null;
+  artifacts: PublishingArtifact[];
+  previewBlocks: PublishingPreviewBlock[];
+  provenance: PublishingProvenance;
+  recommendation: string | null;
+  warning: string | null;
+}
+
+export interface PublishingDashboardSummary {
+  reports: PublishingReportSummary[];
+  latestReport: PublishingReportSummary | null;
+  needsTokenWarning: boolean;
+}
+
+const PREVIEW_LIMIT = 1400;
+const PUBLISH_ARTIFACT_RE = /^- (README|Final report|Manifest|Model card):\s*(.+)$/gim;
+
+function firstNonEmptyText(...values: Array<string | null | undefined>) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown) {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+}
+
+function asStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => asString(item)).filter((item): item is string => Boolean(item));
+  }
+  const text = asString(value);
+  if (!text) return [];
+  return text.split(/[;,]/).map((item) => item.trim()).filter(Boolean);
+}
+
+function unique(values: string[]) {
+  return [...new Set(values.filter((value) => value.trim()))];
+}
+
+function basename(path: string) {
+  return path.trim().replace(/^['"`]|['"`]$/g, '').split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+function artifactKind(label: string, fileName: string) {
+  if (/manifest/i.test(label) || fileName.endsWith('.json')) return 'Manifest';
+  if (/final report/i.test(label)) return 'Final report';
+  if (/readme|model card/i.test(label) || fileName.toLowerCase() === 'readme.md') return 'Model card';
+  return 'Artifact';
+}
+
+function extractArtifacts(output: string | null): PublishingArtifact[] {
+  if (!output) return [];
+  const artifacts = new Map<string, PublishingArtifact>();
+  for (const match of output.matchAll(PUBLISH_ARTIFACT_RE)) {
+    const label = match[1];
+    const path = match[2]?.trim();
+    if (!path) continue;
+    const fileName = basename(path);
+    artifacts.set(path, {
+      path,
+      fileName,
+      kind: artifactKind(label, fileName),
+    });
+  }
+  return [...artifacts.values()];
+}
+
+function boundedPreview(value: string) {
+  const trimmed = value.trim();
+  if (trimmed.length <= PREVIEW_LIMIT) return trimmed;
+  return `${trimmed.slice(0, PREVIEW_LIMIT).trimEnd()}\n...`;
+}
+
+function extractPreviewBlocks(output: string | null): PublishingPreviewBlock[] {
+  if (!output) return [];
+  const blocks: PublishingPreviewBlock[] = [];
+  for (const match of output.matchAll(/^#{2,4}\s+(README\.md|FINAL_REPORT\.md|publish_manifest\.json)\s*\r?\n```(?:\w+)?\s*\r?\n([\s\S]*?)\r?\n```/gim)) {
+    const title = match[1];
+    const content = match[2];
+    if (title && content) {
+      blocks.push({ title, content: boundedPreview(content) });
+    }
+  }
+  return blocks;
+}
+
+function parseJsonObject(value: string | undefined) {
+  if (!value) return null;
+  try {
+    return asRecord(JSON.parse(value));
+  } catch {
+    return null;
+  }
+}
+
+function manifestFromPreviews(previews: PublishingPreviewBlock[]) {
+  const manifest = previews.find((preview) => preview.title === 'publish_manifest.json');
+  return parseJsonObject(manifest?.content);
+}
+
+function outputDirFromArtifacts(artifacts: PublishingArtifact[]) {
+  const first = artifacts[0]?.path;
+  if (!first || !first.includes('/')) return null;
+  return first.split(/[\\/]/).slice(0, -1).join('/');
+}
+
+function publishState(call: ToolCallPayload, text: string | null): PublishState {
+  const lowered = text?.toLowerCase() ?? '';
+  if (lowered.includes('hugging face token is required')) return 'token-required';
+  if (call.success === false || lowered.startsWith('error:')) return 'error';
+  if (lowered.includes('published model assets to https://huggingface.co/')) return 'uploaded';
+  if (call.arguments.publish === true) return 'dry-run';
+  return 'local-only';
+}
+
+function warningForState(state: PublishState) {
+  if (state === 'token-required') return 'A Hugging Face token is required before publishing to the Hub.';
+  if (state === 'dry-run') return 'Publishing was requested; confirm token and approval state before retrying.';
+  if (state === 'uploaded') return 'Assets were uploaded to Hugging Face Hub.';
+  if (state === 'error') return 'Publishing did not complete successfully.';
+  return null;
+}
+
+function argOrManifest(args: Record<string, unknown>, manifest: Record<string, unknown> | null, key: string) {
+  return args[key] ?? manifest?.[key];
+}
+
+function reportFromCall(call: ToolCallPayload, index: number): PublishingReportSummary | null {
+  if (call.tool_name !== 'publish_model_report') return null;
+  const text = firstNonEmptyText(call.output, call.error);
+  const artifacts = extractArtifacts(text);
+  const previewBlocks = extractPreviewBlocks(text);
+  const manifest = manifestFromPreviews(previewBlocks);
+  const state = publishState(call, text);
+
+  return {
+    id: call.id || `publish-${index + 1}`,
+    repoId: asString(argOrManifest(call.arguments, manifest, 'repo_id')),
+    modelName: asString(argOrManifest(call.arguments, manifest, 'model_name')),
+    task: asString(argOrManifest(call.arguments, manifest, 'task')),
+    publishState: state,
+    outputDir: asString(call.arguments.output_dir) ?? outputDirFromArtifacts(artifacts),
+    artifacts,
+    previewBlocks,
+    provenance: {
+      datasets: unique([...asStringList(argOrManifest(call.arguments, manifest, 'datasets'))]),
+      papers: unique([...asStringList(argOrManifest(call.arguments, manifest, 'papers'))]),
+      jobs: unique([...asStringList(argOrManifest(call.arguments, manifest, 'jobs'))]),
+      evals: unique([...asStringList(argOrManifest(call.arguments, manifest, 'evals'))]),
+    },
+    recommendation: asString(argOrManifest(call.arguments, manifest, 'recommendation')),
+    warning: warningForState(state),
+  };
+}
+
+export function buildPublishingDashboardSummary(toolCalls: ToolCallPayload[]): PublishingDashboardSummary {
+  const reports = toolCalls.flatMap((call, index) => {
+    const report = reportFromCall(call, index);
+    return report ? [report] : [];
+  });
+  const latestReport = reports.at(-1) ?? null;
+
+  return {
+    reports,
+    latestReport,
+    needsTokenWarning: reports.some((report) => report.publishState === 'token-required'),
+  };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1624,6 +1624,106 @@ button {
   white-space: nowrap;
 }
 
+.publishing-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.publishing-report-stack,
+.publishing-report-card,
+.publishing-preview-stack,
+.publishing-provenance {
+  display: grid;
+  gap: 12px;
+}
+
+.publishing-report-card {
+  padding: 14px;
+  border: 1px solid rgba(96, 165, 250, 0.14);
+  border-radius: 16px;
+  background: rgba(3, 7, 18, 0.68);
+}
+
+.publishing-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.publishing-status-row strong,
+.publishing-status-row span:not(.status-chip) {
+  color: var(--text);
+  font-size: 0.84rem;
+}
+
+.publishing-artifact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 8px;
+}
+
+.publishing-provenance {
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.publishing-provenance strong,
+.publishing-provenance span,
+.publishing-preview span {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.publishing-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.publishing-chip-row code {
+  max-width: 100%;
+  overflow: hidden;
+  padding: 5px 7px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.75);
+  color: #dbeafe;
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+}
+
+.publishing-preview {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.publishing-preview pre {
+  max-height: 220px;
+  margin: 0;
+  overflow: auto;
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.92);
+  color: #dbeafe;
+  font-size: 0.74rem;
+  white-space: pre-wrap;
+}
+
 .artifact-browser-panel {
   display: grid;
   gap: 14px;


### PR DESCRIPTION
## Summary
- Adds a dedicated Final report and publishing panel for persisted `publish_model_report` tool output.
- Extracts report artifacts, README/FINAL_REPORT/manifest previews, model metadata, recommendation, and provenance from existing tool-call output.
- Labels publishing state as local-only, publish-requested, uploaded, token-required, or failed without adding any accidental Hub publishing path.
- Adds `Open publishing panel` links from publishing tool trace cards and keeps artifact browsing linked through the existing artifact browser.

Closes #118

## Validation
- `npm test` from `frontend/` — 14 files / 17 tests passed
- `npm run build` from `frontend/`
- `python -m pytest tests/ -q` — 246 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`
- `npm audit --omit=dev` from `frontend/`