### PR TITLE
ML-500 / Add autonomous workflow template and preflight planner

### DIFF
--- a/app/agent/loop.py
+++ b/app/agent/loop.py
@@ -941,6 +941,7 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
         repo_analyzer,
         reporting,
         sandbox,
+        workflow_templates,
         workspace,
     )
 
@@ -1045,6 +1046,15 @@ def _create_tool_registry(settings: AppSettings) -> ToolRegistry:
             description=spec["description"],
             input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
             handler=_make_repo_analyzer_handler(settings),
+        )
+        registry.register(tool_spec)
+
+    for spec in workflow_templates.get_tool_specs():
+        tool_spec = ToolSpec(
+            name=spec["name"],
+            description=spec["description"],
+            input_schema=spec.get("parameters", {"type": "object", "properties": {}}),
+            handler=_make_workflow_template_handler(settings),
         )
         registry.register(tool_spec)
 
@@ -1180,6 +1190,16 @@ def _make_repo_analyzer_handler(settings: AppSettings) -> ToolHandler:
 
     async def _handler(args: dict[str, Any]) -> str:
         return await repo_analyzer.analyze_ml_repo_handler(args, settings)
+
+    return _handler
+
+
+def _make_workflow_template_handler(settings: AppSettings) -> ToolHandler:
+    """Create a handler for autonomous workflow template planning."""
+    from app.tools import workflow_templates
+
+    async def _handler(args: dict[str, Any]) -> str:
+        return await workflow_templates.plan_autonomous_workflow_handler(args, settings)
 
     return _handler
 

