### PR TITLE
ML-410 / Strengthen frontend state architecture and session recovery

### DIFF
--- a/docs/superpowers/plans/2026-07-01-frontend-state-recovery.md
+++ b/docs/superpowers/plans/2026-07-01-frontend-state-recovery.md
@@ -1,0 +1,118 @@
+# Frontend State Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Strengthen the frontend session state and recovery path so Phase 5 workbench panels can replay persisted session state and surface stream health without fragile ad hoc updates.
+
+**Architecture:** Add a pure `workbenchState` helper module for session list merges, live event replay/deduplication, recovery snapshots, and connection-health derivation. Add a small `SessionRecoveryPanel` that consumes those typed helpers, then wire App to use the helpers while keeping existing panel props stable.
+
+**Tech Stack:** React, TypeScript, Vite, Vitest, Testing Library.
+
+---
+
+### Task 1: Typed workbench state helpers
+
+**Files:**
+- Create: `frontend/src/workbenchState.ts`
+- Test: `frontend/src/workbenchState.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create tests for:
+- merging session summaries by id without duplicating sessions;
+- replaying live events with id/sequence dedupe, bounded history, assistant chunk delta extraction, and terminal event detection;
+- building a recovery snapshot from active session, transcript, tool calls, and live events;
+- deriving stale/reconnecting/live/offline stream health.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `npm test -- workbenchState.test.ts`
+
+Expected: fail because `./workbenchState` does not exist yet.
+
+- [ ] **Step 3: Implement minimal helpers**
+
+Create the module with exported pure functions:
+- `mergeSessionSummaries`
+- `replaySessionEvents`
+- `buildRecoverySnapshot`
+- `deriveConnectionHealth`
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `npm test -- workbenchState.test.ts`
+
+Expected: pass.
+
+### Task 2: User-visible recovery panel
+
+**Files:**
+- Create: `frontend/src/components/SessionRecoveryPanel.tsx`
+- Test: `frontend/src/components/SessionRecoveryPanel.test.tsx`
+- Modify: `frontend/src/styles.css`
+
+- [ ] **Step 1: Write failing component test**
+
+Test that the panel renders stream status, recovery snapshot counts, last event sequence, replay details, and a reconnect button when recovery is available.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `npm test -- SessionRecoveryPanel.test.tsx`
+
+Expected: fail because `./SessionRecoveryPanel` does not exist yet.
+
+- [ ] **Step 3: Implement minimal component and styles**
+
+Render compact, product-grade session recovery visibility without changing backend contracts.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `npm test -- SessionRecoveryPanel.test.tsx`
+
+Expected: pass.
+
+### Task 3: Wire App to typed state helpers
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/types.ts` if shared string unions are needed
+
+- [ ] **Step 1: Replace ad hoc event append logic**
+
+Use `replaySessionEvents` inside the EventSource handler to cap and dedupe live event history, update the last event sequence, and append assistant chunks from the replay result.
+
+- [ ] **Step 2: Replace ad hoc session list updates**
+
+Use `mergeSessionSummaries` after session create, chat response, and approval response.
+
+- [ ] **Step 3: Add recovery panel and reconnect affordance**
+
+Use `buildRecoverySnapshot` and `deriveConnectionHealth` from App state, render `SessionRecoveryPanel`, and expose a safe reconnect button that calls the existing EventSource flow with replay enabled.
+
+- [ ] **Step 4: Run focused frontend tests**
+
+Run: `npm test -- workbenchState.test.ts SessionRecoveryPanel.test.tsx`
+
+Expected: pass.
+
+### Task 4: Full validation and publish
+
+**Files:**
+- Modify: `ML-COPILOT-WORKFLOW.md` outside the repo only after PR is ready.
+
+- [ ] **Step 1: Run validation**
+
+Run frontend tests/build, backend tests/type/lint checks, pre-commit, audit, and `git diff --check`.
+
+- [ ] **Step 2: Commit and push only scoped files**
+
+Stage only ML-410 files and open PR with the requested PR template:
+`Summary`, `Testing`, `Notes`, `Referrence`, `Close #122`.
+
+- [ ] **Step 3: Verify GitHub metadata**
+
+Confirm labels `feature`/`phase5`, assignee `Sohail-Shaikh-07`, and issue closing reference.
+
+- [ ] **Step 4: Update Notion and local workflow**
+
+Update ML-410 to review state and keep `ML-COPILOT-WORKFLOW.md` local-only.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import PublishingPanel from './components/PublishingPanel';
 import ResearchTrailPanel from './components/ResearchTrailPanel';
 import RichMessageContent from './components/RichMessageContent';
 import RuntimeDetailPanel from './components/RuntimeDetailPanel';
