### PR TITLE
ML-412 / Unify autonomous workflow workbench experience

### DIFF
--- a/docs/superpowers/plans/2026-07-01-unified-workbench-flow.md
+++ b/docs/superpowers/plans/2026-07-01-unified-workbench-flow.md
@@ -1,0 +1,101 @@
+# Unified Workbench Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a guided workbench overview that turns separate Phase 5 panels into one coherent autonomous ML workflow narrative.
+
+**Architecture:** Add pure `workbenchFlow` helpers that derive stage progress from existing session, message, tool-call, metrics, and recovery data. Add a `WorkbenchFlowPanel` that renders setup, data, research, runtime, monitoring, artifacts, evals, report, and publishing stages with jump links into existing panels plus an end-to-end walkthrough. Wire it into App without backend changes.
+
+**Tech Stack:** React, TypeScript, Vite, Vitest, Testing Library.
+
+---
+
+### Task 1: Flow summary helper
+
+**Files:**
+- Create: `frontend/src/workbenchFlow.ts`
+- Test: `frontend/src/workbenchFlow.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create tests for stage derivation from existing session/tool-call/recovery state: setup, data, research, runtime, monitor, artifacts, evals, and publishing.
+
+- [ ] **Step 2: Run focused helper test and verify RED**
+
+Run: `npm test -- workbenchFlow.test.ts`
+
+Expected: fail because `./workbenchFlow` does not exist.
+
+- [ ] **Step 3: Implement minimal helper**
+
+Create `buildWorkbenchFlowSummary` and exported stage types.
+
+- [ ] **Step 4: Run focused helper test and verify GREEN**
+
+Run: `npm test -- workbenchFlow.test.ts`
+
+Expected: pass.
+
+### Task 2: Guided workbench component
+
+**Files:**
+- Create: `frontend/src/components/WorkbenchFlowPanel.tsx`
+- Test: `frontend/src/components/WorkbenchFlowPanel.test.tsx`
+- Modify: `frontend/src/styles.css`
+
+- [ ] **Step 1: Write failing component test**
+
+Render the panel with Phase 5 fixture data and assert the workflow guide, resume state, stage links, and end-to-end walkthrough appear.
+
+- [ ] **Step 2: Run focused component test and verify RED**
+
+Run: `npm test -- WorkbenchFlowPanel.test.tsx`
+
+Expected: fail because `./WorkbenchFlowPanel` does not exist.
+
+- [ ] **Step 3: Implement component and styles**
+
+Render user-visible progress cards and walkthrough copy.
+
+- [ ] **Step 4: Run focused component test and verify GREEN**
+
+Run: `npm test -- WorkbenchFlowPanel.test.tsx`
+
+Expected: pass.
+
+### Task 3: App wiring and anchors
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: existing panel components only if a stable anchor id is missing.
+
+- [ ] **Step 1: Wire WorkbenchFlowPanel into inspector**
+
+Pass active session, messages, tool calls, and recovery snapshot into the panel.
+
+- [ ] **Step 2: Add missing stable anchor ids**
+
+Ensure the workflow guide can link to model controls, jobs, usage, runtime, artifacts, research, evals, publishing, and tool trace panels.
+
+- [ ] **Step 3: Run focused tests**
+
+Run: `npm test -- workbenchFlow.test.ts WorkbenchFlowPanel.test.tsx`
+
+Expected: pass.
+
+### Task 4: Full validation and publish
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-07-01-unified-workbench-flow.md`
+
+- [ ] **Step 1: Run validation**
+
+Run frontend tests/build, backend pytest/type/lint checks, pre-commit, audit, and whitespace check.
+
+- [ ] **Step 2: Commit and push scoped files**
+
+Stage only ML-412 files. Do not stage `.kiro/`, `ml_copilot.egg-info/`, or local workflow changes.
+
+- [ ] **Step 3: Open PR with public template**
+
+Use sections: `Summary`, `Testing`, `Notes`, `Referrence`, `Close #126`. Do not mention Notion or internal tracker URLs.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import {
 } from './sessionControls';
 import ToolTracePanel from './components/ToolTracePanel';
 import UsageMeterPanel from './components/UsageMeterPanel';
