### PR TITLE
ML-411 / Add frontend test harness and regression coverage

### DIFF
--- a/docs/superpowers/plans/2026-07-01-frontend-regression-harness.md
+++ b/docs/superpowers/plans/2026-07-01-frontend-regression-harness.md
@@ -1,0 +1,60 @@
+# Frontend Regression Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add frontend regression coverage that composes Phase 5 workbench panels around a shared realistic session fixture.
+
+**Architecture:** Create test-only fixture helpers that generate a complete session, message transcript, live events, recovery state, and tool-call outputs covering jobs, runtime, publishing, research, evals, artifacts, usage, provider controls, and trace-card anchors. Add one integration-style regression test that renders the panels together and asserts user-visible surfaces and cross-panel links.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library.
+
+---
+
+### Task 1: Shared frontend workbench fixture helpers
+
+**Files:**
+- Create: `frontend/src/testUtils/workbenchFixtures.tsx`
+- Test: `frontend/src/components/WorkbenchRegressionHarness.test.tsx`
+
+- [ ] **Step 1: Write failing harness test**
+
+Create a component test that imports `renderPhase5WorkbenchHarness` from `../testUtils/workbenchFixtures`, renders the harness, and asserts visible sections for provider controls, rich messages, job progress, recovery, usage, runtime, publishing, research, eval, artifact browser, and trace cards.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `npm test -- WorkbenchRegressionHarness.test.tsx`
+
+Expected: fail because `../testUtils/workbenchFixtures` does not exist.
+
+- [ ] **Step 3: Implement fixture helper**
+
+Create shared `phase5WorkbenchFixture()` and `renderPhase5WorkbenchHarness()` helpers. The harness should compose existing production components without modifying production code.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `npm test -- WorkbenchRegressionHarness.test.tsx`
+
+Expected: pass.
+
+### Task 2: Full validation and publish
+
+**Files:**
+- Create: `frontend/src/testUtils/workbenchFixtures.tsx`
+- Create: `frontend/src/components/WorkbenchRegressionHarness.test.tsx`
+- Create: `docs/superpowers/plans/2026-07-01-frontend-regression-harness.md`
+
+- [ ] **Step 1: Run validation**
+
+Run frontend test/build, backend pytest/type/lint checks, pre-commit, audit, and whitespace check.
+
+- [ ] **Step 2: Commit and push only scoped files**
+
+Stage only ML-411 files. Do not stage `.kiro/`, `ml_copilot.egg-info/`, or the local workflow file.
+
+- [ ] **Step 3: Open PR with public template**
+
+Use sections: `Summary`, `Testing`, `Notes`, `Referrence`, `Close #124`. Do not mention Notion or internal tracker URLs.
+
+- [ ] **Step 4: Verify GitHub metadata**
+
+Confirm labels `feature`/`phase5`, assignee `Sohail-Shaikh-07`, and GitHub closing issue reference.