+import SessionRecoveryPanel from './components/SessionRecoveryPanel';
 import SessionSidebar from './components/SessionSidebar';
 import {
   DEFAULT_SESSION_CONTROLS,
@@ -25,6 +26,14 @@ import {
 } from './sessionControls';
 import ToolTracePanel from './components/ToolTracePanel';
 import UsageMeterPanel from './components/UsageMeterPanel';
+import {
+  buildRecoverySnapshot,
+  deriveConnectionHealth,
+  mergeSessionSummaries,
+  replaySessionEvents,
+  type LoadState,
+  type StreamState,
+} from './workbenchState';
 import type {
   ApprovalDecisionRequest,
   MessagePayload,
@@ -35,11 +44,7 @@ import type {
   ToolCallPayload,
 } from './types';
 
-type LoadState = 'idle' | 'loading' | 'ready' | 'error';
-type StreamState = 'idle' | 'connecting' | 'streaming' | 'closed' | 'error';
-
 const sessionMetadataSource = 'frontend-shell';
-const terminalEventTypes = new Set(['turn_complete', 'approval_required', 'error', 'interrupted']);
 
 function formatTimestamp(value: string) {
   const date = new Date(value);
@@ -97,6 +102,12 @@ function App() {
   const [messages, setMessages] = useState<MessagePayload[]>([]);
   const [liveEvents, setLiveEvents] = useState<SessionEventPayload[]>([]);
   const [liveAssistantText, setLiveAssistantText] = useState('');
+  const [lastEventSequence, setLastEventSequence] = useState(-1);
+  const [lastEventAt, setLastEventAt] = useState<string | null>(null);
+  const [replayedEventCount, setReplayedEventCount] = useState(0);
+  const [duplicateEventCount, setDuplicateEventCount] = useState(0);
+  const [recoveredAt, setRecoveredAt] = useState<string | null>(null);
+  const [heartbeatNow, setHeartbeatNow] = useState(() => new Date().toISOString());
   const [state, setState] = useState<LoadState>('idle');
   const [sessionState, setSessionState] = useState<LoadState>('idle');
   const [streamState, setStreamState] = useState<StreamState>('idle');
@@ -116,11 +127,21 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const timer = window.setInterval(() => setHeartbeatNow(new Date().toISOString()), 15_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
     if (!selectedSessionId) {
       setActiveSession(null);
       setMessages([]);
       setLiveEvents([]);
       setLiveAssistantText('');
+      setLastEventSequence(-1);
+      setLastEventAt(null);
+      setReplayedEventCount(0);
+      setDuplicateEventCount(0);
+      setRecoveredAt(null);
       setStreamState('idle');
       closeEventStream();
       return;
@@ -129,6 +150,11 @@ function App() {
     lastEventSequenceRef.current = -1;
     setLiveEvents([]);
     setLiveAssistantText('');
+    setLastEventSequence(-1);
+    setLastEventAt(null);
+    setReplayedEventCount(0);
+    setDuplicateEventCount(0);
+    setRecoveredAt(null);
     void refreshSession(selectedSessionId);
     connectEventStream(selectedSessionId, { replay: true });
 
@@ -148,23 +174,26 @@ function App() {
     eventSourceRef.current = createSessionEventSource(sessionId, {
       after,
       onEvent: (event) => {
-        lastEventSequenceRef.current = Math.max(lastEventSequenceRef.current, event.sequence);
+        setHeartbeatNow(new Date().toISOString());
+        setLastEventAt(event.created_at);
         setStreamState('streaming');
-        setLiveEvents((current) => [...current.slice(-39), event]);
-
-        if (event.event_type === 'assistant_chunk') {
-          const content = event.data.content;
-          if (typeof content === 'string') {
-            setLiveAssistantText((current) => current + content);
+        setLiveEvents((current) => {
+          const replay = replaySessionEvents({ current, incoming: [event] });
+          lastEventSequenceRef.current = replay.lastSequence;
+          setLastEventSequence(replay.lastSequence);
+          setReplayedEventCount((count) => count + replay.replayedCount);
+          setDuplicateEventCount((count) => count + replay.duplicateCount);
+          if (replay.assistantDelta) {
+            setLiveAssistantText((currentText) => currentText + replay.assistantDelta);
           }
-        }
-
-        if (terminalEventTypes.has(event.event_type)) {
-          closeEventStream();
-          setStreamState('closed');
-          void refreshSession(sessionId);
-          void refreshSessions();
-        }
+          if (replay.terminalEventType) {
+            closeEventStream();
+            setStreamState('closed');
+            void refreshSession(sessionId);
+            void refreshSessions();
+          }
+          return replay.events;
+        });
       },
       onError: () => {
         eventSourceRef.current = null;
@@ -212,6 +241,7 @@ function App() {
       ]);
       setActiveSession(detail);
       setMessages(transcript);
+      setRecoveredAt(new Date().toISOString());
       setSessionState('ready');
     } catch (err) {
       setActiveSession(null);
@@ -232,7 +262,7 @@ function App() {
         model: draftModel.trim() || null,
         metadata: buildSessionMetadata(sessionMetadataSource, draftControls),
       }, draftHfToken.trim() || null);
-      setSessions((current) => [created, ...current.filter((session) => session.id !== created.id)]);
+      setSessions((current) => mergeSessionSummaries(current, created));
       setSelectedSessionId(created.id);
       setDraftTitle('');
       setDraftModel('');
@@ -268,9 +298,7 @@ function App() {
       setActiveSession(response.session);
       setMessages(response.messages);
       setLiveAssistantText('');
-      setSessions((current) =>
-        current.map((session) => (session.id === response.session.id ? response.session : session)),
-      );
+      setSessions((current) => mergeSessionSummaries(current, response.session));
 
       if (response.result.status === 'approval_required') {
         setNotice('The agent is waiting for approval. Review the pending action in the approval dialog.');
@@ -309,9 +337,7 @@ function App() {
       );
       setActiveSession(response.session);
       setMessages(response.messages);
-      setSessions((current) =>
-        current.map((session) => (session.id === response.session.id ? response.session : session)),
-      );
+      setSessions((current) => mergeSessionSummaries(current, response.session));
 
       if (response.result.status === 'approval_required') {
         setNotice('One approval was resolved. Another pending approval still needs review.');
@@ -347,6 +373,28 @@ function App() {
 
   const pendingApprovals: PendingApprovalPayload[] = activeSession?.pending_approvals ?? [];
   const toolCalls: ToolCallPayload[] = activeSession?.tool_calls ?? [];
+  const recoverySnapshot = useMemo(() => buildRecoverySnapshot({
+    session: activeSession,
+    messages,
+    liveEvents,
+    lastEventSequence,
+    replayedEventCount,
+    duplicateEventCount,
+    recoveredAt,
+  }), [activeSession, messages, liveEvents, lastEventSequence, replayedEventCount, duplicateEventCount, recoveredAt]);
+  const connectionHealth = useMemo(() => deriveConnectionHealth({
+    loadState: state,
+    sessionState,
+    streamState,
+    lastEventAt,
+    now: heartbeatNow,
+    hasReplayCursor: lastEventSequence >= 0,
+  }), [state, sessionState, streamState, lastEventAt, heartbeatNow, lastEventSequence]);
+
+  function handleReconnectStream() {
+    if (!selectedSessionId) return;
+    connectEventStream(selectedSessionId, { replay: true });
+  }
 
   return (
     <div className="app-shell">
@@ -459,8 +507,8 @@ function App() {
                   />
                 </label>
                 <div className="composer-actions">
-                  <span className={`status-chip ${streamState === 'error' ? 'danger' : streamState === 'streaming' ? 'success' : 'neutral'}`}>
-                    stream: {streamState}
+                  <span className={`status-chip ${connectionHealth.tone}`}>
+                    stream: {connectionHealth.phase}
                   </span>
                   <button className="primary-button" type="submit" disabled={sending || !draftPrompt.trim()}>
                     {sending ? 'Sending...' : 'Send prompt'}
@@ -499,6 +547,12 @@ function App() {
               pendingApprovals={pendingApprovals}
               resolving={resolvingApproval}
               onResolve={handleResolveApproval}
+            />
+
+            <SessionRecoveryPanel
+              health={connectionHealth}
+              snapshot={recoverySnapshot}
+              onReconnect={handleReconnectStream}
             />
 
             <JobProgressPanel toolCalls={toolCalls} />

--- a/frontend/src/components/SessionRecoveryPanel.test.tsx
+++ b/frontend/src/components/SessionRecoveryPanel.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import SessionRecoveryPanel from './SessionRecoveryPanel';
+import type { ConnectionHealth, RecoverySnapshot } from '../workbenchState';
+
+const snapshot: RecoverySnapshot = {
+  sessionId: 'session-1',
+  sessionTitle: 'Train model',
+  messageCount: 4,
+  toolCallCount: 3,
+  liveEventCount: 5,
+  persistedEventCount: 12,
+  lastEventSequence: 11,
+  replayedEventCount: 2,
+  duplicateEventCount: 1,
+  recoveredAt: '2026-07-01T06:05:00Z',
+  status: 'recovered',
+};
+
+const health: ConnectionHealth = {
+  phase: 'stale',
+  label: 'stream heartbeat stale',
+  tone: 'warning',
+  lastEventAgeMs: 125_000,
+  canReconnect: true,
+};
+
+describe('SessionRecoveryPanel', () => {
+  it('shows recovery snapshot, stream health, replay details, and reconnect action', async () => {
+    const user = userEvent.setup();
+    const onReconnect = vi.fn();
+
+    const { unmount } = render(
+      <SessionRecoveryPanel
+        health={health}
+        onReconnect={onReconnect}
+        snapshot={snapshot}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Session recovery' });
+
+    expect(within(panel).getByText('stream heartbeat stale')).toBeInTheDocument();
+    expect(within(panel).getByText('Train model')).toBeInTheDocument();
+    expect(within(panel).getByText('4 messages')).toBeInTheDocument();
+    expect(within(panel).getByText('3 tool calls')).toBeInTheDocument();
+    expect(within(panel).getByText('5 live events')).toBeInTheDocument();
+    expect(within(panel).getByText('sequence 11')).toBeInTheDocument();
+    expect(within(panel).getByText('2 replayed')).toBeInTheDocument();
+    expect(within(panel).getByText('1 duplicate skipped')).toBeInTheDocument();
+    expect(within(panel).getByText('last event 2m 5s ago')).toBeInTheDocument();
+
+    await user.click(within(panel).getByRole('button', { name: 'Reconnect with replay' }));
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('renders an empty recovery state without reconnect when no session is selected', () => {
+    render(
+      <SessionRecoveryPanel
+        health={{
+          phase: 'idle',
+          label: 'stream idle',
+          tone: 'neutral',
+          lastEventAgeMs: null,
+          canReconnect: false,
+        }}
+        onReconnect={vi.fn()}
+        snapshot={null}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Session recovery' });
+    expect(within(panel).getByText('No session recovery snapshot yet.')).toBeInTheDocument();
+    expect(within(panel).queryByRole('button', { name: 'Reconnect with replay' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SessionRecoveryPanel.tsx
+++ b/frontend/src/components/SessionRecoveryPanel.tsx
@@ -1,0 +1,69 @@
+import type { ConnectionHealth, RecoverySnapshot } from '../workbenchState';
+
+interface SessionRecoveryPanelProps {
+  health: ConnectionHealth;
+  snapshot: RecoverySnapshot | null;
+  onReconnect: () => void;
+}
+
+function ageLabel(ms: number | null) {
+  if (ms === null) return 'no live event yet';
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) return `last event ${minutes}m ${seconds}s ago`;
+  return `last event ${seconds}s ago`;
+}
+
+export default function SessionRecoveryPanel({ health, snapshot, onReconnect }: SessionRecoveryPanelProps) {
+  return (
+    <section className="session-recovery-panel" aria-label="Session recovery">
+      <div className="runtime-detail-header">
+        <div>
+          <p className="panel-label">Recovery</p>
+          <h3>Session recovery</h3>
+          <p className="muted">Typed replay state for refreshes, reconnects, and restored workbench panels.</p>
+        </div>
+        <span className={`status-chip ${health.tone}`}>{health.label}</span>
+      </div>
+
+      {snapshot ? (
+        <>
+          <div className="recovery-summary">
+            <div>
+              <span>Session</span>
+              <strong>{snapshot.sessionTitle}</strong>
+            </div>
+            <div>
+              <span>Transcript</span>
+              <strong>{snapshot.messageCount} messages</strong>
+            </div>
+            <div>
+              <span>Tools</span>
+              <strong>{snapshot.toolCallCount} tool calls</strong>
+            </div>
+            <div>
+              <span>Live buffer</span>
+              <strong>{snapshot.liveEventCount} live events</strong>
+            </div>
+          </div>
+
+          <div className="recovery-meta">
+            <span>sequence {snapshot.lastEventSequence}</span>
+            <span>{snapshot.replayedEventCount} replayed</span>
+            <span>{snapshot.duplicateEventCount} duplicate skipped</span>
+            <span>{ageLabel(health.lastEventAgeMs)}</span>
+          </div>
+
+          {health.canReconnect ? (
+            <button className="ghost-button" type="button" onClick={onReconnect}>
+              Reconnect with replay
+            </button>
+          ) : null}
+        </>
+      ) : (
+        <p className="muted">No session recovery snapshot yet.</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2044,6 +2044,53 @@ button {
   word-break: break-word;
 }
 
+.session-recovery-panel {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.recovery-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.recovery-summary div {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.recovery-summary span,
+.recovery-meta span {
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.recovery-summary strong {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--text);
+}
+
+.recovery-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.recovery-meta span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.35rem 0.6rem;
+  background: rgba(148, 163, 184, 0.08);
+}
+
 .muted {
   color: var(--muted);
 }

--- a/frontend/src/workbenchState.test.ts
+++ b/frontend/src/workbenchState.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRecoverySnapshot,
+  deriveConnectionHealth,
+  mergeSessionSummaries,
+  replaySessionEvents,
+} from './workbenchState';
+import type { MessagePayload, SessionDetail, SessionEventPayload, SessionSummary, ToolCallPayload } from './types';
+
+function metrics() {
+  return {
+    session_id: 'session-1',
+    turn_count: 1,
+    prompt_tokens: 10,
+    completion_tokens: 20,
+    total_tokens: 30,
+    estimated_cost_usd: 0.001,
+    tool_calls: 2,
+    tool_errors: 0,
+    tool_retries: 0,
+    tool_latency_ms: 500,
+    average_tool_latency_ms: 250,
+    error_count: 0,
+    last_updated_at: '2026-07-01T06:00:00Z',
+  };
+}
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'session-1',
+    title: 'Train model',
+    status: 'running',
+    model: 'zai-org/GLM-5.2:novita',
+    metadata: {},
+    created_at: '2026-07-01T05:00:00Z',
+    updated_at: '2026-07-01T06:00:00Z',
+    message_count: 2,
+    event_count: 8,
+    pending_approval_count: 0,
+    metrics: metrics(),
+    ...overrides,
+  };
+}
+
+function detail(overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    ...session(),
+    pending_approvals: [],
+    tool_calls: [],
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<MessagePayload> = {}): MessagePayload {
+  return {
+    id: 'message-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    role: 'assistant',
+    content: 'Recovered answer',
+    tool_call_id: null,
+    name: null,
+    raw: {},
+    sequence: 4,
+    created_at: '2026-07-01T05:01:00Z',
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<SessionEventPayload> = {}): SessionEventPayload {
+  return {
+    id: 'event-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    event_type: 'assistant_chunk',
+    data: { content: 'hello' },
+    sequence: 7,
+    created_at: '2026-07-01T05:02:00Z',
+    ...overrides,
+  };
+}
+
+function toolCall(overrides: Partial<ToolCallPayload> = {}): ToolCallPayload {
+  return {
+    id: 'tool-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T05:02:00Z',
+    finished_at: '2026-07-01T05:03:00Z',
+    output: 'done',
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('workbench state helpers', () => {
+  it('merges session summaries by id and keeps the newest updated session first', () => {
+    const merged = mergeSessionSummaries(
+      [session({ id: 'session-1', title: 'Old', updated_at: '2026-07-01T05:00:00Z' })],
+      [
+        session({ id: 'session-2', title: 'Another', updated_at: '2026-07-01T05:30:00Z' }),
+        session({ id: 'session-1', title: 'New', updated_at: '2026-07-01T06:00:00Z' }),
+      ],
+    );
+
+    expect(merged.map((item) => item.id)).toEqual(['session-1', 'session-2']);
+    expect(merged[0].title).toBe('New');
+  });
+
+  it('replays session events with dedupe, bounded history, assistant deltas, and terminal detection', () => {
+    const replay = replaySessionEvents({
+      current: [
+        event({ id: 'event-1', sequence: 7, data: { content: 'hello ' } }),
+        event({ id: 'event-older', sequence: 6, event_type: 'tool_call_started', data: {} }),
+      ],
+      incoming: [
+        event({ id: 'event-1', sequence: 7, data: { content: 'duplicate' } }),
+        event({ id: 'event-2', sequence: 8, data: { content: 'world' } }),
+        event({ id: 'event-3', sequence: 9, event_type: 'turn_complete', data: {} }),
+      ],
+      limit: 3,
+    });
+
+    expect(replay.events.map((item) => item.id)).toEqual(['event-1', 'event-2', 'event-3']);
+    expect(replay.lastSequence).toBe(9);
+    expect(replay.duplicateCount).toBe(1);
+    expect(replay.replayedCount).toBe(2);
+    expect(replay.assistantDelta).toBe('world');
+    expect(replay.terminalEventType).toBe('turn_complete');
+  });
+
+  it('builds a recovery snapshot from persisted session detail and replayed events', () => {
+    const snapshot = buildRecoverySnapshot({
+      session: detail({ event_count: 12, tool_calls: [toolCall(), toolCall({ id: 'tool-2' })] }),
+      messages: [message(), message({ id: 'message-2', sequence: 5 })],
+      liveEvents: [event({ sequence: 7 }), event({ id: 'event-2', sequence: 9 })],
+      lastEventSequence: 9,
+      replayedEventCount: 3,
+      duplicateEventCount: 1,
+      recoveredAt: '2026-07-01T06:05:00Z',
+    });
+
+    expect(snapshot?.sessionTitle).toBe('Train model');
+    expect(snapshot?.messageCount).toBe(2);
+    expect(snapshot?.toolCallCount).toBe(2);
+    expect(snapshot?.lastEventSequence).toBe(9);
+    expect(snapshot?.replayedEventCount).toBe(3);
+    expect(snapshot?.duplicateEventCount).toBe(1);
+    expect(snapshot?.status).toBe('recovered');
+  });
+
+  it('derives live, stale, reconnecting, and offline connection health', () => {
+    expect(deriveConnectionHealth({
+      loadState: 'ready',
+      sessionState: 'ready',
+      streamState: 'streaming',
+      lastEventAt: '2026-07-01T06:00:00Z',
+      now: '2026-07-01T06:00:20Z',
+      staleAfterMs: 60_000,
+    }).phase).toBe('live');
+
+    expect(deriveConnectionHealth({
+      loadState: 'ready',
+      sessionState: 'ready',
+      streamState: 'streaming',
+      lastEventAt: '2026-07-01T06:00:00Z',
+      now: '2026-07-01T06:02:00Z',
+      staleAfterMs: 60_000,
+    }).phase).toBe('stale');
+
+    expect(deriveConnectionHealth({
+      loadState: 'ready',
+      sessionState: 'ready',
+      streamState: 'connecting',
+      lastEventAt: '2026-07-01T06:00:00Z',
+      now: '2026-07-01T06:00:10Z',
+      staleAfterMs: 60_000,
+      hasReplayCursor: true,
+    }).phase).toBe('reconnecting');
+
+    expect(deriveConnectionHealth({
+      loadState: 'error',
+      sessionState: 'idle',
+      streamState: 'idle',
+      lastEventAt: null,
+      now: '2026-07-01T06:00:10Z',
+      staleAfterMs: 60_000,
+    }).phase).toBe('offline');
+  });
+});

--- a/frontend/src/workbenchState.ts
+++ b/frontend/src/workbenchState.ts
@@ -1,0 +1,233 @@
+import type { MessagePayload, SessionDetail, SessionEventPayload, SessionSummary, ToolCallPayload } from './types';
+
+export type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+export type StreamState = 'idle' | 'connecting' | 'streaming' | 'closed' | 'error';
+export type ConnectionPhase = 'idle' | 'loading' | 'recovering' | 'reconnecting' | 'live' | 'stale' | 'closed' | 'offline';
+
+const terminalEventTypes = new Set(['turn_complete', 'approval_required', 'error', 'interrupted']);
+
+export interface EventReplayInput {
+  current: SessionEventPayload[];
+  incoming: SessionEventPayload[];
+  limit?: number;
+}
+
+export interface EventReplayResult {
+  events: SessionEventPayload[];
+  lastSequence: number;
+  duplicateCount: number;
+  replayedCount: number;
+  assistantDelta: string;
+  terminalEventType: string | null;
+}
+
+export interface RecoverySnapshotInput {
+  session: SessionDetail | null;
+  messages: MessagePayload[];
+  liveEvents: SessionEventPayload[];
+  lastEventSequence: number;
+  replayedEventCount: number;
+  duplicateEventCount: number;
+  recoveredAt: string | null;
+}
+
+export interface RecoverySnapshot {
+  sessionId: string;
+  sessionTitle: string;
+  messageCount: number;
+  toolCallCount: number;
+  liveEventCount: number;
+  persistedEventCount: number;
+  lastEventSequence: number;
+  replayedEventCount: number;
+  duplicateEventCount: number;
+  recoveredAt: string | null;
+  status: 'recovering' | 'recovered' | 'empty';
+}
+
+export interface ConnectionHealthInput {
+  loadState: LoadState;
+  sessionState: LoadState;
+  streamState: StreamState;
+  lastEventAt: string | null;
+  now?: string;
+  staleAfterMs?: number;
+  hasReplayCursor?: boolean;
+}
+
+export interface ConnectionHealth {
+  phase: ConnectionPhase;
+  label: string;
+  tone: 'neutral' | 'success' | 'warning' | 'danger';
+  lastEventAgeMs: number | null;
+  canReconnect: boolean;
+}
+
+function timestamp(value: string) {
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function sessionTitle(session: SessionSummary | SessionDetail) {
+  return session.title?.trim() || 'Untitled session';
+}
+
+export function mergeSessionSummaries(current: SessionSummary[], incoming: SessionSummary | SessionSummary[]) {
+  const nextById = new Map(current.map((session) => [session.id, session]));
+  for (const session of Array.isArray(incoming) ? incoming : [incoming]) {
+    nextById.set(session.id, session);
+  }
+  return [...nextById.values()].sort((left, right) => timestamp(right.updated_at) - timestamp(left.updated_at));
+}
+
+export function replaySessionEvents({ current, incoming, limit = 40 }: EventReplayInput): EventReplayResult {
+  const byId = new Map(current.map((item) => [item.id, item]));
+  const seenSequences = new Set(current.map((item) => item.sequence));
+  let duplicateCount = 0;
+  let replayedCount = 0;
+  let assistantDelta = '';
+  let terminalEventType: string | null = null;
+
+  for (const item of incoming) {
+    if (byId.has(item.id) || seenSequences.has(item.sequence)) {
+      duplicateCount += 1;
+      continue;
+    }
+    byId.set(item.id, item);
+    seenSequences.add(item.sequence);
+    replayedCount += 1;
+
+    if (item.event_type === 'assistant_chunk' && typeof item.data.content === 'string') {
+      assistantDelta += item.data.content;
+    }
+    if (terminalEventTypes.has(item.event_type)) {
+      terminalEventType = item.event_type;
+    }
+  }
+
+  const events = [...byId.values()]
+    .sort((left, right) => left.sequence - right.sequence)
+    .slice(-limit);
+  const lastSequence = events.reduce((last, item) => Math.max(last, item.sequence), -1);
+
+  return {
+    events,
+    lastSequence,
+    duplicateCount,
+    replayedCount,
+    assistantDelta,
+    terminalEventType,
+  };
+}
+
+export function buildRecoverySnapshot(input: RecoverySnapshotInput): RecoverySnapshot | null {
+  if (!input.session) return null;
+
+  const toolCalls: ToolCallPayload[] = input.session.tool_calls ?? [];
+  const hasRecoveredState = input.messages.length > 0 || toolCalls.length > 0 || input.liveEvents.length > 0;
+
+  return {
+    sessionId: input.session.id,
+    sessionTitle: sessionTitle(input.session),
+    messageCount: input.messages.length,
+    toolCallCount: toolCalls.length,
+    liveEventCount: input.liveEvents.length,
+    persistedEventCount: input.session.event_count,
+    lastEventSequence: input.lastEventSequence,
+    replayedEventCount: input.replayedEventCount,
+    duplicateEventCount: input.duplicateEventCount,
+    recoveredAt: input.recoveredAt,
+    status: input.recoveredAt ? 'recovered' : hasRecoveredState ? 'recovering' : 'empty',
+  };
+}
+
+export function deriveConnectionHealth({
+  loadState,
+  sessionState,
+  streamState,
+  lastEventAt,
+  now = new Date().toISOString(),
+  staleAfterMs = 90_000,
+  hasReplayCursor = false,
+}: ConnectionHealthInput): ConnectionHealth {
+  const nowMs = timestamp(now);
+  const lastEventAgeMs = lastEventAt ? Math.max(0, nowMs - timestamp(lastEventAt)) : null;
+
+  if (loadState === 'error') {
+    return {
+      phase: 'offline',
+      label: 'backend offline',
+      tone: 'danger',
+      lastEventAgeMs,
+      canReconnect: false,
+    };
+  }
+
+  if (loadState === 'loading' || sessionState === 'loading') {
+    return {
+      phase: streamState === 'connecting' && hasReplayCursor ? 'reconnecting' : 'loading',
+      label: streamState === 'connecting' && hasReplayCursor ? 'replaying stream' : 'loading session',
+      tone: 'neutral',
+      lastEventAgeMs,
+      canReconnect: false,
+    };
+  }
+
+  if (streamState === 'connecting') {
+    return {
+      phase: hasReplayCursor ? 'reconnecting' : 'recovering',
+      label: hasReplayCursor ? 'reconnecting from replay cursor' : 'opening stream',
+      tone: 'neutral',
+      lastEventAgeMs,
+      canReconnect: false,
+    };
+  }
+
+  if (streamState === 'error') {
+    return {
+      phase: 'offline',
+      label: 'stream disconnected',
+      tone: 'danger',
+      lastEventAgeMs,
+      canReconnect: true,
+    };
+  }
+
+  if (streamState === 'closed') {
+    return {
+      phase: 'closed',
+      label: 'stream closed after turn',
+      tone: 'success',
+      lastEventAgeMs,
+      canReconnect: hasReplayCursor,
+    };
+  }
+
+  if (streamState === 'streaming' && lastEventAgeMs !== null && lastEventAgeMs > staleAfterMs) {
+    return {
+      phase: 'stale',
+      label: 'stream heartbeat stale',
+      tone: 'warning',
+      lastEventAgeMs,
+      canReconnect: true,
+    };
+  }
+
+  if (streamState === 'streaming') {
+    return {
+      phase: 'live',
+      label: 'stream live',
+      tone: 'success',
+      lastEventAgeMs,
+      canReconnect: false,
+    };
+  }
+
+  return {
+    phase: 'idle',
+    label: 'stream idle',
+    tone: 'neutral',
+    lastEventAgeMs,
+    canReconnect: hasReplayCursor,
+  };
+}


### PR DESCRIPTION
Summary
- Adds typed frontend workbench state helpers for session summary merges, live event replay, dedupe, recovery snapshots, and connection health.
- Adds a Session recovery panel that shows replay status, persisted transcript/tool/live-event counts, last event sequence, duplicate skips, and reconnect-with-replay affordance.
- Wires App to use the helper layer for stream replay, assistant chunk accumulation, session list updates, heartbeat/stale-stream visibility, and refresh/reconnect recovery without backend API changes.

Testing
- `npm test` from `frontend/` - 18 files / 25 tests passed
- `npm run build` from `frontend/`
- `python -m pytest tests/ -q` - 246 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`
- `npm audit --omit=dev` from `frontend/`

Notes
- Frontend-first slice only; no broad backend rewrites or API contract changes.
- Existing Phase 5 panels keep receiving the same session/tool-call props.
- Adds focused regression coverage for state replay and the recovery panel.

Referrence
- Frontend state architecture and session recovery follow-up for the Phase 5 workbench.

Close #122