+import WorkbenchFlowPanel from './components/WorkbenchFlowPanel';
 import {
   buildRecoverySnapshot,
   deriveConnectionHealth,
@@ -547,6 +548,13 @@ function App() {
               pendingApprovals={pendingApprovals}
               resolving={resolvingApproval}
               onResolve={handleResolveApproval}
+            />
+
+            <WorkbenchFlowPanel
+              messages={messages}
+              recovery={recoverySnapshot}
+              session={activeSession}
+              toolCalls={toolCalls}
             />
 
             <SessionRecoveryPanel

--- a/frontend/src/components/JobProgressPanel.tsx
+++ b/frontend/src/components/JobProgressPanel.tsx
@@ -175,7 +175,7 @@ export default function JobProgressPanel({ toolCalls }: JobProgressPanelProps) {
   const activeCount = jobs.filter((job) => ACTIVE_STATUSES.has(job.status)).length;
 
   return (
-    <section className="job-progress-panel" aria-label="Hugging Face job progress">
+    <section className="job-progress-panel" id="job-progress" aria-label="Hugging Face job progress">
       <div className="job-progress-header">
         <div>
           <p className="panel-label">HF Jobs</p>

--- a/frontend/src/components/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar.tsx
@@ -140,7 +140,7 @@ export default function SessionSidebar({
             placeholder="Plan a dataset audit"
           />
         </label>
-        <section className="model-control-card" aria-label="Model and provider controls">
+        <section className="model-control-card" id="model-provider-controls" aria-label="Model and provider controls">
           <div>
             <p className="panel-label">Agent controls</p>
             <strong>Model and provider</strong>

--- a/frontend/src/components/ToolTracePanel.tsx
+++ b/frontend/src/components/ToolTracePanel.tsx
@@ -461,7 +461,7 @@ export default function ToolTracePanel({ liveEvents, pendingApprovals, metrics, 
   const recentEvents = liveEvents.slice(-6);
 
   return (
-    <div className="tool-trace-panel">
+    <div className="tool-trace-panel" id="tool-trace">
       <section className="tool-trace-card">
         <div className="tool-trace-header">
           <div>

--- a/frontend/src/components/UsageMeterPanel.tsx
+++ b/frontend/src/components/UsageMeterPanel.tsx
@@ -36,7 +36,7 @@ export default function UsageMeterPanel({ session, toolCalls }: UsageMeterPanelP
   );
 
   return (
-    <section className="usage-meter-panel" aria-label="Usage and cost estimate">
+    <section className="usage-meter-panel" id="usage-meter" aria-label="Usage and cost estimate">
       <div className="usage-meter-header">
         <div>
           <p className="panel-label">Usage</p>

--- a/frontend/src/components/WorkbenchFlowPanel.test.tsx
+++ b/frontend/src/components/WorkbenchFlowPanel.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import WorkbenchFlowPanel from './WorkbenchFlowPanel';
+import { phase5WorkbenchFixture } from '../test/workbenchFixtures';
+
+describe('WorkbenchFlowPanel', () => {
+  it('guides users through the full autonomous workflow with panel links and resume state', () => {
+    const fixture = phase5WorkbenchFixture();
+
+    render(
+      <WorkbenchFlowPanel
+        messages={fixture.messages}
+        recovery={fixture.recoverySnapshot}
+        session={fixture.activeSession}
+        toolCalls={fixture.toolCalls}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Autonomous workflow guide' });
+    expect(within(panel).getByText('8 / 8 stages complete')).toBeInTheDocument();
+    expect(within(panel).getByText('Recovered through event #9')).toBeInTheDocument();
+    expect(within(panel).getByText('Choose model and operating mode')).toBeInTheDocument();
+    expect(within(panel).getByText('Research papers, recipes, and Hub candidates')).toBeInTheDocument();
+    expect(within(panel).getByText('Generate final report and publish intentionally')).toBeInTheDocument();
+
+    expect(within(panel).getByRole('link', { name: 'Open Choose model and operating mode' })).toHaveAttribute('href', '#model-provider-controls');
+    expect(within(panel).getByRole('link', { name: 'Open Run sandbox or hosted jobs' })).toHaveAttribute('href', '#runtime-details');
+    expect(within(panel).getByRole('link', { name: 'Open Run evals and check release gates' })).toHaveAttribute('href', '#eval-dashboard');
+    expect(within(panel).getByRole('link', { name: 'Open Generate final report and publish intentionally' })).toHaveAttribute('href', '#publishing-panel');
+
+    const walkthrough = within(panel).getByRole('list', { name: 'End-to-end walkthrough' });
+    expect(within(walkthrough).getAllByRole('listitem')).toHaveLength(8);
+    expect(within(walkthrough).getByText(/Choose provider/)).toBeInTheDocument();
+    expect(within(walkthrough).getByText(/Generate the final report/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/WorkbenchFlowPanel.tsx
+++ b/frontend/src/components/WorkbenchFlowPanel.tsx
@@ -1,0 +1,64 @@
+import { buildWorkbenchFlowSummary } from '../workbenchFlow';
+import type { MessagePayload, SessionDetail, ToolCallPayload } from '../types';
+import type { RecoverySnapshot } from '../workbenchState';
+
+interface WorkbenchFlowPanelProps {
+  session: SessionDetail | null;
+  messages: MessagePayload[];
+  toolCalls: ToolCallPayload[];
+  recovery: RecoverySnapshot | null;
+}
+
+function statusTone(status: string) {
+  if (status === 'complete') return 'success';
+  if (status === 'active') return 'warning';
+  return 'neutral';
+}
+
+export default function WorkbenchFlowPanel({ session, messages, toolCalls, recovery }: WorkbenchFlowPanelProps) {
+  const summary = buildWorkbenchFlowSummary({ session, messages, toolCalls, recovery });
+
+  return (
+    <section className="workbench-flow-panel" aria-label="Autonomous workflow guide">
+      <div className="runtime-detail-header">
+        <div>
+          <p className="panel-label">Workflow</p>
+          <h3>Autonomous workflow guide</h3>
+          <p className="muted">A single path through setup, data, research, runtime, evals, reports, and publishing.</p>
+        </div>
+        <div className="workbench-flow-summary">
+          <span className="status-chip success">
+            {summary.completedCount} / {summary.totalCount} stages complete
+          </span>
+          <span className="status-chip neutral">{summary.resumeLabel}</span>
+        </div>
+      </div>
+
+      <div className="workbench-stage-grid">
+        {summary.stages.map((stage, index) => (
+          <article className={`workbench-stage-card ${stage.status}`} key={stage.id}>
+            <div className="workbench-stage-head">
+              <span className={`status-chip ${statusTone(stage.status)}`}>{stage.status}</span>
+              <span className="workbench-stage-number">{index + 1}</span>
+            </div>
+            <h4>{stage.title}</h4>
+            <p>{stage.summary}</p>
+            {stage.evidence.length ? (
+              <div className="workbench-stage-evidence">
+                {stage.evidence.slice(0, 2).map((item) => <code key={item}>{item}</code>)}
+              </div>
+            ) : null}
+            <a href={stage.href}>Open {stage.title}</a>
+          </article>
+        ))}
+      </div>
+
+      <div className="workbench-walkthrough">
+        <h4>End-to-end walkthrough</h4>
+        <ol aria-label="End-to-end walkthrough">
+          {summary.walkthrough.map((step) => <li key={step}>{step}</li>)}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2091,6 +2091,110 @@ button {
   background: rgba(148, 163, 184, 0.08);
 }
 
+.workbench-flow-panel {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 1rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.66));
+}
+
+.workbench-flow-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.workbench-stage-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.workbench-stage-card {
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.workbench-stage-card.complete {
+  border-color: rgba(74, 222, 128, 0.3);
+}
+
+.workbench-stage-card.active {
+  border-color: rgba(251, 191, 36, 0.42);
+}
+
+.workbench-stage-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.workbench-stage-number {
+  display: inline-grid;
+  place-items: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.workbench-stage-card h4 {
+  margin: 0.65rem 0 0.35rem;
+}
+
+.workbench-stage-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.workbench-stage-card a {
+  display: inline-block;
+  margin-top: 0.65rem;
+}
+
+.workbench-stage-evidence {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.65rem;
+}
+
+.workbench-stage-evidence code {
+  border: 1px solid rgba(96, 165, 250, 0.2);
+  border-radius: 999px;
+  padding: 0.25rem 0.45rem;
+  background: rgba(30, 64, 175, 0.15);
+  color: #dbeafe;
+  font-size: 0.72rem;
+}
+
+.workbench-walkthrough {
+  border-top: 1px solid var(--border);
+  padding-top: 0.85rem;
+}
+
+.workbench-walkthrough h4 {
+  margin: 0 0 0.5rem;
+}
+
+.workbench-walkthrough ol {
+  margin: 0;
+  padding-left: 1.3rem;
+  color: var(--muted);
+}
+
+.workbench-walkthrough li + li {
+  margin-top: 0.35rem;
+}
+
 .muted {
   color: var(--muted);
 }

--- a/frontend/src/workbenchFlow.test.ts
+++ b/frontend/src/workbenchFlow.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildWorkbenchFlowSummary } from './workbenchFlow';
+import type { RecoverySnapshot } from './workbenchState';
+import type { MessagePayload, SessionDetail, ToolCallPayload } from './types';
+
+function metrics() {
+  return {
+    session_id: 'session-1',
+    turn_count: 3,
+    prompt_tokens: 1000,
+    completion_tokens: 700,
+    total_tokens: 1700,
+    estimated_cost_usd: 0.034,
+    tool_calls: 7,
+    tool_errors: 0,
+    tool_retries: 1,
+    tool_latency_ms: 45000,
+    average_tool_latency_ms: 6428,
+    error_count: 0,
+    last_updated_at: '2026-07-01T06:10:00Z',
+  };
+}
+
+function toolCall(overrides: Partial<ToolCallPayload>): ToolCallPayload {
+  return {
+    id: 'call-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    tool_name: 'manage_job',
+    arguments: {},
+    status: 'success',
+    requires_approval: false,
+    approval_id: null,
+    started_at: '2026-07-01T06:00:00Z',
+    finished_at: '2026-07-01T06:01:00Z',
+    output: null,
+    success: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+function session(toolCalls: ToolCallPayload[]): SessionDetail {
+  return {
+    id: 'session-1',
+    title: 'Autonomous workflow',
+    status: 'running',
+    model: 'zai-org/GLM-5.2:novita',
+    metadata: { agent_controls: { provider: 'zai', reasoning_effort: 'high' } },
+    created_at: '2026-07-01T06:00:00Z',
+    updated_at: '2026-07-01T06:10:00Z',
+    message_count: 2,
+    event_count: 12,
+    pending_approval_count: 0,
+    metrics: metrics(),
+    pending_approvals: [],
+    tool_calls: toolCalls,
+  };
+}
+
+function message(overrides: Partial<MessagePayload> = {}): MessagePayload {
+  return {
+    id: 'message-1',
+    session_id: 'session-1',
+    turn_id: 'turn-1',
+    role: 'assistant',
+    content: 'Ready.',
+    tool_call_id: null,
+    name: null,
+    raw: {},
+    sequence: 1,
+    created_at: '2026-07-01T06:00:00Z',
+    ...overrides,
+  };
+}
+
+const recovery: RecoverySnapshot = {
+  sessionId: 'session-1',
+  sessionTitle: 'Autonomous workflow',
+  messageCount: 2,
+  toolCallCount: 7,
+  liveEventCount: 2,
+  persistedEventCount: 12,
+  lastEventSequence: 11,
+  replayedEventCount: 2,
+  duplicateEventCount: 1,
+  recoveredAt: '2026-07-01T06:10:00Z',
+  status: 'recovered',
+};
+
+describe('buildWorkbenchFlowSummary', () => {
+  it('derives an end-to-end autonomous workflow from existing session state', () => {
+    const toolCalls = [
+      toolCall({ id: 'dataset', tool_name: 'inspect_dataset', arguments: { dataset: 'imdb' }, output: 'Dataset imdb has train/test splits.' }),
+      toolCall({ id: 'paper', tool_name: 'paper_details', arguments: { arxiv_id: '2401.12345' }, output: '# Efficient Fine-Tuning' }),
+      toolCall({ id: 'sandbox', tool_name: 'experiment_workspace', arguments: { operation: 'run', command: 'python train.py' }, output: 'Wrote src/train.py' }),
+      toolCall({ id: 'job', tool_name: 'manage_job', arguments: { operation: 'run', hardware_flavor: 'cpu-basic' }, output: 'Status: RUNNING' }),
+      toolCall({ id: 'eval', tool_name: 'manage_eval_suite', arguments: { operation: 'run' }, output: 'Suite report: {"status":"passed"}' }),
+      toolCall({ id: 'publish', tool_name: 'publish_model_report', arguments: { repo_id: 'owner/model-a' }, output: 'Prepared README.md and FINAL_REPORT.md' }),
+    ];
+
+    const summary = buildWorkbenchFlowSummary({
+      session: session(toolCalls),
+      messages: [message({ role: 'user', content: 'Train a model.' }), message()],
+      toolCalls,
+      recovery,
+    });
+
+    expect(summary.completedCount).toBe(8);
+    expect(summary.resumeLabel).toBe('Recovered through event #11');
+    expect(summary.stages.map((stage) => stage.id)).toEqual([
+      'setup',
+      'data',
+      'research',
+      'runtime',
+      'monitor',
+      'artifacts',
+      'evals',
+      'publish',
+    ]);
+    expect(summary.stages.every((stage) => stage.status === 'complete')).toBe(true);
+    expect(summary.stages.find((stage) => stage.id === 'setup')?.href).toBe('#model-provider-controls');
+    expect(summary.stages.find((stage) => stage.id === 'runtime')?.href).toBe('#runtime-details');
+    expect(summary.stages.find((stage) => stage.id === 'evals')?.href).toBe('#eval-dashboard');
+    expect(summary.walkthrough).toHaveLength(8);
+    expect(summary.walkthrough[0]).toContain('Choose provider');
+  });
+
+  it('marks the first missing stage as active so users know where to continue', () => {
+    const summary = buildWorkbenchFlowSummary({
+      session: session([]),
+      messages: [message()],
+      toolCalls: [],
+      recovery: null,
+    });
+
+    expect(summary.completedCount).toBe(1);
+    expect(summary.stages.find((stage) => stage.id === 'setup')?.status).toBe('complete');
+    expect(summary.stages.find((stage) => stage.id === 'data')?.status).toBe('active');
+    expect(summary.stages.find((stage) => stage.id === 'research')?.status).toBe('waiting');
+    expect(summary.resumeLabel).toBe('No recovery snapshot yet');
+  });
+});

--- a/frontend/src/workbenchFlow.ts
+++ b/frontend/src/workbenchFlow.ts
@@ -1,0 +1,171 @@
+import type { MessagePayload, SessionDetail, ToolCallPayload } from './types';
+import type { RecoverySnapshot } from './workbenchState';
+
+export type WorkbenchStageId = 'setup' | 'data' | 'research' | 'runtime' | 'monitor' | 'artifacts' | 'evals' | 'publish';
+export type WorkbenchStageStatus = 'complete' | 'active' | 'waiting';
+
+export interface WorkbenchStage {
+  id: WorkbenchStageId;
+  title: string;
+  summary: string;
+  status: WorkbenchStageStatus;
+  href: string;
+  evidence: string[];
+}
+
+export interface WorkbenchFlowSummary {
+  completedCount: number;
+  totalCount: number;
+  resumeLabel: string;
+  stages: WorkbenchStage[];
+  walkthrough: string[];
+}
+
+interface WorkbenchFlowInput {
+  session: SessionDetail | null;
+  messages: MessagePayload[];
+  toolCalls: ToolCallPayload[];
+  recovery: RecoverySnapshot | null;
+}
+
+function textForCall(call: ToolCallPayload) {
+  return `${call.tool_name} ${JSON.stringify(call.arguments)} ${call.output ?? ''} ${call.error ?? ''}`.toLowerCase();
+}
+
+function hasTool(toolCalls: ToolCallPayload[], names: string[]) {
+  return toolCalls.some((call) => names.includes(call.tool_name));
+}
+
+function evidenceFor(toolCalls: ToolCallPayload[], predicate: (call: ToolCallPayload) => boolean, fallback: string) {
+  const match = toolCalls.find(predicate);
+  if (!match) return [];
+  return [match.tool_name, match.id || fallback].filter(Boolean);
+}
+
+function statusFor(completed: boolean, priorComplete: boolean): WorkbenchStageStatus {
+  if (completed) return 'complete';
+  return priorComplete ? 'active' : 'waiting';
+}
+
+export function buildWorkbenchFlowSummary({ session, messages, toolCalls, recovery }: WorkbenchFlowInput): WorkbenchFlowSummary {
+  const setupComplete = Boolean(session?.model || session?.metadata.agent_controls);
+  const dataComplete = toolCalls.some((call) => {
+    const text = textForCall(call);
+    return ['inspect_dataset', 'hf_inspect_dataset'].includes(call.tool_name)
+      || text.includes('dataset')
+      || text.includes('.csv')
+      || text.includes('data/');
+  });
+  const researchComplete = hasTool(toolCalls, [
+    'paper_details',
+    'paper_citation_graph',
+    'read_paper',
+    'extract_training_recipe',
+    'hf_papers',
+    'search_hub',
+    'hf_search_hub',
+  ]);
+  const runtimeComplete = hasTool(toolCalls, ['experiment_workspace', 'manage_job']);
+  const monitorComplete = Boolean(recovery || toolCalls.length > 0);
+  const artifactsComplete = toolCalls.some((call) => {
+    const text = textForCall(call);
+    return text.includes('readme.md')
+      || text.includes('final_report.md')
+      || text.includes('manifest')
+      || text.includes('wrote ')
+      || text.includes('.ml-copilot/');
+  });
+  const evalsComplete = hasTool(toolCalls, ['manage_eval_suite']);
+  const publishComplete = hasTool(toolCalls, ['publish_model_report']);
+
+  const definitions = [
+    {
+      id: 'setup' as const,
+      title: 'Choose model and operating mode',
+      summary: session?.model ? `Session is configured for ${session.model}.` : 'Pick provider, model, effort, and safety preferences.',
+      href: '#model-provider-controls',
+      completed: setupComplete,
+      evidence: session?.model ? [session.model] : [],
+    },
+    {
+      id: 'data' as const,
+      title: 'Ingest or inspect data',
+      summary: 'Bring datasets, previews, and generated files into the workbench context.',
+      href: '#artifact-browser',
+      completed: dataComplete,
+      evidence: evidenceFor(toolCalls, (call) => textForCall(call).includes('dataset'), 'dataset'),
+    },
+    {
+      id: 'research' as const,
+      title: 'Research papers, recipes, and Hub candidates',
+      summary: 'Connect papers, recipes, datasets, and models to decisions.',
+      href: '#research-trail',
+      completed: researchComplete,
+      evidence: evidenceFor(toolCalls, (call) => ['paper_details', 'extract_training_recipe', 'search_hub'].includes(call.tool_name), 'research'),
+    },
+    {
+      id: 'runtime' as const,
+      title: 'Run sandbox or hosted jobs',
+      summary: 'Launch code, monitor jobs, and inspect runtime logs.',
+      href: '#runtime-details',
+      completed: runtimeComplete,
+      evidence: evidenceFor(toolCalls, (call) => ['experiment_workspace', 'manage_job'].includes(call.tool_name), 'runtime'),
+    },
+    {
+      id: 'monitor' as const,
+      title: 'Monitor usage, traces, and recovery',
+      summary: recovery ? `Recovered ${recovery.toolCallCount} tool calls and ${recovery.messageCount} messages.` : 'Watch tool traces, cost estimates, and session recovery state.',
+      href: '#tool-trace',
+      completed: monitorComplete,
+      evidence: recovery ? [`event #${recovery.lastEventSequence}`] : [],
+    },
+    {
+      id: 'artifacts' as const,
+      title: 'Inspect files and artifacts',
+      summary: 'Open generated datasets, reports, manifests, and sandbox outputs.',
+      href: '#artifact-browser',
+      completed: artifactsComplete,
+      evidence: evidenceFor(toolCalls, (call) => textForCall(call).includes('readme.md') || textForCall(call).includes('wrote '), 'artifact'),
+    },
+    {
+      id: 'evals' as const,
+      title: 'Run evals and check release gates',
+      summary: 'Review fixture results, failures, changed files, and gate status.',
+      href: '#eval-dashboard',
+      completed: evalsComplete,
+      evidence: evidenceFor(toolCalls, (call) => call.tool_name === 'manage_eval_suite', 'eval'),
+    },
+    {
+      id: 'publish' as const,
+      title: 'Generate final report and publish intentionally',
+      summary: 'Preview model cards, final reports, manifests, provenance, and publish state.',
+      href: '#publishing-panel',
+      completed: publishComplete,
+      evidence: evidenceFor(toolCalls, (call) => call.tool_name === 'publish_model_report', 'publish'),
+    },
+  ];
+
+  let priorComplete = true;
+  const stages = definitions.map((definition) => {
+    const status = statusFor(definition.completed, priorComplete);
+    priorComplete = priorComplete && definition.completed;
+    return { ...definition, status };
+  });
+
+  return {
+    completedCount: stages.filter((stage) => stage.status === 'complete').length,
+    totalCount: stages.length,
+    resumeLabel: recovery ? `Recovered through event #${recovery.lastEventSequence}` : 'No recovery snapshot yet',
+    stages,
+    walkthrough: [
+      'Choose provider, model, effort, and safety controls before starting the run.',
+      'Attach or inspect data so the agent has concrete inputs.',
+      'Research papers, training recipes, datasets, and model candidates.',
+      'Launch sandbox commands or hosted jobs and monitor runtime state.',
+      'Use traces, usage estimates, and recovery state to understand progress after refresh.',
+      'Inspect generated files, reports, manifests, and sandbox outputs.',
+      'Run evals and resolve release-gate failures before publishing.',
+      'Generate the final report and publish only after reviewing provenance and token state.',
+    ],
+  };
+}


### PR DESCRIPTION
Summary
- Adds a unified autonomous workflow guide that connects setup, data, research, runtime, monitoring, artifacts, evals, and publishing into one end-to-end workbench narrative.
- Derives workflow stage progress from existing session, message, tool-call, metrics, and recovery data without adding backend APIs.
- Adds stable jump links from each workflow stage into the relevant existing panels and includes an in-UI end-to-end walkthrough for resumed sessions.

Testing
- `npm test` from `frontend/` - 21 files / 29 tests passed
- `npm run build` from `frontend/`
- `python -m pytest tests/ -q` - 246 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `ruff check app/ tests/`
- `ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`
- `npm audit --omit=dev` from `frontend/`

Notes
- Frontend-first slice only; no backend API changes.
- Existing Phase 5 panels remain in place and the new guide links into them.
- The walkthrough is rendered in the UI so resumed workflows remain understandable after refresh.

Referrence
- Autonomous workflow workbench convergence follow-up for the Phase 5 UI.

Close #126