--- a/frontend/src/components/WorkbenchRegressionHarness.test.tsx
+++ b/frontend/src/components/WorkbenchRegressionHarness.test.tsx
@@ -1,0 +1,41 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderPhase5WorkbenchHarness } from '../test/workbenchFixtures';
+
+function expectLink(name: string, href: string) {
+  expect(screen.getAllByRole('link', { name }).some((link) => link.getAttribute('href') === href)).toBe(true);
+}
+
+describe('Phase 5 workbench regression harness', () => {
+  it('composes the workbench panels around one shared session fixture', async () => {
+    const user = userEvent.setup();
+    const onReconnect = vi.fn();
+    renderPhase5WorkbenchHarness({ onReconnect });
+
+    expect(screen.getByRole('region', { name: 'Model and provider controls' })).toBeInTheDocument();
+    expect(screen.getByText('Provider: Z.ai')).toBeInTheDocument();
+    expect(screen.getAllByText('Regression fixture assistant response').length).toBeGreaterThanOrEqual(1);
+
+    const recovery = screen.getByRole('region', { name: 'Session recovery' });
+    expect(within(recovery).getByText('stream heartbeat stale')).toBeInTheDocument();
+    await user.click(within(recovery).getByRole('button', { name: 'Reconnect with replay' }));
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByRole('region', { name: 'Hugging Face job progress' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Usage and cost estimate' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Runtime detail panels' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Final report and publishing UI' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Research evidence trail' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Eval suite dashboard' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'File and artifact browser' })).toBeInTheDocument();
+    expect(screen.getByText('Tool trace')).toBeInTheDocument();
+
+    expectLink('Open artifact browser', '#artifact-browser');
+    expectLink('Open publishing panel', '#publishing-panel');
+    expectLink('Open research trail', '#research-trail');
+    expectLink('Open eval artifacts', '#artifact-browser');
+    expectLink('Open runtime panel', '#runtime-details');
+  });
+});

--- a/frontend/src/test/workbenchFixtures.tsx
+++ b/frontend/src/test/workbenchFixtures.tsx
@@ -1,0 +1,349 @@
+import { render } from '@testing-library/react';
+import type { FormEvent } from 'react';
+
+import ArtifactBrowserPanel from '../components/ArtifactBrowserPanel';
+import EvalDashboardPanel from '../components/EvalDashboardPanel';
+import JobProgressPanel from '../components/JobProgressPanel';
+import PublishingPanel from '../components/PublishingPanel';
+import ResearchTrailPanel from '../components/ResearchTrailPanel';
+import RichMessageContent from '../components/RichMessageContent';
+import RuntimeDetailPanel from '../components/RuntimeDetailPanel';
+import SessionRecoveryPanel from '../components/SessionRecoveryPanel';
+import SessionSidebar from '../components/SessionSidebar';
+import ToolTracePanel from '../components/ToolTracePanel';
+import UsageMeterPanel from '../components/UsageMeterPanel';
+import { DEFAULT_SESSION_CONTROLS, type SessionControlState } from '../sessionControls';
+import type { ConnectionHealth, RecoverySnapshot } from '../workbenchState';
+import type { MessagePayload, SessionDetail, SessionEventPayload, ToolCallPayload } from '../types';
+
+function metrics() {
+  return {
+    session_id: 'session-1',
+    turn_count: 3,
+    prompt_tokens: 1200,
+    completion_tokens: 800,
+    total_tokens: 2000,
+    estimated_cost_usd: 0.045,
+    tool_calls: 8,
+    tool_errors: 1,
+    tool_retries: 1,
+    tool_latency_ms: 90000,
+    average_tool_latency_ms: 11250,
+    error_count: 1,
+    last_updated_at: '2026-07-01T06:10:00Z',
+  };
+}
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<MessagePayload>): MessagePayload {
+  return {
+    id: 'message-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    role: 'assistant',
+    content: 'Regression fixture assistant response',
+    tool_call_id: null,
+    name: null,
+    raw: {},
+    sequence: 1,
+    created_at: '2026-07-01T06:00:00Z',
+    ...overrides,
+  };
+}
+
+function liveEvent(overrides: Partial<SessionEventPayload>): SessionEventPayload {
+  return {
+    id: 'event-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    event_type: 'tool_call_started',
+    data: { tool_name: 'manage_job', operation: 'run' },
+    sequence: 8,
+    created_at: '2026-07-01T06:01:00Z',
+    ...overrides,
+  };
+}
+
+export function phase5WorkbenchFixture() {
+  const evalReport = {
+    status: 'failed',
+    summary: {
+      fixtures_total: 2,
+      fixtures_passed: 1,
+      fixtures_failed: 1,
+      fixtures_error: 0,
+      average_score: 0.5,
+      runtime_seconds: 9.25,
+      total_tokens: 42,
+    },
+    fixtures: [
+      {
+        fixture_id: 'fixture-pass',
+        status: 'passed',
+        score: 1,
+        markdown_path: '.ml-copilot/evals/artifacts/pass/report.md',
+        report_path: '.ml-copilot/evals/artifacts/pass/report.json',
+        report: {
+          agent_output: { mode: 'live' },
+          checks: [{ type: 'contains', passed: true, message: 'Expected text found.' }],
+        },
+      },
+      {
+        fixture_id: 'fixture-fail',
+        status: 'failed',
+        score: 0,
+        markdown_path: '.ml-copilot/evals/artifacts/fail/report.md',
+        report_path: '.ml-copilot/evals/artifacts/fail/report.json',
+        report: {
+          fixture: { metadata: { mode: 'scripted' } },
+          scoring: { file_changes: { files_changed: ['src/train.py'] } },
+          checks: [{ type: 'file_contains', passed: false, path: 'src/train.py', message: 'Metric missing.' }],
+        },
+      },
+    ],
+  };
+
+  const toolCalls: ToolCallPayload[] = [
+    toolCall({
+      id: 'job-run',
+      tool_name: 'manage_job',
+      arguments: { operation: 'run', hardware_flavor: 'cpu-basic', timeout: '30m' },
+      output: [
+        '# Job launched',
+        '### Job job-123',
+        '- **Status:** RUNNING',
+        '- **Message:** pulling image',
+        '- **Hardware:** cpu-basic',
+        '- **Created:** 2026-07-01T06:00:00Z',
+        '- **Command:** `python train.py`',
+        '- **URL:** https://huggingface.co/jobs/job-123',
+      ].join('\n'),
+    }),
+    toolCall({
+      id: 'job-logs',
+      tool_name: 'manage_job',
+      arguments: { operation: 'logs', job_id: 'job-123' },
+      output: ['# Logs for job-123', '```', 'epoch=1 loss=0.42', 'eval accuracy=0.91', '```'].join('\n'),
+    }),
+    toolCall({
+      id: 'sandbox-create',
+      tool_name: 'experiment_workspace',
+      arguments: { operation: 'create', hardware: 'cpu-basic' },
+      output: [
+        'Experiment workspace created.',
+        '- Space: owner/ml-copilot-sandbox-session-1',
+        '- URL: https://owner-ml-copilot-sandbox-session-1.hf.space',
+        '- Hardware: cpu-basic',
+        '- Created: 2026-07-01T06:00:00Z',
+      ].join('\n'),
+    }),
+    toolCall({
+      id: 'sandbox-run',
+      tool_name: 'experiment_workspace',
+      arguments: { operation: 'run', command: 'python src/train.py' },
+      status: 'failed',
+      success: false,
+      error: 'Command failed with CUDA out of memory while training.',
+    }),
+    toolCall({
+      id: 'publish-call',
+      tool_name: 'publish_model_report',
+      arguments: {
+        repo_id: 'owner/model-a',
+        output_dir: '.ml-copilot/reports/model-a',
+        model_name: 'Model A',
+        task: 'text-classification',
+        datasets: ['imdb'],
+        jobs: ['job-123'],
+        publish: false,
+      },
+      output: [
+        'Prepared model publishing assets.',
+        '- README: .ml-copilot/reports/model-a/README.md',
+        '- Final report: .ml-copilot/reports/model-a/FINAL_REPORT.md',
+        '- Manifest: .ml-copilot/reports/model-a/publish_manifest.json',
+        '',
+        '### README.md',
+        '```markdown',
+        '# Model A',
+        'Generated model card content.',
+        '```',
+        '',
+        '### FINAL_REPORT.md',
+        '```markdown',
+        '# Final Report: Model A',
+        'Recommendation: Ship after one more eval pass.',
+        '```',
+      ].join('\n'),
+    }),
+    toolCall({
+      id: 'paper',
+      tool_name: 'paper_details',
+      arguments: { arxiv_id: '2401.12345' },
+      output: [
+        '# Efficient Fine-Tuning for Small Models',
+        '**arxiv_id:** 2401.12345',
+        'https://arxiv.org/abs/2401.12345',
+        '## AI Summary',
+        'Adapters improve accuracy while keeping training cost low.',
+      ].join('\n'),
+    }),
+    toolCall({
+      id: 'recipe',
+      tool_name: 'extract_training_recipe',
+      arguments: { arxiv_id: '2401.12345' },
+      output: [
+        '# Training recipe for Efficient Fine-Tuning for Small Models',
+        '- evidence: "We train on IMDb and SST-2 sentiment datasets."',
+        'Recipe values are extracted deterministically. Verify against read_paper before relying on them for training.',
+      ].join('\n'),
+    }),
+    toolCall({
+      id: 'eval-suite',
+      tool_name: 'manage_eval_suite',
+      arguments: { operation: 'run' },
+      output: ['Suite report:', '```json', JSON.stringify(evalReport), '```'].join('\n'),
+    }),
+  ];
+
+  const activeSession: SessionDetail = {
+    id: 'session-1',
+    title: 'Phase 5 regression fixture',
+    status: 'running',
+    model: 'zai-org/GLM-5.2:novita',
+    metadata: {
+      agent_controls: {
+        provider: 'zai',
+        reasoning_effort: 'high',
+        temperature: 0.2,
+        operating_mode: 'careful',
+        yolo_mode: false,
+        max_turns: 4,
+        spend_cap_usd: 0.05,
+      },
+    },
+    created_at: '2026-07-01T06:00:00Z',
+    updated_at: '2026-07-01T06:10:00Z',
+    message_count: 2,
+    event_count: 12,
+    pending_approval_count: 0,
+    metrics: metrics(),
+    pending_approvals: [],
+    tool_calls: toolCalls,
+  };
+
+  const messages = [
+    message({ id: 'message-user', role: 'user', content: 'Run the Phase 5 workflow.' }),
+    message({ id: 'message-assistant', sequence: 2 }),
+  ];
+
+  const recoverySnapshot: RecoverySnapshot = {
+    sessionId: 'session-1',
+    sessionTitle: 'Phase 5 regression fixture',
+    messageCount: messages.length,
+    toolCallCount: toolCalls.length,
+    liveEventCount: 2,
+    persistedEventCount: 12,
+    lastEventSequence: 9,
+    replayedEventCount: 2,
+    duplicateEventCount: 1,
+    recoveredAt: '2026-07-01T06:10:00Z',
+    status: 'recovered',
+  };
+
+  const connectionHealth: ConnectionHealth = {
+    phase: 'stale',
+    label: 'stream heartbeat stale',
+    tone: 'warning',
+    lastEventAgeMs: 125_000,
+    canReconnect: true,
+  };
+
+  const draftControls: SessionControlState = {
+    ...DEFAULT_SESSION_CONTROLS,
+    provider: 'zai',
+    reasoningEffort: 'high',
+    operatingMode: 'careful',
+    temperature: '0.2',
+    maxTurns: '4',
+    spendCapUsd: '0.05',
+  };
+
+  return {
+    activeSession,
+    connectionHealth,
+    draftControls,
+    liveEvents: [liveEvent({ id: 'event-job', sequence: 8 }), liveEvent({ id: 'event-research', sequence: 9, data: { tool_name: 'paper_details', arxiv_id: '2401.12345' } })],
+    messages,
+    recoverySnapshot,
+    toolCalls,
+  };
+}
+
+export function renderPhase5WorkbenchHarness({ onReconnect }: { onReconnect: () => void }) {
+  const fixture = phase5WorkbenchFixture();
+  const noop = () => undefined;
+  const noopSubmit = (event: FormEvent<HTMLFormElement>) => event.preventDefault();
+
+  return render(
+    <div>
+      <SessionSidebar
+        activeSession={fixture.activeSession}
+        creating={false}
+        draftControls={fixture.draftControls}
+        draftHfToken=""
+        draftModel="zai-org/GLM-5.2:novita"
+        draftTitle=""
+        messages={fixture.messages}
+        onCreateSession={noopSubmit}
+        onRefreshSessions={noop}
+        onSelectSession={noop}
+        selectedSessionId={fixture.activeSession.id}
+        sessions={[fixture.activeSession]}
+        setDraftControls={noop}
+        setDraftHfToken={noop}
+        setDraftModel={noop}
+        setDraftTitle={noop}
+      />
+
+      <RichMessageContent content={fixture.messages[1].content} />
+
+      <SessionRecoveryPanel
+        health={fixture.connectionHealth}
+        snapshot={fixture.recoverySnapshot}
+        onReconnect={onReconnect}
+      />
+      <JobProgressPanel toolCalls={fixture.toolCalls} />
+      <UsageMeterPanel session={fixture.activeSession} toolCalls={fixture.toolCalls} />
+      <RuntimeDetailPanel toolCalls={fixture.toolCalls} />
+      <PublishingPanel toolCalls={fixture.toolCalls} />
+      <ResearchTrailPanel toolCalls={fixture.toolCalls} />
+      <EvalDashboardPanel toolCalls={fixture.toolCalls} />
+      <ArtifactBrowserPanel toolCalls={fixture.toolCalls} />
+      <ToolTracePanel
+        liveEvents={fixture.liveEvents}
+        metrics={fixture.activeSession.metrics}
+        pendingApprovals={[]}
+        toolCalls={fixture.toolCalls}
+      />
+    </div>,
+  );
+}


### PR DESCRIPTION
Summary
- Adds a shared frontend workbench regression fixture for the Phase 5 UI surfaces.
- Adds an integration-style harness test that composes provider controls, rich messages, session recovery, job progress, usage, runtime, publishing, research, eval, artifact browser, and tool trace panels around the same session/tool-call data.
- Verifies user-visible cross-panel anchors for artifacts, publishing, research, eval artifacts, and runtime details without changing production behavior.

Testing
- `npm test` from `frontend/` - 19 files / 26 tests passed
- `npm run build` from `frontend/`
- `python -m pytest tests/ -q` - 246 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`
- `npm audit --omit=dev` from `frontend/`

Notes
- Test-only slice; no production behavior or backend API changes.
- The shared fixture is kept under frontend test utilities so production builds do not include it.
- Assertions target user-visible panel composition and links rather than private implementation details.

Referrence
- Frontend regression coverage follow-up for the Phase 5 workbench.

Close #124