--- a/app/tools/workflow_templates.py
+++ b/app/tools/workflow_templates.py
@@ -1,0 +1,348 @@
+"""Autonomous workflow template and preflight planning tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.config import AppSettings
+
+
+@dataclass(frozen=True)
+class WorkflowTemplate:
+    key: str
+    title: str
+    required_inputs: tuple[str, ...]
+    stages: tuple[tuple[str, tuple[str, ...], str], ...]
+    expected_artifacts: tuple[str, ...]
+    risks: tuple[str, ...]
+
+
+TEMPLATES: dict[str, WorkflowTemplate] = {
+    "tabular_classification": WorkflowTemplate(
+        key="tabular_classification",
+        title="Tabular classification",
+        required_inputs=("dataset", "target_column"),
+        stages=(
+            (
+                "Scope and data readiness",
+                ("inspect_dataset", "ingest_dataset"),
+                "Validate the tabular source, target column, schema, label balance, and leakage risks.",
+            ),
+            (
+                "Research and baseline selection",
+                ("search_hub", "search_docs", "paper_details"),
+                "Find comparable datasets/models and choose a simple baseline before heavier training.",
+            ),
+            (
+                "Sandbox training loop",
+                ("experiment_workspace", "manage_experiment_loop"),
+                "Run local or sandbox smoke experiments, diagnose failures, and iterate toward the target metric.",
+            ),
+            (
+                "Evaluation gate",
+                ("manage_experiment_loop", "git_report"),
+                "Compare validation metrics against the requested target and capture reproducibility evidence.",
+            ),
+            (
+                "Report and publish-ready assets",
+                ("publish_model_report",),
+                "Prepare a model card, final report, manifest, limitations, and follow-up recommendations.",
+            ),
+        ),
+        expected_artifacts=(
+            "dataset profile",
+            "baseline metrics",
+            "training command history",
+            "evaluation summary",
+            "model card and final report",
+        ),
+        risks=(
+            "target leakage or unstable validation split",
+            "class imbalance",
+            "metric target not aligned with business objective",
+        ),
+    ),
+    "text_classification": WorkflowTemplate(
+        key="text_classification",
+        title="Text classification",
+        required_inputs=("dataset", "text_column", "label_column"),
+        stages=(
+            (
+                "Scope and data readiness",
+                ("inspect_dataset", "ingest_dataset"),
+                "Validate text and label columns, empty text rates, label balance, and train/validation split.",
+            ),
+            (
+                "Research and recipe extraction",
+                ("search_hub", "paper_details", "paper_citation_graph", "extract_training_recipe"),
+                "Identify candidate base models, papers, and training recipes for the task size.",
+            ),
+            (
+                "Sandbox fine-tuning loop",
+                ("experiment_workspace", "manage_experiment_loop"),
+                "Run a bounded smoke fine-tune, classify failures, and choose the next safest iteration.",
+            ),
+            (
+                "Evaluation gate",
+                ("manage_experiment_loop", "read_file"),
+                "Check target metrics, inspect errors, and capture validation evidence before publishing.",
+            ),
+            (
+                "Report and publish-ready assets",
+                ("publish_model_report",),
+                "Prepare a model card, final report, manifest, limitations, and recommended next steps.",
+            ),
+        ),
+        expected_artifacts=(
+            "dataset profile",
+            "candidate model shortlist",
+            "training recipe notes",
+            "fine-tune/eval logs",
+            "model card and final report",
+        ),
+        risks=(
+            "private or sensitive text in examples",
+            "label noise",
+            "base-model/license mismatch",
+        ),
+    ),
+    "image_classification": WorkflowTemplate(
+        key="image_classification",
+        title="Image classification",
+        required_inputs=("dataset", "label_column"),
+        stages=(
+            (
+                "Scope and data readiness",
+                ("inspect_dataset", "ingest_dataset"),
+                "Validate image paths, labels, split structure, corrupt files, and class balance.",
+            ),
+            (
+                "Research and baseline selection",
+                ("search_hub", "paper_details", "search_docs"),
+                "Choose a lightweight vision baseline and training recipe before remote acceleration.",
+            ),
+            (
+                "Sandbox training loop",
+                ("experiment_workspace", "manage_experiment_loop"),
+                "Run preprocessing and a small training/eval smoke loop before scaling.",
+            ),
+            (
+                "Remote job escalation",
+                ("manage_job", "manage_experiment_loop"),
+                "Escalate only when local smoke checks pass and credentials/quota are available.",
+            ),
+            (
+                "Report and publish-ready assets",
+                ("publish_model_report",),
+                "Prepare model documentation, sample predictions, limitations, and release notes.",
+            ),
+        ),
+        expected_artifacts=(
+            "dataset integrity report",
+            "baseline metrics",
+            "training logs",
+            "sample predictions",
+            "model card and final report",
+        ),
+        risks=(
+            "large files or corrupt images",
+            "GPU memory pressure",
+            "train/validation data leakage through near-duplicates",
+        ),
+    ),
+    "custom_experiment": WorkflowTemplate(
+        key="custom_experiment",
+        title="Custom ML experiment",
+        required_inputs=("objective",),
+        stages=(
+            (
+                "Clarify objective and assets",
+                ("git_report", "list_files", "search_text"),
+                "Inventory existing code/data and convert the objective into measurable acceptance criteria.",
+            ),
+            (
+                "Research and environment setup",
+                ("search_docs", "paper_details", "experiment_workspace"),
+                "Identify reference implementation details and prepare a safe sandbox workspace.",
+            ),
+            (
+                "Experiment loop",
+                ("manage_experiment_loop", "run_command"),
+                "Run bounded experiments, classify failures, and stop on target, budget, or max attempts.",
+            ),
+            (
+                "Evaluation and reporting",
+                ("git_report", "publish_model_report"),
+                "Capture changed files, metrics, limitations, and publish-ready documentation.",
+            ),
+        ),
+        expected_artifacts=(
+            "objective checklist",
+            "workspace inventory",
+            "experiment history",
+            "evaluation notes",
+            "final report",
+        ),
+        risks=(
+            "unclear metric target",
+            "missing dataset or baseline",
+            "unbounded runtime without explicit constraints",
+        ),
+    ),
+}
+
+
+def get_tool_specs() -> list[dict[str, Any]]:
+    """Return tool specs for autonomous workflow planning."""
+    return [
+        {
+            "name": "plan_autonomous_workflow",
+            "description": (
+                "Choose an ML workflow template and return a deterministic preflight plan with stages, "
+                "required inputs, recommended tools, risks, and expected artifacts before long autonomous runs."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "objective": {
+                        "type": "string",
+                        "description": "User-facing ML objective or project goal.",
+                    },
+                    "template": {
+                        "type": "string",
+                        "enum": [
+                            "auto",
+                            "tabular_classification",
+                            "text_classification",
+                            "image_classification",
+                            "custom_experiment",
+                        ],
+                        "description": "Workflow template to use; auto selects from the objective.",
+                    },
+                    "available_inputs": {
+                        "type": "object",
+                        "description": (
+                            "Known inputs and capabilities such as dataset, target_column, text_column, "
+                            "label_column, target_metric, provider_api_key, hf_token, repo_id, or eval_fixture."
+                        ),
+                    },
+                    "constraints": {
+                        "type": "object",
+                        "description": "Run constraints such as allow_remote_jobs, max_cost_usd, max_runtime_minutes.",
+                    },
+                },
+                "required": ["objective"],
+            },
+        }
+    ]
+
+
+async def plan_autonomous_workflow_handler(args: dict[str, Any], settings: AppSettings) -> str:
+    """Return a deterministic workflow plan and readiness checklist."""
+    del settings
+    objective = str(args.get("objective") or "").strip()
+    if not objective:
+        return "Error: objective is required."
+
+    available_inputs = _dict_arg(args.get("available_inputs"))
+    constraints = _dict_arg(args.get("constraints"))
+    template_key = _resolve_template(str(args.get("template") or "auto"), objective)
+    template = TEMPLATES.get(template_key)
+    if template is None:
+        known = ", ".join(["auto", *TEMPLATES])
+        return f"Error: Unknown workflow template {template_key!r}. Known templates: {known}."
+
+    readiness = _readiness_lines(template, available_inputs, constraints)
+
+    lines = [
+        f"# Autonomous workflow plan: {template.key}",
+        "",
+        f"Objective: {objective}",
+        f"Template: {template.title}",
+        "",
+        "## Readiness",
+        *readiness,
+        "",
+        "## Stages",
+    ]
+
+    for index, (stage_name, tools, description) in enumerate(template.stages, start=1):
+        lines.append(f"{index}. {stage_name}")
+        lines.append(f"   - Recommended tools: {', '.join(tools)}")
+        lines.append(f"   - Plan: {description}")
+
+    lines.extend(["", "## Expected artifacts"])
+    lines.extend(f"- {artifact}" for artifact in template.expected_artifacts)
+    lines.extend(["", "## Key risks"])
+    lines.extend(f"- {risk}" for risk in template.risks)
+
+    return "\n".join(lines)
+
+
+def _dict_arg(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _resolve_template(requested: str, objective: str) -> str:
+    requested = requested.strip() or "auto"
+    if requested != "auto":
+        return requested
+
+    lowered = objective.lower()
+    if any(token in lowered for token in ("text", "sentiment", "ticket", "review", "classification")):
+        return "text_classification"
+    if any(token in lowered for token in ("image", "vision", "photo", "picture")):
+        return "image_classification"
+    if any(token in lowered for token in ("tabular", "csv", "churn", "account", "row", "rows", "customer")):
+        return "tabular_classification"
+    return "custom_experiment"
+
+
+def _has_input(available_inputs: dict[str, Any], key: str) -> bool:
+    value = available_inputs.get(key)
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value)
+
+
+def _readiness_lines(
+    template: WorkflowTemplate,
+    available_inputs: dict[str, Any],
+    constraints: dict[str, Any],
+) -> list[str]:
+    lines: list[str] = []
+
+    for required in template.required_inputs:
+        if required == "objective":
+            continue
+        if _has_input(available_inputs, required):
+            lines.append(f"- Ready: {required.replace('_', ' ').title()} is available.")
+        elif required == "dataset":
+            lines.append("- Blocker: Dataset path, upload, or Hub dataset id is required.")
+        else:
+            lines.append(f"- Blocker: {required.replace('_', ' ').title()} is required.")
+
+    if _has_input(available_inputs, "target_metric"):
+        lines.append(f"- Ready: Target metric is defined as {available_inputs['target_metric']}.")
+    else:
+        lines.append("- Warning: Target metric is not defined; add one before evaluating release readiness.")
+
+    if not _has_input(available_inputs, "provider_api_key"):
+        lines.append(
+            "- Warning: Provider API key is missing; planning is still available but LLM-assisted research may be "
+            "limited."
+        )
+
+    if not _has_input(available_inputs, "hf_token"):
+        lines.append("- Blocker: Hugging Face token is not available for remote jobs or publishing.")
+
+    if constraints.get("allow_remote_jobs") is False:
+        lines.append("- Remote jobs disabled by constraints; prefer sandbox/local smoke runs first.")
+
+    if "max_cost_usd" in constraints:
+        lines.append(f"- Constraint: Maximum expected spend is ${float(constraints['max_cost_usd']):g}.")
+    if "max_runtime_minutes" in constraints:
+        lines.append(f"- Constraint: Maximum runtime is {float(constraints['max_runtime_minutes']):g} minutes.")
+
+    return lines or ["- Ready: No blocking preflight requirements were detected."]

--- a/docs/phase-6-autonomous-workflow-planner.md
+++ b/docs/phase-6-autonomous-workflow-planner.md
@@ -1,0 +1,42 @@
+# Phase 6 Autonomous Workflow Planner
+
+ML-500 adds `plan_autonomous_workflow`, a deterministic planning tool that helps the agent turn a user objective into a safe, inspectable ML workflow before long-running jobs begin.
+
+The planner currently supports these templates:
+
+- `tabular_classification`
+- `text_classification`
+- `image_classification`
+- `custom_experiment`
+- `auto`, which selects one of the templates from the objective text
+
+Each plan includes:
+
+- readiness checks for required inputs and credentials
+- recommended ML Copilot tools for each stage
+- expected artifacts
+- key risks to resolve before release or publishing
+- run constraints such as remote-job availability, maximum spend, or maximum runtime
+
+The planner is intentionally dry-run friendly. It does not call external services, upload files, launch jobs, or persist secrets.
+
+Example:
+
+```json
+{
+  "objective": "Fine tune a sentiment classifier for support tickets.",
+  "template": "text_classification",
+  "available_inputs": {
+    "dataset": "data/support_tickets.csv",
+    "text_column": "ticket_text",
+    "label_column": "sentiment",
+    "target_metric": "f1 >= 0.85",
+    "provider_api_key": true,
+    "hf_token": false
+  },
+  "constraints": {
+    "allow_remote_jobs": false,
+    "max_cost_usd": 5
+  }
+}
+```

--- a/docs/superpowers/plans/2026-07-01-autonomous-workflow-template-planner.md
+++ b/docs/superpowers/plans/2026-07-01-autonomous-workflow-template-planner.md
@@ -1,0 +1,67 @@
+# Autonomous Workflow Template Planner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic autonomous workflow template and preflight planner so the agent can turn a user ML objective into a safe, inspectable run plan before long jobs begin.
+
+**Architecture:** Add a focused backend tool module that owns workflow template definitions and readiness rendering. Wire the tool into the existing `AgentLoop` tool registry using the same pattern as publishing, jobs, experiments, and repository analysis tools. Cover the contract with unit tests before implementation.
+
+**Tech Stack:** Python, pytest, existing `ToolRegistry`, existing `AppSettings` test helpers.
+
+---
+
+### Task 1: Planner contract tests
+
+**Files:**
+- Create: `tests/unit/test_workflow_templates.py`
+
+- [x] **Step 1: Write the failing tests**
+
+Define tests that import `app.tools.workflow_templates`, assert the `plan_autonomous_workflow` schema, exercise a deterministic text-classification plan, check auto-selection for a tabular churn objective, reject an unknown template, and verify registry inclusion.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_workflow_templates.py -q`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.tools.workflow_templates'`.
+
+### Task 2: Planner implementation
+
+**Files:**
+- Create: `app/tools/workflow_templates.py`
+- Modify: `app/agent/loop.py`
+
+- [x] **Step 1: Add template definitions**
+
+Create `WorkflowTemplate` records for `tabular_classification`, `text_classification`, `image_classification`, and `custom_experiment`, each with required inputs, stages, recommended tools, expected artifacts, and risks.
+
+- [x] **Step 2: Add tool spec and handler**
+
+Expose `plan_autonomous_workflow` with `objective`, `template`, `available_inputs`, and `constraints`. Return deterministic Markdown with readiness, stages, expected artifacts, and key risks.
+
+- [x] **Step 3: Wire registry**
+
+Import `workflow_templates` in `_create_tool_registry`, register its spec, and add `_make_workflow_template_handler`.
+
+- [x] **Step 4: Run focused tests**
+
+Run: `python -m pytest tests/unit/test_workflow_templates.py -q`
+
+Expected: PASS with `5 passed`.
+
+### Task 3: Validation and PR
+
+**Files:**
+- Modify as needed based on validation.
+
+- [x] **Step 1: Run backend validation**
+
+Run focused tests, full backend tests, Ruff check/format, mypy, pre-commit, and diff whitespace checks.
+
+- [ ] **Step 2: Commit and push**
+
+Stage only ML-500 files, commit with `feat: add autonomous workflow planner`, and push `feature/ML-500-workflow-template-planner`.
+
+- [ ] **Step 3: Open PR**
+
+Use the requested public PR template with `Summary`, `Testing`, `Notes`, `Referrence`, and `Close #128`. Do not mention internal tracker URLs.

--- a/tests/unit/test_workflow_templates.py
+++ b/tests/unit/test_workflow_templates.py
@@ -1,0 +1,101 @@
+"""Tests for autonomous workflow template and preflight planning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.agent.loop import _create_tool_registry
+from app.config import AppPaths, AppSettings
+from app.tools.workflow_templates import get_tool_specs, plan_autonomous_workflow_handler
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings.from_paths(AppPaths.from_workspace_root(tmp_path))
+
+
+def test_get_tool_specs_exposes_planner_schema() -> None:
+    specs = get_tool_specs()
+
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec["name"] == "plan_autonomous_workflow"
+    props = spec["parameters"]["properties"]
+    assert "objective" in props
+    assert "template" in props
+    assert "available_inputs" in props
+    assert "constraints" in props
+
+
+@pytest.mark.asyncio
+async def test_planner_returns_deterministic_text_classification_plan(tmp_path: Path) -> None:
+    result = await plan_autonomous_workflow_handler(
+        {
+            "objective": "Fine tune a sentiment classifier for support tickets.",
+            "template": "text_classification",
+            "available_inputs": {
+                "dataset": "data/support_tickets.csv",
+                "text_column": "ticket_text",
+                "label_column": "sentiment",
+                "target_metric": "f1 >= 0.85",
+                "provider_api_key": True,
+                "hf_token": False,
+            },
+            "constraints": {
+                "allow_remote_jobs": False,
+                "max_cost_usd": 5,
+            },
+        },
+        _settings(tmp_path),
+    )
+
+    assert "Autonomous workflow plan: text_classification" in result
+    assert "Fine tune a sentiment classifier for support tickets." in result
+    assert "inspect_dataset" in result
+    assert "paper_details" in result
+    assert "experiment_workspace" in result
+    assert "manage_experiment_loop" in result
+    assert "publish_model_report" in result
+    assert "Blocker: Hugging Face token is not available for remote jobs or publishing." in result
+    assert "Remote jobs disabled by constraints; prefer sandbox/local smoke runs first." in result
+    assert "Expected artifacts" in result
+
+
+@pytest.mark.asyncio
+async def test_planner_auto_selects_template_and_marks_missing_dataset(tmp_path: Path) -> None:
+    result = await plan_autonomous_workflow_handler(
+        {
+            "objective": "Train a churn prediction model from customer account rows.",
+            "available_inputs": {
+                "target_column": "churned",
+                "provider_api_key": False,
+                "hf_token": True,
+            },
+        },
+        _settings(tmp_path),
+    )
+
+    assert "Autonomous workflow plan: tabular_classification" in result
+    assert "Blocker: Dataset path, upload, or Hub dataset id is required." in result
+    assert (
+        "Warning: Provider API key is missing; planning is still available but LLM-assisted research may be limited."
+        in result
+    )
+
+
+@pytest.mark.asyncio
+async def test_planner_rejects_unknown_template(tmp_path: Path) -> None:
+    result = await plan_autonomous_workflow_handler(
+        {"objective": "Train something useful.", "template": "magic"},
+        _settings(tmp_path),
+    )
+
+    assert result.startswith("Error:")
+    assert "Unknown workflow template 'magic'" in result
+
+
+def test_tool_registry_includes_autonomous_workflow_planner(tmp_path: Path) -> None:
+    registry = _create_tool_registry(_settings(tmp_path))
+
+    assert registry.get("plan_autonomous_workflow").name == "plan_autonomous_workflow"


### PR DESCRIPTION
﻿Summary
- Adds `plan_autonomous_workflow`, a deterministic backend planner that turns a user ML objective into a template-based autonomous run plan.
- Includes tabular classification, text classification, image classification, custom experiment, and auto-selection templates with readiness checks, recommended tools, expected artifacts, and key risks.
- Wires the planner into the agent tool registry and documents the Phase 6 planning flow.

Testing
- `python -m pytest tests/unit/test_workflow_templates.py -q` - 5 passed
- `python -m pytest tests/unit/test_workflow_templates.py tests/unit/test_agent_loop.py -q` - 13 passed
- `python -m pytest tests/ -q` - 251 passed
- `mypy app/ --ignore-missing-imports --follow-imports=skip`
- `python -m ruff check app/ tests/`
- `python -m ruff format --check app/ tests/`
- `git diff --check`
- `pre-commit run --all-files`

Notes
- The planner is dry-run friendly and does not call external services, launch jobs, upload files, or persist secrets.
- Missing credentials are surfaced as readiness warnings/blockers instead of causing runtime side effects.
- This is a backend planning/tool-registry slice; no frontend API changes are included.

Referrence
- Production autonomy follow-up for repeatable end-to-end ML workflow planning.

Close #128
