### PR TITLE
ML-409 / Visualize research steps and evidence trail

### DIFF
--- a/docs/superpowers/plans/2026-07-01-research-evidence-trail.md
+++ b/docs/superpowers/plans/2026-07-01-research-evidence-trail.md
@@ -1,0 +1,95 @@
+# Research Evidence Trail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a frontend research-step visualization that turns persisted research tool calls into an expandable evidence-backed timeline.
+
+**Architecture:** Keep the slice frontend-first. Add pure parser helpers for paper/docs/Hub/dataset/repository/decision signals from `ToolCallPayload`, then render those steps in an inspector panel and link research tool cards into it.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Testing Library, existing persisted session tool-call payloads.
+
+---
+
+### Task 1: Research trail parser
+
+**Files:**
+- Create: `frontend/src/researchTrail.test.ts`
+- Create: `frontend/src/researchTrail.ts`
+
+- [ ] **Step 1: Write the failing parser test**
+
+Create a test that feeds `paper_details`, `extract_training_recipe`, `search_hub`, `inspect_dataset`, and `analyze_repository` calls. Assert that `buildResearchTrailSummary` returns five steps, groups them into paper/recipe/model/dataset/repository kinds, extracts evidence snippets, source links, recipe confidence/limitations, and reports a decision count.
+
+- [ ] **Step 2: Verify RED**
+
+Run `cd frontend && npm test -- researchTrail.test.ts`.
+
+Expected: FAIL because `researchTrail.ts` does not exist.
+
+- [ ] **Step 3: Implement minimal parser**
+
+Create `researchTrail.ts` with typed `ResearchStep`, `ResearchEvidence`, `ResearchTrailSummary`, helpers for coercion/bounded snippets/links, and parsers for known research tools.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run `cd frontend && npm test -- researchTrail.test.ts`.
+
+Expected: PASS.
+
+### Task 2: Research trail panel
+
+**Files:**
+- Create: `frontend/src/components/ResearchTrailPanel.test.tsx`
+- Create: `frontend/src/components/ResearchTrailPanel.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Render `<ResearchTrailPanel toolCalls={calls} />` and assert the region name, timeline title, paper title/arxiv id, evidence quote, recipe confidence/limitation text, Hub candidate, dataset, repository, and expand/collapse behavior.
+
+- [ ] **Step 2: Verify RED**
+
+Run `cd frontend && npm test -- ResearchTrailPanel.test.tsx`.
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement minimal panel**
+
+Create a panel that shows summary chips, ordered timeline cards, expandable detail sections, evidence snippets, source links, and recipe/decision labels.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run `cd frontend && npm test -- ResearchTrailPanel.test.tsx`.
+
+Expected: PASS.
+
+### Task 3: Wire panel and trace links
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/ToolTracePanel.tsx`
+- Modify: `frontend/src/components/ToolTracePanel.test.tsx`
+- Modify: `frontend/src/styles.css`
+
+- [ ] **Step 1: Write failing trace-link test**
+
+Update `ToolTracePanel.test.tsx` so a research-related card exposes `Open research trail` with `href="#research-trail"`.
+
+- [ ] **Step 2: Verify RED**
+
+Run `cd frontend && npm test -- ToolTracePanel.test.tsx`.
+
+Expected: FAIL because the link is not wired.
+
+- [ ] **Step 3: Implement wiring and styles**
+
+Render `ResearchTrailPanel` in the inspector, add a research-trail link helper in `ToolTracePanel.tsx`, and add focused timeline/evidence styles.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run `cd frontend && npm test -- researchTrail.test.ts ResearchTrailPanel.test.tsx ToolTracePanel.test.tsx`.
+
+Expected: PASS.
+
+### Task 4: Full validation and PR
+
+Run full frontend/backend validation, commit only scoped files, push `feature/ML-409-research-evidence-trail`, and open PR title `ML-409 / Visualize research steps and evidence trail` with the established `## Summary`, `Closes #120`, and `## Validation` sections.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import ArtifactBrowserPanel from './components/ArtifactBrowserPanel';
 import EvalDashboardPanel from './components/EvalDashboardPanel';
 import JobProgressPanel from './components/JobProgressPanel';
 import PublishingPanel from './components/PublishingPanel';
+import ResearchTrailPanel from './components/ResearchTrailPanel';
 import RichMessageContent from './components/RichMessageContent';
 import RuntimeDetailPanel from './components/RuntimeDetailPanel';
 import SessionSidebar from './components/SessionSidebar';
@@ -507,6 +508,8 @@ function App() {
             <RuntimeDetailPanel toolCalls={toolCalls} />
 
             <PublishingPanel toolCalls={toolCalls} />
+
+            <ResearchTrailPanel toolCalls={toolCalls} />
 
             <EvalDashboardPanel toolCalls={toolCalls} />
 

--- a/frontend/src/components/ResearchTrailPanel.test.tsx
+++ b/frontend/src/components/ResearchTrailPanel.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import ResearchTrailPanel from './ResearchTrailPanel';
+import type { ToolCallPayload } from '../types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'paper_details',
+    arguments: {},
+    status: 'completed',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:00:02Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('ResearchTrailPanel', () => {
+  it('renders an expandable evidence-backed research timeline', async () => {
+    const user = userEvent.setup();
+    render(
+      <ResearchTrailPanel
+        toolCalls={[
+          toolCall({
+            id: 'paper',
+            tool_name: 'paper_details',
+            arguments: { arxiv_id: '2401.12345' },
+            output: [
+              '# Efficient Fine-Tuning for Small Models',
+              '**arxiv_id:** 2401.12345 | **upvotes:** 42',
+              'https://arxiv.org/abs/2401.12345',
+              '## AI Summary',
+              'Adapters improve accuracy while keeping training cost low.',
+            ].join('\n'),
+          }),
+          toolCall({
+            id: 'recipe',
+            tool_name: 'extract_training_recipe',
+            arguments: { arxiv_id: '2401.12345' },
+            output: [
+              '# Training recipe for Efficient Fine-Tuning for Small Models',
+              '## Dataset',
+              '- We train on IMDb and SST-2 sentiment datasets.',
+              '  - evidence: "We train on IMDb and SST-2 sentiment datasets."',
+              '**Note:** Recipe values are extracted deterministically from method and experiment sections. Verify against read_paper before relying on them for training.',
+            ].join('\n'),
+          }),
+          toolCall({
+            id: 'hub',
+            tool_name: 'search_hub',
+            arguments: { repo_type: 'model', query: 'distilbert sentiment' },
+            output: '| 91 | [distilbert/distilbert-base-uncased](https://huggingface.co/distilbert/distilbert-base-uncased) | text-classification | apache-2.0 | 1000 | 50 | task match |',
+          }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Research evidence trail' });
+    expect(within(panel).getByText('Research evidence trail')).toBeInTheDocument();
+    expect(within(panel).getByText('3 steps')).toBeInTheDocument();
+    expect(within(panel).getByText('Efficient Fine-Tuning for Small Models')).toBeInTheDocument();
+    expect(within(panel).getAllByText('2401.12345').length).toBeGreaterThan(0);
+    expect(within(within(panel).getByTestId('research-step-paper')).getByRole('link', { name: 'Open source 1' })).toHaveAttribute('href', 'https://arxiv.org/abs/2401.12345');
+    expect(within(panel).getByText('distilbert/distilbert-base-uncased')).toBeInTheDocument();
+
+    const recipeCard = within(panel).getByTestId('research-step-recipe');
+    expect(within(recipeCard).queryByText(/IMDb and SST-2/)).not.toBeInTheDocument();
+
+    await user.click(within(recipeCard).getByRole('button', { name: 'Show details for Training recipe for Efficient Fine-Tuning for Small Models' }));
+
+    expect(within(recipeCard).getByText(/IMDb and SST-2/)).toBeInTheDocument();
+    expect(within(recipeCard).getByText('deterministic extraction')).toBeInTheDocument();
+    expect(within(recipeCard).getByText(/Verify against read_paper/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ResearchTrailPanel.tsx
+++ b/frontend/src/components/ResearchTrailPanel.tsx
@@ -1,0 +1,125 @@
+import { useMemo, useState } from 'react';
+
+import { buildResearchTrailSummary } from '../researchTrail';
+import type { ResearchStep, ResearchStepKind } from '../researchTrail';
+import type { ToolCallPayload } from '../types';
+
+interface ResearchTrailPanelProps {
+  toolCalls: ToolCallPayload[];
+}
+
+function kindLabel(kind: ResearchStepKind) {
+  if (kind === 'paper') return 'Paper';
+  if (kind === 'citation') return 'Citation graph';
+  if (kind === 'reading') return 'Paper reading';
+  if (kind === 'recipe') return 'Recipe';
+  if (kind === 'model') return 'Model';
+  if (kind === 'dataset') return 'Dataset';
+  if (kind === 'docs') return 'Docs';
+  if (kind === 'repository') return 'Repository';
+  return 'Decision';
+}
+
+function kindTone(kind: ResearchStepKind) {
+  if (kind === 'recipe' || kind === 'decision') return 'warning';
+  if (kind === 'paper' || kind === 'model' || kind === 'dataset') return 'success';
+  return 'neutral';
+}
+
+function ResearchStepCard({ step, index }: { step: ResearchStep; index: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const showDetails = expanded && (step.evidence.length || step.confidence || step.limitations || step.decision);
+
+  return (
+    <article className="research-step-card" data-testid={`research-step-${step.kind}`}>
+      <div className="research-step-marker">{index + 1}</div>
+      <div className="research-step-body">
+        <div className="research-step-head">
+          <div>
+            <span className={`status-chip ${kindTone(step.kind)}`}>{kindLabel(step.kind)}</span>
+            <h4>{step.title}</h4>
+            {step.sourceId ? <code>{step.sourceId}</code> : null}
+          </div>
+          {step.links.length ? (
+            <div className="research-step-links">
+              {step.links.slice(0, 3).map((link, linkIndex) => (
+                <a href={link} key={link} rel="noopener noreferrer" target="_blank">
+                  Open source {linkIndex + 1}
+                </a>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <p>{step.summary}</p>
+
+        <button
+          className="ghost-button research-step-toggle"
+          type="button"
+          aria-label={`${expanded ? 'Hide' : 'Show'} details for ${step.title}`}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+
+        {showDetails ? (
+          <div className="research-step-details">
+            {step.confidence ? (
+              <div>
+                <span>Confidence</span>
+                <p>{step.confidence}</p>
+              </div>
+            ) : null}
+            {step.limitations ? (
+              <div>
+                <span>Limitations</span>
+                <p>{step.limitations}</p>
+              </div>
+            ) : null}
+            {step.decision ? (
+              <div>
+                <span>Decision</span>
+                <p>{step.decision}</p>
+              </div>
+            ) : null}
+            {step.evidence.map((item, evidenceIndex) => (
+              <blockquote key={`${item.label}-${evidenceIndex}`}>
+                <span>{item.label}</span>
+                {item.snippet}
+              </blockquote>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+export default function ResearchTrailPanel({ toolCalls }: ResearchTrailPanelProps) {
+  const summary = useMemo(() => buildResearchTrailSummary(toolCalls), [toolCalls]);
+
+  return (
+    <section className="research-trail-panel" id="research-trail" aria-label="Research evidence trail">
+      <div className="runtime-detail-header">
+        <div>
+          <p className="panel-label">Research</p>
+          <h3>Research evidence trail</h3>
+          <p className="muted">Paper, dataset, model, documentation, and repository evidence recovered from persisted tool calls.</p>
+        </div>
+        <div className="research-trail-counts">
+          <span className="status-chip neutral">{summary.steps.length} step{summary.steps.length === 1 ? '' : 's'}</span>
+          <span className="status-chip neutral">{summary.evidenceCount} evidence</span>
+          <span className="status-chip neutral">{summary.decisionCount} decisions</span>
+        </div>
+      </div>
+
+      {!summary.steps.length ? (
+        <p className="muted">Research steps will appear here after paper, docs, Hub, dataset, or repository tools run.</p>
+      ) : (
+        <div className="research-timeline">
+          {summary.steps.map((step, index) => <ResearchStepCard index={index} key={step.id} step={step} />)}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ToolTracePanel.test.tsx
+++ b/frontend/src/components/ToolTracePanel.test.tsx
@@ -95,6 +95,12 @@ describe('ToolTracePanel', () => {
             arguments: { output_dir: '.ml-copilot/reports/model-a' },
             output: 'Prepared README.md, FINAL_REPORT.md, and publish_manifest.json.',
           }),
+          toolCall({
+            id: 'research-call',
+            tool_name: 'paper_details',
+            arguments: { arxiv_id: '2401.12345' },
+            output: '# Efficient Fine-Tuning\nhttps://arxiv.org/abs/2401.12345',
+          }),
         ]}
       />,
     );
@@ -137,6 +143,12 @@ describe('ToolTracePanel', () => {
     expect(within(publishCard).getByRole('link', { name: 'Open artifact browser' })).toHaveAttribute(
       'href',
       '#artifact-browser',
+    );
+
+    const researchCard = screen.getByTestId('tool-card-research-call');
+    expect(within(researchCard).getByRole('link', { name: 'Open research trail' })).toHaveAttribute(
+      'href',
+      '#research-trail',
     );
   });
 });

--- a/frontend/src/components/ToolTracePanel.tsx
+++ b/frontend/src/components/ToolTracePanel.tsx
@@ -215,6 +215,15 @@ function addPublishingPanelLink(items: ToolMetadataItem[]) {
   });
 }
 
+function addResearchTrailLink(items: ToolMetadataItem[]) {
+  addMetadata(items, {
+    label: 'Research',
+    value: 'Evidence trail',
+    href: '#research-trail',
+    linkLabel: 'Open research trail',
+  });
+}
+
 function buildToolProfile(call: ToolCallPayload): ToolProfile {
   const args = call.arguments;
   const output = textOutput(call);
@@ -298,12 +307,17 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
         metadata,
       };
     }
+    case 'paper_details':
+    case 'paper_citation_graph':
+    case 'read_paper':
+    case 'extract_training_recipe':
     case 'hf_papers':
       addMetadata(metadata, { label: 'Query', value: getArgText(args, 'query') ?? getArgText(args, 'arxiv_id') ?? '' });
+      addResearchTrailLink(metadata);
       return {
         category: 'Research',
-        title: 'Paper search',
-        description: 'Search, inspect, and connect papers, citations, datasets, and models.',
+        title: call.tool_name === 'extract_training_recipe' ? 'Training recipe' : call.tool_name === 'paper_citation_graph' ? 'Citation graph' : call.tool_name === 'read_paper' ? 'Paper reading' : 'Paper research',
+        description: 'Search, inspect, read, and connect papers, citations, recipes, datasets, and models.',
         icon: '📄',
         metadata,
       };
@@ -311,6 +325,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
     case 'explore_hf_docs':
     case 'find_hf_api':
       addMetadata(metadata, { label: 'Topic', value: getArgText(args, 'query') ?? getArgText(args, 'url') ?? '' });
+      addResearchTrailLink(metadata);
       return {
         category: 'Documentation',
         title: sentenceCase(call.tool_name),
@@ -325,6 +340,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
         label: 'Resource',
         value: getArgText(args, 'dataset') ?? getArgText(args, 'repo_id') ?? getArgText(args, 'query') ?? '',
       });
+      addResearchTrailLink(metadata);
       addArtifactBrowserLink(metadata);
       return {
         category: 'Hub operation',
@@ -335,6 +351,7 @@ function buildToolProfile(call: ToolCallPayload): ToolProfile {
       };
     case 'analyze_repository':
       addMetadata(metadata, { label: 'Path', value: getArgText(args, 'path') ?? '' });
+      addResearchTrailLink(metadata);
       addArtifactBrowserLink(metadata);
       return {
         category: 'Repository analysis',

--- a/frontend/src/researchTrail.test.ts
+++ b/frontend/src/researchTrail.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildResearchTrailSummary } from './researchTrail';
+import type { ToolCallPayload } from './types';
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'paper_details',
+    arguments: {},
+    status: 'completed',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:00:02Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('buildResearchTrailSummary', () => {
+  it('builds an evidence-backed timeline from research tool calls', () => {
+    const summary = buildResearchTrailSummary([
+      toolCall({
+        id: 'paper',
+        tool_name: 'paper_details',
+        arguments: { arxiv_id: '2401.12345' },
+        output: [
+          '# Efficient Fine-Tuning for Small Models',
+          '**arxiv_id:** 2401.12345 | **upvotes:** 42',
+          'https://huggingface.co/papers/2401.12345',
+          'https://arxiv.org/abs/2401.12345',
+          '## AI Summary',
+          'Adapters improve accuracy while keeping training cost low.',
+        ].join('\n'),
+      }),
+      toolCall({
+        id: 'recipe',
+        tool_name: 'extract_training_recipe',
+        arguments: { arxiv_id: '2401.12345' },
+        output: [
+          '# Training recipe for Efficient Fine-Tuning for Small Models',
+          'Scanned 2 method/experiment section(s).',
+          '## Dataset',
+          '- We train on IMDb and SST-2 sentiment datasets.',
+          '  - evidence: "We train on IMDb and SST-2 sentiment datasets."',
+          '**Note:** Recipe values are extracted deterministically from method and experiment sections. Verify against read_paper before relying on them for training.',
+        ].join('\n'),
+      }),
+      toolCall({
+        id: 'hub',
+        tool_name: 'search_hub',
+        arguments: { repo_type: 'model', query: 'distilbert sentiment', task: 'text-classification' },
+        output: [
+          '## Hub models discovery',
+          '| Score | Repository | Task | License | Downloads | Likes | Fit signals |',
+          '|---:|---|---|---|---:|---:|---|',
+          '| 91 | [distilbert/distilbert-base-uncased](https://huggingface.co/distilbert/distilbert-base-uncased) | text-classification | apache-2.0 | 1000 | 50 | task match |',
+        ].join('\n'),
+      }),
+      toolCall({
+        id: 'dataset',
+        tool_name: 'inspect_dataset',
+        arguments: { source: 'imdb' },
+        output: '## imdb (Hugging Face)\n**Status:** Dataset preview available\n| text | string |\n| label | class_label |',
+      }),
+      toolCall({
+        id: 'repo',
+        tool_name: 'analyze_repository',
+        arguments: { path: '.' },
+        output: '## Repository analysis\nDecision: use adapter fine-tuning and gate with eval fixtures.\nEvidence: tests and configs are present.',
+      }),
+    ]);
+
+    expect(summary.steps).toHaveLength(5);
+    expect(summary.steps.map((step) => step.kind)).toEqual(['paper', 'recipe', 'model', 'dataset', 'repository']);
+    expect(summary.steps[0].title).toBe('Efficient Fine-Tuning for Small Models');
+    expect(summary.steps[0].sourceId).toBe('2401.12345');
+    expect(summary.steps[0].links).toContain('https://arxiv.org/abs/2401.12345');
+    expect(summary.steps[1].evidence[0].snippet).toContain('IMDb and SST-2');
+    expect(summary.steps[1].confidence).toBe('deterministic extraction');
+    expect(summary.steps[1].limitations).toContain('Verify against read_paper');
+    expect(summary.steps[2].title).toContain('distilbert/distilbert-base-uncased');
+    expect(summary.steps[3].title).toBe('imdb');
+    expect(summary.decisionCount).toBe(1);
+    expect(summary.evidenceCount).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/frontend/src/researchTrail.ts
+++ b/frontend/src/researchTrail.ts
@@ -1,0 +1,196 @@
+import type { ToolCallPayload } from './types';
+
+export type ResearchStepKind = 'paper' | 'citation' | 'reading' | 'recipe' | 'model' | 'dataset' | 'docs' | 'repository' | 'decision';
+
+export interface ResearchEvidence {
+  label: string;
+  snippet: string;
+}
+
+export interface ResearchStep {
+  id: string;
+  kind: ResearchStepKind;
+  title: string;
+  sourceId: string | null;
+  summary: string;
+  links: string[];
+  evidence: ResearchEvidence[];
+  confidence: string | null;
+  limitations: string | null;
+  decision: string | null;
+}
+
+export interface ResearchTrailSummary {
+  steps: ResearchStep[];
+  evidenceCount: number;
+  decisionCount: number;
+}
+
+const RESEARCH_TOOLS = new Set([
+  'paper_details',
+  'paper_citation_graph',
+  'read_paper',
+  'extract_training_recipe',
+  'search_hub',
+  'inspect_hub_repo',
+  'inspect_dataset',
+  'hf_papers',
+  'hf_search_hub',
+  'hf_inspect_dataset',
+  'hf_repo_files',
+  'fetch_hf_docs',
+  'explore_hf_docs',
+  'find_hf_api',
+  'analyze_repository',
+]);
+
+function firstNonEmptyText(...values: Array<string | null | undefined>) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
+}
+
+function asString(value: unknown) {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+}
+
+function bounded(value: string, limit = 260) {
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (trimmed.length <= limit) return trimmed;
+  return `${trimmed.slice(0, limit).trimEnd()}...`;
+}
+
+function heading(text: string | null, fallback: string) {
+  const match = text?.match(/^#\s+(.+)$/m) ?? text?.match(/^##\s+(.+)$/m);
+  return match?.[1]?.trim() ?? fallback;
+}
+
+function links(text: string | null) {
+  return [...new Set(text?.match(/https?:\/\/[^\s)]+/g) ?? [])];
+}
+
+function matchLine(text: string | null, pattern: RegExp) {
+  if (!text) return null;
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(pattern);
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+  return null;
+}
+
+function arxivId(call: ToolCallPayload, text: string | null) {
+  return asString(call.arguments.arxiv_id) ?? matchLine(text, /\*\*arxiv_id:\*\*\s*([^|\n]+)/i);
+}
+
+function evidenceFromLines(text: string | null): ResearchEvidence[] {
+  if (!text) return [];
+  const evidence: ResearchEvidence[] = [];
+
+  for (const match of text.matchAll(/evidence:\s*"([^"]+)"/gi)) {
+    evidence.push({ label: 'Evidence', snippet: bounded(match[1]) });
+  }
+  for (const match of text.matchAll(/^Evidence:\s*(.+)$/gim)) {
+    evidence.push({ label: 'Evidence', snippet: bounded(match[1]) });
+  }
+
+  const aiSummary = text.match(/## AI Summary\s+([\s\S]*?)(?:\n## |\n\*\*Next:|$)/i);
+  if (aiSummary?.[1]) {
+    evidence.push({ label: 'AI summary', snippet: bounded(aiSummary[1]) });
+  }
+
+  const abstract = text.match(/## Abstract\s+([\s\S]*?)(?:\n## |\n\*\*Next:|$)/i);
+  if (abstract?.[1]) {
+    evidence.push({ label: 'Abstract', snippet: bounded(abstract[1]) });
+  }
+
+  return evidence;
+}
+
+function firstHubCandidate(text: string | null) {
+  const match = text?.match(/\|\s*\d+\s*\|\s*\[([^\]]+)\]\(([^)]+)\)/);
+  return match ? { repo: match[1], link: match[2] } : null;
+}
+
+function decisionFromText(text: string | null) {
+  return matchLine(text, /^Decision:\s*(.+)$/i);
+}
+
+function kindForCall(call: ToolCallPayload, text: string | null): ResearchStepKind | null {
+  if (call.tool_name === 'paper_details' || call.tool_name === 'hf_papers') return 'paper';
+  if (call.tool_name === 'paper_citation_graph') return 'citation';
+  if (call.tool_name === 'read_paper') return 'reading';
+  if (call.tool_name === 'extract_training_recipe') return 'recipe';
+  if (call.tool_name === 'search_hub' || call.tool_name === 'inspect_hub_repo' || call.tool_name === 'hf_search_hub' || call.tool_name === 'hf_repo_files') {
+    return (asString(call.arguments.repo_type) ?? text ?? '').toLowerCase().includes('dataset') ? 'dataset' : 'model';
+  }
+  if (call.tool_name === 'inspect_dataset' || call.tool_name === 'hf_inspect_dataset') return 'dataset';
+  if (call.tool_name === 'fetch_hf_docs' || call.tool_name === 'explore_hf_docs' || call.tool_name === 'find_hf_api') return 'docs';
+  if (call.tool_name === 'analyze_repository') return 'repository';
+  return RESEARCH_TOOLS.has(call.tool_name) ? 'decision' : null;
+}
+
+function titleForStep(call: ToolCallPayload, kind: ResearchStepKind, text: string | null) {
+  if (kind === 'model' || kind === 'dataset') {
+    const candidate = firstHubCandidate(text);
+    if (candidate) return candidate.repo;
+    return asString(call.arguments.repo_id) ?? asString(call.arguments.source) ?? asString(call.arguments.dataset) ?? heading(text, call.tool_name);
+  }
+  if (kind === 'docs') return asString(call.arguments.query) ?? asString(call.arguments.url) ?? heading(text, 'Documentation research');
+  if (kind === 'repository') return asString(call.arguments.path) ?? heading(text, 'Repository analysis');
+  return heading(text, asString(call.arguments.arxiv_id) ?? call.tool_name);
+}
+
+function summaryForStep(kind: ResearchStepKind, text: string | null, evidence: ResearchEvidence[]) {
+  if (kind === 'recipe') return 'Extracted training recipe with source-linked evidence.';
+  if (kind === 'citation') return 'Citation context and related work traversal.';
+  if (kind === 'model') return 'Model candidate or Hub repository considered.';
+  if (kind === 'dataset') return 'Dataset candidate, schema, or preview considered.';
+  if (kind === 'repository') return 'Repository evidence and implementation readiness considered.';
+  return evidence[0]?.snippet ?? bounded(text ?? 'Research step captured from tool output.');
+}
+
+function reportFromCall(call: ToolCallPayload, index: number): ResearchStep | null {
+  const text = firstNonEmptyText(call.output, call.error);
+  const kind = kindForCall(call, text);
+  if (!kind) return null;
+
+  const evidence = evidenceFromLines(text);
+  const candidate = firstHubCandidate(text);
+  const sourceLinks = links(text);
+  if (candidate?.link && !sourceLinks.includes(candidate.link)) sourceLinks.push(candidate.link);
+  if (!evidence.length && text) {
+    evidence.push({ label: 'Output', snippet: bounded(text) });
+  }
+
+  const decision = decisionFromText(text);
+  const limitation = text?.match(/Verify against read_paper[^.\n]*[.\n]?/i)?.[0]?.trim() ?? null;
+
+  return {
+    id: call.id || `research-${index + 1}`,
+    kind,
+    title: titleForStep(call, kind, text),
+    sourceId: arxivId(call, text) ?? asString(call.arguments.repo_id) ?? asString(call.arguments.source) ?? null,
+    summary: summaryForStep(kind, text, evidence),
+    links: sourceLinks,
+    evidence,
+    confidence: kind === 'recipe' && text?.toLowerCase().includes('deterministically') ? 'deterministic extraction' : null,
+    limitations: limitation,
+    decision,
+  };
+}
+
+export function buildResearchTrailSummary(toolCalls: ToolCallPayload[]): ResearchTrailSummary {
+  const steps = toolCalls.flatMap((call, index) => {
+    const step = reportFromCall(call, index);
+    return step ? [step] : [];
+  });
+
+  return {
+    steps,
+    evidenceCount: steps.reduce((total, step) => total + step.evidence.length, 0),
+    decisionCount: steps.filter((step) => step.decision).length,
+  };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1724,6 +1724,126 @@ button {
   white-space: pre-wrap;
 }
 
+.research-trail-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.research-trail-counts,
+.research-step-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.research-timeline {
+  display: grid;
+  gap: 12px;
+}
+
+.research-step-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(96, 165, 250, 0.14);
+  border-radius: 16px;
+  background: rgba(3, 7, 18, 0.68);
+}
+
+.research-step-marker {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid rgba(96, 165, 250, 0.28);
+  border-radius: 999px;
+  color: #bfdbfe;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.research-step-body,
+.research-step-details {
+  display: grid;
+  gap: 10px;
+}
+
+.research-step-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.research-step-head h4 {
+  margin: 6px 0;
+  color: var(--text);
+  font-size: 0.95rem;
+  letter-spacing: -0.02em;
+}
+
+.research-step-head code {
+  color: #dbeafe;
+  font-size: 0.72rem;
+}
+
+.research-step-links a {
+  color: var(--accent);
+  font-size: 0.76rem;
+  text-decoration: none;
+}
+
+.research-step-links a:hover {
+  text-decoration: underline;
+}
+
+.research-step-body > p,
+.research-step-details p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.research-step-toggle {
+  width: fit-content;
+}
+
+.research-step-details {
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.research-step-details span,
+.research-step-details blockquote span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.research-step-details blockquote {
+  margin: 0;
+  padding: 10px;
+  border-left: 3px solid rgba(96, 165, 250, 0.45);
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.55);
+  color: #dbeafe;
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
 .artifact-browser-panel {
   display: grid;
   gap: 14px;


### PR DESCRIPTION
## Summary
- Adds a dedicated Research evidence trail panel for persisted research-related tool calls.
- Extracts paper, citation, reading, recipe, model, dataset, documentation, repository, and decision signals into an ordered timeline.
- Surfaces evidence snippets, source links/IDs, deterministic recipe confidence, limitations, and decisions with expandable detail cards.
- Adds `Open research trail` links from research/documentation/Hub/repository tool trace cards without adding broad backend graph APIs.

Closes #120

## Validation
- `npm test` from `frontend/` — 16 files / 19 tests passed
- `npm run build` from `frontend/`
- `python -m pytest tests/ -q` — 246 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`
- `npm audit --omit=dev` from `frontend/`